### PR TITLE
Update Orange Guidance Tomestone to 1.6.2

### DIFF
--- a/stable/OrangeGuidanceTomestone/manifest.toml
+++ b/stable/OrangeGuidanceTomestone/manifest.toml
@@ -1,10 +1,9 @@
 [plugin]
 repository = 'https://git.anna.lgbt/ascclemens/OrangeGuidanceTomestone.git'
-commit = '7a7c6acf25d8f405eb3e1b801d2dd9e565a65219'
+commit = '53fcde6a1342c6c381d6ffd73f60f9af69876307'
 owners = [ 'ascclemens' ]
 project_path = 'client'
 changelog = """\
-- Added new glyph.
-- Added option to hide signs during gpose and cutscenes.
-- Added ban list interface to settings.
+- Fixed an issue where players without Stormblood would crash in some
+  situations.
 """


### PR DESCRIPTION
- Fixed an issue where players without Stormblood would crash in some situations.