### PR TITLE
[Testing] Neko Fans 1.1.2

### DIFF
--- a/testing/live/Neko/manifest.toml
+++ b/testing/live/Neko/manifest.toml
@@ -19,4 +19,6 @@ Neko Fans now has a configuration menu, which you can open with /nekocfg
 - Added API: shibe.online
 - Added API: The Cat API
 - Added API: WAIFU.IM
-- Added API: Waifu.pics"""
+- Added API: Waifu.pics
+- Update to .Net6 and Dalamud API 7
+- Faster Json parsing with .Net6"""

--- a/testing/live/Neko/manifest.toml
+++ b/testing/live/Neko/manifest.toml
@@ -1,12 +1,22 @@
 [plugin]
 repository = "https://github.com/Meisterlala/NekoFans.git"
-commit = "b13b01605d592cc5ad29a2164e6e85d888a1c80a"
+commit = "17e972e13ef909e769648ab0c1d2b5c8b23be5c9"
 owners = [
     "Meisterlala",
 ]
 project_path = "Neko"
-changelog = """
-- Queue system for preloading images
-- Reworked memory management system
-- Revert to .Net5
-"""
+changelog = """Huge Update!
+Neko Fans now has a configuration menu, which you can open with /nekocfg
+- Added options to change to Look and Feel of the Plugin
+- Added option to configure image preloading system
+- Added hotkey to open image in web browser
+- Added hotkey to copy image url to clipboard
+- Added Option to lock window position
+- Added API: Catboys
+- Added API: Dog CEO
+- Added API: Nekos.life
+- Added API: Pic.re
+- Added API: shibe.online
+- Added API: The Cat API
+- Added API: WAIFU.IM
+- Added API: Waifu.pics"""

--- a/testing/live/Neko/manifest.toml
+++ b/testing/live/Neko/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Meisterlala/NekoFans.git"
-commit = "618447cc493f4092b94cef48d8505cdc308c2116"
+commit = "8a73a19f0d2d60f12d42275e841a60312f5d9121"
 owners = [
     "Meisterlala",
 ]

--- a/testing/live/Neko/manifest.toml
+++ b/testing/live/Neko/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Meisterlala/NekoFans.git"
-commit = "6a76f7ea0d0da7ecf9bceeaaf7820eb712531521"
+commit = "618447cc493f4092b94cef48d8505cdc308c2116"
 owners = [
     "Meisterlala",
 ]

--- a/testing/live/Neko/manifest.toml
+++ b/testing/live/Neko/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Meisterlala/NekoFans.git"
-commit = "17e972e13ef909e769648ab0c1d2b5c8b23be5c9"
+commit = "6a76f7ea0d0da7ecf9bceeaaf7820eb712531521"
 owners = [
     "Meisterlala",
 ]


### PR DESCRIPTION
## Changelog
Huge Update!
Neko Fans now has a configuration menu, which you can open with /nekocfg
- Added options to change to Look and Feel of the Plugin
- Added option to configure image preloading system
- Added hotkey to open image in web browser
- Added hotkey to copy image url to clipboard
- Added API: Catboys
- Added API: Dog CEO
- Added API: Nekos.life
- Added API: Pic.re
- Added API: shibe.online
- Added API: The Cat API
- Added API: WAIFU.IM
- Added API: Waifu.pics
- Update to .Net6 and Dalamud API 7
- Faster Json parsing with .Net6 source generation

## New dependencies

This Plugin now ships with [TextCopy](https://www.nuget.org/packages/TextCopy/) to copy text to the clipboard cross platform.


## NSFW Images

Some of the APIs added have NSFW endpoints. All images which are shown are still SFW.
The NSFW images are not accessable through the configuration menu and also not accessable by editing the plugin config file.

You can only enable NSFW images by installing a [second plugin](https://github.com/Meisterlala/NekoFans/releases/tag/1.0.1-NSFW) (only avalible in a custom repo). It is [checked via IPC](https://github.com/Meisterlala/NekoFans/blob/master/Neko/NSFW.cs) if the second plugin is loaded and enabled.

I did some edits to the .sln file and the automated build system should only build the normal SFW plugin


