### PR TITLE
GatherBuddy 3.1.5.1

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "76d0bb8219256a6f664afd63506bb76d41a208ae"
+commit = "0a8fafd433edea7449e6eb9d7a34cc1df185ff5b"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Add Gathering Map Flags with Radius instead of the red flag. Radius is customizable in Locations but takes default from game data.
- Add early 6.2 fish data. This is taken from the discovery sheet from Fisherman's Horizon and probably not 100% accurate yet.