### PR TITLE
[Testing] DailyDuty v3.0.3.0

### DIFF
--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "dd7c4a6b0c2c1c508b3262e1083b0f8c52c868e8"
+commit = "76b73f0b9c852124a1bd2953386343c536721488"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
Add `Raids (Normal)` module
Add `Raids (Alliance)` module

These new modules are designed to help you keep track of your weekly rewards from either normal raids, or alliance raids.

Currently the `Raids (Alliance)` module doesn't function because this patch's alliance raid is no longer loot restricted.
When Patch 6.3 releases, you can hit "Reset Tracked Raids" in the ui to have the plugin adjust to the new content dynamically.

These modules have clickable links that will open the duty finder to the correct category.

I have implemented an auto-resync feature that will automatically update the duty status when you click on the duty in the dutyfinder. (See gif attached below)

![YoloMouse_y540wkpdd0](https://user-images.githubusercontent.com/9083275/189513432-d4e02069-f18e-4700-a91e-970016c61c3e.gif)
