### PR TITLE
CurrencyAlert 0.3.3.0 for testing

### DIFF
--- a/testing/live/CurrencyAlert/manifest.toml
+++ b/testing/live/CurrencyAlert/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/Lharz/xiv-currency-alert.git"
+commit = "2d1dd4fba51bbfc23c7a01595046f8daebac02dd"
+owners = ["Lharz"]
+project_path = "CurrencyAlert"
+changelog = "Added Tomestones of Causality support. Added API7 support. Fixed typos."

--- a/testing/live/CurrencyAlert/manifest.toml
+++ b/testing/live/CurrencyAlert/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lharz/xiv-currency-alert.git"
-commit = "2d1dd4fba51bbfc23c7a01595046f8daebac02dd"
+commit = "1fe93b3a34327413be3a0863f34ec7829d0a10f1"
 owners = ["Lharz"]
 project_path = "CurrencyAlert"
 changelog = "Added Tomestones of Causality support. Added API7 support. Fixed typos."


### PR DESCRIPTION
Added
* New Tomestones of Causality from patch 6.2

Fixed
* Added support for API7 and a bit of code cleanup (thanks [reiichi001](https://github.com/reiichi001))
* Naming typos (thanks [Terin](https://github.com/Terin))

Diff code can be found here : https://github.com/Lharz/xiv-currency-alert/compare/0.3.2.0...0.3.3.0