### PR TITLE
[Stable] Fix broken message translation

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "2e5eef0d0060a55c1758f68c213dd1371f61c4bc"
+commit = "2d8cb04ffdf6ae88f017bee2657f6359ecbbeb53"
 owners = [
     "BitsOfAByte",
 ]

--- a/testing/live/GoodFriend/manifest.toml
+++ b/testing/live/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "0f493a7231b7c6fac6c242442d39472c7127e984"
+commit = "ba7b19f73f9298e88ea7416363815c5fc1dfec74"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
- Fixes a bug where after a user has installed the plugin, some messages will not be properly localized and will not show the proper placeholders.
- Minor improvements on the server-side.