### PR TITLE
GatherBuddy 3.1.6.0

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "0a8fafd433edea7449e6eb9d7a34cc1df185ff5b"
+commit = "3a728fb5467b98f1af5f9969096763db583587ec"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Added separate option to place a red flag marker on the target location (visible on minimap, does not open map, compatible with regular map option with gather area)
- Added highlighting of bait currently in your inventory with customizable color. Sadly no filtering for this is possible for technical reasons at the moment.
- Updated 6.2 fish data with current fisherman's horizon data (still not finalized, I think)