### PR TITLE
XIVDeck 0.2.14

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "767e9c5c268177d6a5eda0a6237a56e4f8e39c8c"
+commit = "e7bbaaf22909da337b03aad4b50dfa16915ca4ec"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
WEE WOO WEE WOO EMERGENCY FIX. I left a convention to do this, but to be fair I did screw up pretty badly. This *corrects* that rather egregious oversight.

- Fix a bug that showed emotes that couldn't actually be used.

Full release notes and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.2.14).