### PR TITLE
DailyDuty v3.0.3.3

### DIFF
--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "d5074cfb190250ff243ceec8d9c85c75841d7407"
+commit = "ff6f08640991ce37d28726dbdf6444f6918bc1c9"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
New Modules! `Raids (Normal)` and `Raids (Alliance)`!

Now you can automatically track your weekly-limited drops!
These new modules are designed to help you keep track of your weekly rewards from either normal raids, or alliance raids.

Currently the `Raids (Alliance)` does not function as you expect, instead when patch 6.3 arrives, simply click `Reset Tracked Raids` and it will automatically update to the new raid and function as you would expect.

These modules have clickable links that will open the duty finder to those duties.

There is an auto-resync mechanism implemented that will correct any incorrect information when the duty is selected in the duty finder.

Misc Fixes:
`Custom Delivery` fixed comparison mode defaulting to equal to not less than 12 allowances
`Readme` Updated information to be more clear, removed references to removed wiki
`Hunt Marks (Weekly)` Added Force Override Button to mark the task as complete for the week

![image](https://user-images.githubusercontent.com/9083275/190357863-1a3df2b3-0c3b-477f-8fc7-6a3a06bb2862.png)
