### PR TITLE
[Testing] Update to Orange Guidance Tomestone 1.3.0

### DIFF
--- a/testing/live/OrangeGuidanceTomestone/manifest.toml
+++ b/testing/live/OrangeGuidanceTomestone/manifest.toml
@@ -1,16 +1,11 @@
 [plugin]
 repository = 'https://git.anna.lgbt/ascclemens/OrangeGuidanceTomestone.git'
-commit = '4345dfd61331fe8eae2f0f3ddce0446716934f63'
+commit = '22ffdca8a0c3564b570785c7a50de5461501b7b1'
 owners = [ 'ascclemens' ]
 project_path = 'client'
 changelog = """\
-- Added /ogt help, /ogt ban, /ogt unban, /ogt refresh, and /ogt viewer.
-- Message list now shows your current and maximum number of messages.
-- Message list is now sorted by date (newest first).
-- Added option to disable in trials and Deep Dungeons.
-- Added option to remove the glowy pillar above signs.
-- Added option to automatically show the viewer when near a message.
-- Added option to configure viewer opacity.
-- Added "extra code" claim to redeem codes that increase your maximum message count.
-- Enabled global filter algorithm - you should see slightly fewer messages in crowded areas now.
+- Fixed trials filter to also hide from high-end duties.
+- Added multiple glyphs for signs.
+- Split auto-open setting into an auto-open and auto-close setting.
+- Updated FFXIV word pack.
 """


### PR DESCRIPTION
- Fixed trials filter to also hide from high-end duties.
- Added multiple glyphs for signs.
- Split auto-open setting into an auto-open and auto-close setting.
- Updated FFXIV word pack.