### PR TITLE
PlayerTrack 2.6.3.0

### DIFF
--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "src/PlayerTrack"
-commit = "f47d1caa4ef5e618a8a1658a3ea9a962702042b3"
+commit = "6b5f62977ead155c4e79d3c5d448d607e730c096"


### PR DESCRIPTION
Fully removed nameplate and examine that broke in 6.2. These features will be back later this year in a bigger PlayerTrack update. Please look forward to it.