### PR TITLE
strict validation for models

### DIFF
--- a/pyckager/models.py
+++ b/pyckager/models.py
@@ -38,4 +38,5 @@ class Plugin(BaseModel):
 class Manifest(BaseModel):
     plugin: Plugin
 
-    extra = Extra.forbid
+    class Config:
+        extra = Extra.forbid

--- a/pyckager/models.py
+++ b/pyckager/models.py
@@ -1,7 +1,7 @@
 from re import compile
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, Extra, validator
 
 
 NUMBERS_ONLY = compile(r'^\d+$')
@@ -31,6 +31,11 @@ class Plugin(BaseModel):
                 return segments
         raise ValueError(f'Value "{version}" is not a valid version')
 
+    class Config:
+        extra = Extra.forbid
+
 
 class Manifest(BaseModel):
     plugin: Plugin
+
+    extra = Extra.forbid


### PR DESCRIPTION
This forces all models into *strict validation* (if there are extra fields, this will cause an error as opposed to ignoring them). For example:

```python
>>> from pyckager.models import Plugin, Manifest
>>> Manifest(**{'plugin': {'repository': 'foo', 'commit': 'foo', 'owners': ['nonowazu'], 'mcdoesntexist': 'wat'}})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Manifest
plugin -> mcdoesntexist
  extra fields not permitted (type=value_error.extra)
```