### PR TITLE
 DelvUI release 1.4.4.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "3adea2152e702357c9cb50cb2c681b84693339e1"
+commit = "907179364a138e0ff24b920636fb60ffa9012557"
 owners = ["Tischel"]
 project_path = "DelvUI"

--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "907179364a138e0ff24b920636fb60ffa9012557"
+commit = "9c36d566b621c29e38d603bb545811a7fd0eb41a"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added a Ready Check Status Icon for the Party Frames.
- Added a "Count Swiftcast" setting to Black Mage's Triplecast Bar, which will add an extra charge to the bar when the buff is active.
- Fixed Party Cooldowns not resetting after a wipe.