### PR TITLE
Update Chat 2 and ExtraChat

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,5 +1,7 @@
 [plugin]
 repository = 'https://git.annaclemens.io/ascclemens/ChatTwo.git'
-commit = '5deb7a7f7bf04b1f73182aed159ca448f5767859'
+commit = 'd3e924d34e4be137f9c4ebf13b291223fc689e18'
 owners = [ 'ascclemens' ]
-changelog = 'Fixed linkshells and party invite crashes.'
+changelog = '''\
+- Added ExtraChat channel filters
+'''

--- a/stable/ExtraChat/manifest.toml
+++ b/stable/ExtraChat/manifest.toml
@@ -1,6 +1,8 @@
 [plugin]
 repository = 'https://git.annaclemens.io/ascclemens/ExtraChat.git'
-commit = '8cd95f7b483358f88ac999ed0c9a0fa46a451e7c'
+commit = 'ce73a1837491543c13a965d56070d8c03b81c825'
 owners = [ 'ascclemens' ]
 project_path = 'client'
-changelog = 'Fix message handling preventing connection.'
+changelog = '''\
+- Added additional IPC and filter payloads.
+'''


### PR DESCRIPTION
This update allows users of both Chat 2 and ExtraChat to filter ExtraChat messages in their Chat 2 tabs!

(Note that this only applies to messages received after updating ExtraChat.)