### PR TITLE
[Testing] Update KikoGuide to v1.3.0.0

### DIFF
--- a/testing/live/KikoGuide/manifest.toml
+++ b/testing/live/KikoGuide/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/KikoGuide.git"
-commit = "894ff03529eaaf79f28055064ee43c9da396b54e"
+commit = "30f3846cbb36c2173538ff6f5874b749c04aa687"
 owners = [
     "BitsOfAByte",
 ]

--- a/testing/live/KikoGuide/manifest.toml
+++ b/testing/live/KikoGuide/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/KikoGuide.git"
-commit = "6fefb16d10be3335398a00aa76fa28840558c6b9"
+commit = "894ff03529eaaf79f28055064ee43c9da396b54e"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
**Features**
 - Integration with Wotsit (Can be found in the "Integrations" settings tab)
 - Guides are now unlocked when accepting their associated quests, not when entering them for the first time

Lots more refactoring and cleanup. This test release is likely to have a few bugs that need to be squashed, but if all goes well then it's almost time to go to a stable release.