### PR TITLE
PartyIcons 1.0.9.0

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "e12c6224b38bce9eefd5419542df9d9062025b54"
+commit = "27fcec3d5697407fe3643a89f3eaa06f7b480bc6"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,9 +8,15 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-- Added setting to enable or disable context menu role assignment.
-- Made the /ppi command toggle the settings window instead of only showing the window.
-- Fixed the initial size and position of the settings window not matching the current display dimensions.
-- Fixed the size and position of the settings window not persisting.
-- Fixed the settings window height being zero when expanding the window after it was hidden.
+Changed the way the game's nameplates are accessed
+- This allows a newly started ACT to still find the chat log after loading the plugin
+
+Added setting to toggle role assignment based on party chat (by hmm-norah)
+- e.g. saying 'h1' to be assigned H1 (or 'mt' to be assigned MT)
+
+Cleaned up settings UI
+- Added section headers and formatting
+- Moved chat name settings to their own tab
+- Various other adjustments
+- This should help finding what you need and experimenting with different combinations
 """


### PR DESCRIPTION
Changed the way the game's nameplates are accessed
- This allows a newly started ACT to still find the chat log after loading the plugin

Added setting to toggle role assignment based on party chat (by hmm-norah)
- e.g. saying 'h1' to be assigned H1 (or 'mt' to be assigned MT)

Cleaned up settings UI
- Added section headers and formatting
- Moved chat name settings to their own tab
- Various other adjustments
- This should help finding things and experimenting with different combinations

![Before](https://user-images.githubusercontent.com/99750849/188517867-910a1b62-12fb-420e-9fa2-ba28a36a0fd8.png)

![After](https://user-images.githubusercontent.com/99750849/188517870-82443c26-86b3-4406-8343-a4f8278c49e8.png)