### PR TITLE
XIVDeck 0.2.13 [HotFix]

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "3b2e4e2f37f14fac754755519be6ab5bc83cbd19"
+commit = "767e9c5c268177d6a5eda0a6237a56e4f8e39c8c"
 owners = [
     "KazWolfe",
 ]

--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "3b2e4e2f37f14fac754755519be6ab5bc83cbd19"
+commit = "767e9c5c268177d6a5eda0a6237a56e4f8e39c8c"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
I mean, technically speaking, you never actually *did* read `Ballroom Etiquette - Resplendent Reclining`, so did you ever *really* unlock the `/sit` emote?

- Fix default emotes (`/sit`, `/think`, etc.) being falsely reported as locked.

Full release notes and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.2.13).