### PR TITLE
[Testing] Update KikoGuide to 1.4.1.0

### DIFF
--- a/testing/live/KikoGuide/manifest.toml
+++ b/testing/live/KikoGuide/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/KikoGuide.git"
-commit = "7f29a944ecda2e615fa4546323407c170b225645"
+commit = "c9f7eb17f830a8e8db0309b70327787b62f68bfd"
 owners = [
     "BitsOfAByte",
 ]

--- a/testing/live/KikoGuide/manifest.toml
+++ b/testing/live/KikoGuide/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/KikoGuide.git"
-commit = "d84b69cb7291de2df69a275fcb699da51d9e4cac"
+commit = "7f29a944ecda2e615fa4546323407c170b225645"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
Fixes a plugin crash for first time users when a timestamp was saved to the configuration file.

If you are experiencing crashes when the plugin launches, you will need to delete your configuration which can be found at `AppData/Roaming/XIVLauncher/pluginConfigs/KikoGuide.json` and restart