### PR TITLE
Update PlayerTags to v1.6

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "0be77a25d7d5da69b86a3fa17bcc325abb35a887"
+commit = "c63998ec16b12ce4e926478f25df3507bcd10f91"
 owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = "- Target .NET 6\n- Target API v7\n- Updated Libs"
+changelog = "Version 1.6\n- Optimized some code for text formatting to probably fix issues with other plugins, such as Simple Tweaks\n- Added a new option to specify where some general settings depending on the current activity (in duty, no duty). E.g. visible in chat, nameplate title options, etc.\n- Added Spanish translation (thanks to unknown!) (before added the new strings in v1.6)\n\nVersion 1.5\n- Target .NET 6\n- Target API v7\n- Updated Libs"


### PR DESCRIPTION
- Optimized some code for text formatting to probably fix issues with other plugins, such as Simple Tweaks
- Added a new option to specify where some general settings depending on the current activity (in duty, no duty). E.g. visible in chat, nameplate title options, etc.
- Added Spanish translation (thanks to unknown!) (before added the new strings in v1.6)