### PR TITLE
Update TextToTalk to v1.16.2

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "57f90db11af32834758ed3580b0b9b9eef84cc4c"
+commit = "c054460d5a43dc89c16ec4b6e156d6d38c98c73c"
 project_path= "src"
 owners = ["karashiiro"]
-changelog = "Updates for compatibility with the latest version of Dalamud."
+changelog = "Fixes installation on WINE-based systems."


### PR DESCRIPTION
* Fixes installation on WINE-based systems.