### PR TITLE
[Testing] Update PriceInsight 2.1.1

### DIFF
--- a/testing/live/PriceInsight/manifest.toml
+++ b/testing/live/PriceInsight/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-priceinsight.git"
-commit = "28984fd685db84b6c7e5e795977d661d54142a65"
+commit = "02e76187f5db6d755f6d7d02eb42ebb4e161fb78"
 owners = [
     "Kouzukii",
 ]
 project_path = ""
 changelog = """
-Prevent tooltip from overflowing below the screen
+Fix tooltips with the "fixed position" setting enabled moving down the screen
+Fix wrong home world being used when logging into other characters
+Fix key items having marketboard information
 """


### PR DESCRIPTION
Fix tooltips moving down the screen with the "fixed position" setting enabled
Fix wrong home world being used when logging into other characters
Fix key items having marketboard information