### PR TITLE
PartyIcons 1.0.9.2

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "27fcec3d5697407fe3643a89f3eaa06f7b480bc6"
+commit = "1e311a75ee4c2711bab9de601ccec6bf30fee412"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,15 +8,9 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-Changed the way the game's nameplates are accessed
-- This allows a newly started ACT to still find the chat log after loading the plugin
-
-Added setting to toggle role assignment based on party chat (by hmm-norah)
-- e.g. saying 'h1' to be assigned H1 (or 'mt' to be assigned MT)
-
-Cleaned up settings UI
-- Added section headers and formatting
-- Moved chat name settings to their own tab
-- Various other adjustments
-- This should help finding what you need and experimenting with different combinations
+2nd pass UI update
+- Ensure the tab bar remains visible when scrolling (helps in the Nameplates tab)
+- Rename the "Static Roles" tab to "Roles"
+- Move role-related settings from the General tab to the Roles tab
+- Adjust organization and appearance of items in the Roles tab
 """


### PR DESCRIPTION
2nd pass UI update
- Ensure the tab bar remains visible when scrolling (helps in the Nameplates tab)
- Rename the "Static Roles" tab to "Roles"
- Move role-related settings from the General tab to the Roles tab
- Adjust organization and appearance of items in the Roles tab

![Roles tab](https://user-images.githubusercontent.com/99750849/189499992-cfcededc-a776-4dee-92e6-af05099391ca.png)