### PR TITLE
[Testing] Ffxiv2Mqtt 1.0.3.1

### DIFF
--- a/testing/net6/Ffxiv2Mqtt/manifest.toml
+++ b/testing/net6/Ffxiv2Mqtt/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Xpahtalo/Ffxiv2Mqtt.git"
-commit = "69cea6762f5466eeabdf1c5f779f77274998c869"
+commit = "6207c379f53c9271dce5758d946fb21bfef2d96b"
 owners = [
     "Xpahtalo",
 ]
 project_path = "ffxiv2Mqtt"
-changelog = "API7 support and some other accidental changes."
+changelog = "Added hacky support for setting retained flag and QoS options to messages published over IPC."

--- a/testing/net6/Ffxiv2Mqtt/manifest.toml
+++ b/testing/net6/Ffxiv2Mqtt/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Xpahtalo/Ffxiv2Mqtt.git"
-commit = "6207c379f53c9271dce5758d946fb21bfef2d96b"
+commit = "3044b578966b6ab68ca76e61b5d7b0beb964f8b3"
 owners = [
     "Xpahtalo",
 ]
 project_path = "ffxiv2Mqtt"
-changelog = "Added hacky support for setting retained flag and QoS options to messages published over IPC."
+changelog = "Can now subscribe to MQTT topics and have them displayed in game. Cleaned up IPC so it easier to publish messages."


### PR DESCRIPTION
Added hacky support for setting retained flag and QoS options to messages published over IPC.