### PR TITLE
Update Chat 2 to 1.18.1

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,7 +1,9 @@
 [plugin]
 repository = 'https://git.annaclemens.io/ascclemens/ChatTwo.git'
-commit = 'd3e924d34e4be137f9c4ebf13b291223fc689e18'
+commit = '65563d72bbe41f8e212f2ce27ba7c8e34bcba24a'
 owners = [ 'ascclemens' ]
 changelog = '''\
-- Added ExtraChat channel filters
+- Fixed ExtraChat filters to not require the System Messages channel
+- This update will run a database migration, which may take a couple minutes based on your database size
+  - Chat 2 will not appear until the migration is finished
 '''


### PR DESCRIPTION
- Fixed an issue where ExtraChat filters also required the System Messages channel to function.
- This update will run a migration on startup, which may take a few minutes depending on your database size.
- Chat 2 **will not be visible until the migration is complete**. You can see the progress in `/xllog`.