### PR TITLE
DelvUI release 1.4.3.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "784a095e3a569e74f625428d464c079326b2f324"
+commit = "3adea2152e702357c9cb50cb2c681b84693339e1"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added a "First of my role" setting to the player overridden position for Party Frames:
    + It will place the player as the first of their current role, respecting the game's party list sorting settings.
    + In cross-world parties the party is not sorted so this setting will not work properly.