### PR TITLE
Manifest validation on PR

### DIFF
--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Check for manifest changes
       id: changed_manifests

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -9,12 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Check for manifest changes
       id: changed_manifests
-      run: echo "::set-output name=toml::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}) ${{ github.sha }} | grep '\.toml$' | xargs"
+      run: echo "::set-output name=toml::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep '\.toml$' | xargs)"
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v4

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -2,7 +2,8 @@ name: Validate Manifest
 on:
   pull_request:
     paths:
-      - '**/*.toml'
+      - 'stable/**/*.toml'
+      - 'testing/**/*.toml'
 
 jobs:
   lint-manifest:
@@ -17,7 +18,8 @@ jobs:
       uses: tj-actions/changed-files@v24
       with:
         files: |
-          *.toml
+          stable/**/*.toml
+          testing/**/*.toml
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v4

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Install python deps
       run: python -mpip install pydantic==1.9.1 toml==0.10.2
 
+      # this does technically break on a filename with spaces, but nobody would do that, right? ...right?
     - name: Validate changed manifests
       run: python -mpyckager validate ${{ steps.changed-files.outputs.all_changed_files }}
   

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -12,7 +12,7 @@ jobs:
 
     - name: Check for manifest changes
       id: changed_manifests
-      run: echo "::set-output name=toml::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}) ${{ github.sha }} | grep '\.toml$' | xargs"
+      run: echo "::set-output name=toml::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep '\.toml$' | xargs)"
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v4

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -1,0 +1,27 @@
+name: Validate Manifest
+on:
+  pull_request:
+    paths:
+      - '**/*.toml'
+
+jobs:
+  lint-manifest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check for manifest changes
+      id: changed_manifests
+      run: echo "::set-output name=toml::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}) ${{ github.sha }} | grep '\.toml$' | xargs"
+
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install python deps
+      run: python -mpip install pydantic==1.9.1 toml==0.10.2
+
+    - name: Validate changed manifests
+      run: python -mpyckager validate ${{ steps.changed_manifests.toml }}
+  

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -9,10 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-    - name: Check for manifest changes
-      id: changed_manifests
-      run: echo "::set-output name=toml::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep '\.toml$' | xargs)"
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v24
+      with:
+        files: |
+          *.toml
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v4
@@ -23,5 +28,5 @@ jobs:
       run: python -mpip install pydantic==1.9.1 toml==0.10.2
 
     - name: Validate changed manifests
-      run: python -mpyckager validate ${{ steps.changed_manifests.outputs.toml }}
+      run: python -mpyckager validate ${{ steps.changed-files.outputs.all_changed_files }}
   

--- a/.github/workflows/validate_manifest.yml
+++ b/.github/workflows/validate_manifest.yml
@@ -12,7 +12,7 @@ jobs:
 
     - name: Check for manifest changes
       id: changed_manifests
-      run: echo "::set-output name=toml::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep '\.toml$' | xargs)"
+      run: echo "::set-output name=toml::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}) ${{ github.sha }} | grep '\.toml$' | xargs"
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v4
@@ -23,5 +23,5 @@ jobs:
       run: python -mpip install pydantic==1.9.1 toml==0.10.2
 
     - name: Validate changed manifests
-      run: python -mpyckager validate ${{ steps.changed_manifests.toml }}
+      run: python -mpyckager validate ${{ steps.changed_manifests.outputs.toml }}
   

--- a/pyckager/__main__.py
+++ b/pyckager/__main__.py
@@ -1,0 +1,71 @@
+"""CLI tooling for working with package manifest files"""
+from sys import exit, stderr
+from argparse import ArgumentParser, ArgumentTypeError
+from pathlib import Path
+
+import toml
+
+from pyckager.models import Manifest
+from pydantic import ValidationError
+
+
+def to_manifest_path(str_path: str) -> Path | None:
+    """Helper for converting str to path in argparse arguments"""
+    try:
+        path = Path(str_path)
+    except Exception:
+        raise ArgumentTypeError(f"Path '{str_path}' has issues")
+
+    match path.suffix:
+        case '.toml':
+            return path
+        case _:
+            raise ArgumentTypeError(f'Extension {path.suffix} not supported')
+
+
+def create_parser() -> ArgumentParser:
+    """Creates the ArgumentParser"""
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(help='action to perform', dest='action')
+
+    validate_parser = subparsers.add_parser('validate')
+    validate_parser.add_argument('manifests', type=to_manifest_path, nargs='+', help='Path to the manifest to validate')
+
+    return parser
+
+
+def validate_manifests(**kwargs) -> bool:
+    """Takes a manifest and validates it
+    
+    :param Path manifest: 
+
+    """
+    manifests: list[Path] = kwargs.get('manifests')
+
+    for manifest in manifests:
+        with open(manifest, 'r', encoding='utf-8') as f:
+            manifest_dict = toml.loads(f.read())
+        try:
+            manifest = Manifest(**manifest_dict)
+        except ValidationError as e:
+            print(e, file=stderr)
+            return False
+
+    return True
+
+
+def main() -> int:
+    parser = create_parser()
+    args = parser.parse_args()
+
+    match args.action:
+        case 'validate':
+            if validate_manifests(**vars(args)) is False:
+                return 1
+        case _:
+            parser.print_help()
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/pyckager/models.py
+++ b/pyckager/models.py
@@ -1,0 +1,24 @@
+from re import compile
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+NUMBERS_ONLY = compile(r'^\d+$')
+
+class Plugin(BaseModel):
+    repository: str
+    commit: str
+    owners: list[str]
+    project_path: Optional[str]
+    changelog: Optional[str]
+
+    @validator('owners')
+    def validate_owners(cls, owners):
+        for owner in owners:
+            if NUMBERS_ONLY.match(owner):
+                raise ValueError(f'Value "{owner}" must be a github username; ids are not allowed')
+        return owners
+
+class Manifest(BaseModel):
+    plugin: Plugin


### PR DESCRIPTION
Like it says on the tin, this sets up a gh workflow to validate any `.toml` files that get added to the `stable` or `testing` directories. I'm very open to changing paths (for example, moving/renaming pyckager) to keep things a bit cleaner in the root of the repo.

To change how the toml file is validated, update the [pydantic](https://pydantic-docs.helpmanual.io/usage/models/) models in `pyckager/models.py`.

One caveat is that this will break on any *new* toml file added that uses github IDs rather than strings (see the validator in the model for more information; I'm also open to changing this as well).