### PR TITLE
[nofranz] EnemyListHP: Added former name into plugin's name as well

### DIFF
--- a/stable/EnmityHp/manifest.toml
+++ b/stable/EnmityHp/manifest.toml
@@ -5,10 +5,8 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/EnmityHp.git"
 # The commit to check out and build from the repository.
-commit = "3cef17044ce80c92ad3ab87c368325dbf88f9842"
+commit = "ee02b155b6b859240f45e43116a6131f81e971f7"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Eternita-S"
 ]
-# The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
-changelog = ".NET 6 update" 


### PR DESCRIPTION
I'm just adding former name because I get quite often questions about people remembering it as EnmityHp and trying to search for the plugin in installer but unable to find it. Will just keep it for some time and will remove it with some further update.