### PR TITLE
PartyIcons 1.0.9.1

### DIFF
--- a/testing/live/PartyIcons/manifest.toml
+++ b/testing/live/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "ba8eee690a124c20a0129261e2dfc75ac09618df"
+commit = "f29dad9a8a757efa063804202208617c4d0a52f2"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,9 +8,5 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-Setting to toggle role assignment based on party chat (by hmm-norah)
-- e.g. saying 'h1' to be assigned H1 (or 'mt' to be assigned MT)
-
-Cleaned up settings UI
-- This is a rough first pass and I'm looking for feedback
+- Automatically fix old settings window sizes that were saved from before the fix to set default window size relative to the main viewport.
 """


### PR DESCRIPTION
- Automatically fix old settings window sizes that were saved from before the fix to set default window size relative to the main viewport.