### PR TITLE
It's Wotsit Version 1.0.1.11

### DIFF
--- a/stable/Dalamud.FindAnything/manifest.toml
+++ b/stable/Dalamud.FindAnything/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/goaaats/Dalamud.FindAnything.git"
-commit = "ea41ea7f285b75c6e83dc0e1b3e5b469abd43f33"
+commit = "3a4d9fff680f9e0e218776ca1f651aadde287ea7"
 owners = [
     "goaaats",
 ]


### PR DESCRIPTION
* Added "Closes striking dummy" teleport option (by BerkeBat)
    => Disabled by default, you can turn it on by searching for "Wotsit"
* Fixed an issue wherein teleports were not available in the newly released content "Island Sanctuary" (by MidoriKami)

![image](https://user-images.githubusercontent.com/16760685/187559105-4d0e2a66-7236-427a-a873-1c734483c77e.png)
