### PR TITLE
GatherBuddy 3.1.6.3

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "8a85faa4f37136012413771956f35a2008a71615"
+commit = "5683c9e17552fb5d48d690bb057a634fabf29884"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Add support for a Gather entry in context menus generated by Recipe Trees and Recipe Raw Material Lists.