### PR TITLE
[Testing] DailyDuty v3.0.3.3

### DIFF
--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "b22f61641ed7dc3a7cd863a7c1904f8600669f4b"
+commit = "ff6f08640991ce37d28726dbdf6444f6918bc1c9"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
*That's a lot of 3's*

`Custom Delivery` fixed comparison mode defaulting to `equal to` not `less than` 12 allowances
`Readme` Updated information to be more clear, removed references to removed wiki
`Raids (Alliance)` Implemented something that should work well for tracking 6.3's Alliance Raids
`Raids (Normal)` Improved tracking to ignore random things you can get from Pandemonium 8
`Hunt Marks (Weekly)` Added Force Override Button to mark the task as complete for the week