### PR TITLE
TPie release 1.6.0.0

### DIFF
--- a/stable/TPie/manifest.toml
+++ b/stable/TPie/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/TPie.git"
-commit = "f358b6b340ea3f90b351e2c5e651fa4bb3cb5341"
+commit = "f5ae5bdf84a0e68510c3a1915fbdd389facedd3d"
 owners = ["Tischel"]
 project_path = "TPie"
-changelog = "Added support for Patch 6.2 and Dalamud Api7."
+changelog = "- Added Emote as a ring item:\n    + This is just a convenience feature to be able to add emotes without having to manually search for their icons.\n    + It will simply use the command for the selected emote.\n    + The plugin doesn't and won't know which emotes you have unlocked. Trying to use an unlocked emote won't work.\n\n- Added a \"Draw Text\" setting to Game Macro and Command items.\n- Added a \"Draw Text Only When Selected\" setting to Game Macro, Command and Gear Set items.\n- The Keybind Edit Window will now focus the input field automatically when opened.\n- Fixed ring preview overlapping with the settings window on high Dalamud Font Scales."


### PR DESCRIPTION
- Added Emote as a ring item:
    + This is just a convenience feature to be able to add emotes without having to manually search for their icons.
    + It will simply use the command for the selected emote.
    + The plugin doesn't and won't know which emotes you have unlocked. Trying to use an unlocked emote won't work.
    
- Added a "Draw Text" setting to Game Macro and Command items.
- Added a "Draw Text Only When Selected" setting to Game Macro, Command and Gear Set items.
- The Keybind Edit Window will now focus the input field automatically when opened.
- Fixed ring preview overlapping with the settings window on high Dalamud Font Scales.