### PR TITLE
[Testing] DailyDuty v3.0.3.2

### DIFF
--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "0522326c3751cb0741fe09b13e22b8ada2638899"
+commit = "b22f61641ed7dc3a7cd863a7c1904f8600669f4b"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
`Raids (Normal)` Use DutyFinder Refresh event to refresh only when needed
`Raids (Alliance)` Use DutyFinder Refresh event to refresh only when needed
`Raids (Normal)` Filter drops on `Miscellany` category