### PR TITLE
DelvUI release 1.4.1.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "8f5a0c5ed51d6ec1e7ef6760893c93c08db6ca94"
+commit = "f81159d98d51ba0e450a5d0dbc91290960143ca7"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
Features:
- Added visibility settings for Island Sanctuary.

Fixes:
- Fixed Ninja Job Hud not working properly.
- Fixed Astrologian's Minor Arcana cooldown.
- Fixed job icons not working on cross-world parties.
- Fixed Target of Target not working.
- Fixed name hide logic for the Party Frames.
- Fixed enmity indicators not working in Party Frames.