### PR TITLE
Update PlayerTags to v1.6.1

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "c63998ec16b12ce4e926478f25df3507bcd10f91"
+commit = "3ac85bdc9abb9746d1870d98601e8400130011c9"
 owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = "Version 1.6\n- Optimized some code for text formatting to probably fix issues with other plugins, such as Simple Tweaks\n- Added a new option to specify where some general settings depending on the current activity (in duty, no duty). E.g. visible in chat, nameplate title options, etc.\n- Added Spanish translation (thanks to unknown!) (before added the new strings in v1.6)\n\nVersion 1.5\n- Target .NET 6\n- Target API v7\n- Updated Libs"
+changelog = "Version 1.6.1\n- Adjust some default settings regarding text coloring.\nIf you miss some colors on nameplate and chat now, please ensure you enabled them for the respective element.\n\nVersion 1.6\n- Optimized some code for text formatting to probably fix issues with other plugins, such as Simple Tweaks\n- Added a new option to specify where some general settings depending on the current activity (in duty, no duty). E.g. visible in chat, nameplate title options, etc.\n- Added Spanish translation (thanks to unknown!) (before added the new strings in v1.6)\n\nVersion 1.5\n- Target .NET 6\n- Target API v7\n- Updated Libs"


### PR DESCRIPTION
- Adjust some default settings regarding text coloring.
Hint: If you miss some colors on nameplate and chat now, please ensure you enabled them for the respective element. There are a lot of options and the default options will not be fine for everyone. Just adjust them, if you like yours more. ^^

Resolve https://github.com/Pilzinsel64/PlayerTags/issues/10