### PR TITLE
WaymarkPresetPlugin 1.4.3.2

### DIFF
--- a/stable/WaymarkPresetPlugin/manifest.toml
+++ b/stable/WaymarkPresetPlugin/manifest.toml
@@ -1,8 +1,11 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/WaymarkPresetPlugin.git"
-commit = "5bbc8193d18bb27568cef07e7512af09f3eb5e70"
+commit = "23e319f088934aba88007217110c0125a855e756"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "WaymarkPresetPlugin"
-changelog = "Updated for Dalamud API7"
+changelog = '''
+- Disabled access to the preset editor following SE's complaints about OOB waymarks.
+- This will probably be a temporary restriction.
+'''


### PR DESCRIPTION
- Disabled access to the preset editor following SE's complaints about out of bounds (OOB) waymarks.  This will probably be a temporary restriction if further safegaurds can easily be implemented.
- This was done to make it a bit harder for people to shoot themselves in the foot.  It's still possible to place OOB waymarks in the same way the game allows you to do so, so use your brain.
- Any presets you import from outside of the game, I'd personally advise checking on the map view for OOB waymarks before using.