### PR TITLE
Add version checking to manifest validation

### DIFF
--- a/pyckager/models.py
+++ b/pyckager/models.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, validator
 
 
 NUMBERS_ONLY = compile(r'^\d+$')
+VERSION = compile(r'^(\d+\.)+\d+$')
 
 class Plugin(BaseModel):
     repository: str
@@ -12,6 +13,7 @@ class Plugin(BaseModel):
     owners: list[str]
     project_path: Optional[str]
     changelog: Optional[str]
+    version: Optional[str]
 
     @validator('owners')
     def validate_owners(cls, owners):
@@ -19,6 +21,16 @@ class Plugin(BaseModel):
             if NUMBERS_ONLY.match(owner):
                 raise ValueError(f'Value "{owner}" must be a github username; ids are not allowed')
         return owners
+
+    @validator('version')
+    def validate_version(cls, version):
+        version_match = VERSION.match(version)
+        if version_match:
+            segments = tuple(int(x) for x in version_match[0].split('.'))
+            if 1 < len(segments) < 5:
+                return segments
+        raise ValueError(f'Value "{version}" is not a valid version')
+
 
 class Manifest(BaseModel):
     plugin: Plugin


### PR DESCRIPTION
What is says on the tin, but the short of it is:

* Based on some discussion in-channel, semver actually doesn't respect 4-segment versions (`w.x.y.z`), so I left us with a much simpler `^(\d+\.)+\d+$` regex (which I validate to `w` version all the way to `w.x.y.z` in the validator function)
* (Doesn't change the `validate` subcommand in the cli) parses the version as type `tuple[int]` – not useful at the moment, but could be nice for csproj comparison later with the same tool