### PR TITLE
Allagan Tools v1.2.0.5

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "5abf458b732fba457cfd632ffdb8ea31383a00f4"
+commit = "8597b973a111b12a50ceee4ed19f8b21fd7f1949"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "Barring anything major probably the last release for a few weeks at least, back to EW main story, hopefully this get's the majority of people sorted :)\n- Bug Fixes\n- Stopped a potential memory leak\n- Removed old commands from showing in help\n- The hotkey check I had in place could have been causing lag, have tweaked it.\n- Improved draw times of each window\n- People with higher font sizes and ui scales should hopefully be able to see all the buttons\n- Collapsing either of the craft window sections will have the other section take the available space.\n- The inventory scanning process now runs in the thread pool, hopefully this should reduce stuttering when any item movement occurs(and a rescan needs to happen)."
-version = "1.2.0.4"
+changelog = "Mini update, one new feature and a refresh on some of the data sourced from garland tools for 6.2\n- Thanks to @sabrinaxiv we have a new setting for tooltips, 'Limit to items belonging to the current character?'"
+version = "1.2.0.5"


### PR DESCRIPTION
Mini update, one new feature and a refresh on some of the data sourced from garland tools for 6.2
- Thanks to @sabrinaxiv we have a new setting for tooltips, 'Limit to items belonging to the current character?'