### PR TITLE
Allagan Tools v1.2.0.4

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "0fb1fa5cf02f39f0a25dba0ce8e4be94224956ea"
+commit = "5abf458b732fba457cfd632ffdb8ea31383a00f4"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "- API 7\n- Decreased non CS sig usage\n- Glamour Chest supports 800\n - Fixed an issue that would cause the more info window to open regardless if no hot key was set."
-version = "1.2.0.2"
+changelog = "Barring anything major probably the last release for a few weeks at least, back to EW main story, hopefully this get's the majority of people sorted :)\n- Bug Fixes\n- Stopped a potential memory leak\n- Removed old commands from showing in help\n- The hotkey check I had in place could have been causing lag, have tweaked it.\n- Improved draw times of each window\n- People with higher font sizes and ui scales should hopefully be able to see all the buttons\n- Collapsing either of the craft window sections will have the other section take the available space.\n- The inventory scanning process now runs in the thread pool, hopefully this should reduce stuttering when any item movement occurs(and a rescan needs to happen)."
+version = "1.2.0.4"


### PR DESCRIPTION
Barring anything major probably the last release for a few weeks at least, back to EW main story, hopefully this get's the majority of people sorted :)
- Bug Fixes
- Stopped a potential memory leak
- Removed old commands from showing in help
- The hotkey check I had in place could have been causing lag, have tweaked it.
- Improved draw times of each window
- People with higher font sizes and ui scales should hopefully be able to see all the buttons
- Collapsing either of the craft window sections will have the other section take the available space.
- The inventory scanning process now runs in the thread pool, hopefully this should reduce stuttering when any item movement occurs(and a rescan needs to happen).