### PR TITLE
DeepDungeonDex 1.8.2

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = ""
-commit = "4d8d22f07b02181b3dccbe255302d4ff3258e976"
-changelog = "### 1.8.1 (2022-08-23)\n\n\n### Bug Fixes\n\n* Finalize .NET 6 and API7 update (4194254)"
-version = "1.8.1"
+commit = "438e0f7fe207be57ec1274283e2526735e4c1037"
+changelog = "### 1.8.2 (2022-08-24)\n\n\n### Bug Fixes\n\n* remove hard set of api version and use dalamudpackager instead (e6f04cc)"
+version = "1.8.2"


### PR DESCRIPTION
### 1.8.2 (2022-08-24)


### Bug Fixes

* remove hard set of api version and use dalamudpackager instead (e6f04cc)