### PR TITLE
[Testing] XIVDeck 0.2.9-dirty1

### DIFF
--- a/testing/api6/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/api6/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,0 +1,7 @@
+[plugin]
+repository = "https://github.com/KazWolfe/XIVDeck.git"
+commit = "55465dd4adc2a8c0b359a087e00a6208ec0fbd37"
+owners = [
+    "KazWolfe",
+]
+project_path = "FFXIVPlugin"


### PR DESCRIPTION
This is a maintenance release to bring XIVDeck to the new DIP17 system.

No code changes to either testing or stable versions are present in this release.