### PR TITLE
GatherBuddy 3.1.6.2

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,8 +1,7 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "b4e0b5c62d08d197be2d6f905bd82a50a5875bff"
+commit = "8a85faa4f37136012413771956f35a2008a71615"
 owners = [
     "Ottermandias",
 ]
 project_path = "GatherBuddy"
-changelog = "Updated for Dalamud staging and fixed some stuff."


### PR DESCRIPTION
- Fix some combos not respecting global scale.
- Fix teleporter not updating attuned aetherytes.
- Do no longer treat Island Sanctuary as a duty
- Another update for 6.2 fish data from Fisherman's Horizon.