### PR TITLE
Fix discordBridge

### DIFF
--- a/stable/Dalamud.DiscordBridge/manifest.toml
+++ b/stable/Dalamud.DiscordBridge/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/reiichi001/Dalamud.DiscordBridge.git"
-commit = "ae4d13e33bc3010c5ee307f6a807e6e019f06a4d"
+commit = "5982140d18c89354a67b8fc023bf3292265968c5"
 owners = [
     "reiichi001",
 	"goaaats",

--- a/stable/Dalamud.DiscordBridge/manifest.toml
+++ b/stable/Dalamud.DiscordBridge/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/reiichi001/Dalamud.DiscordBridge.git"
-commit = "5982140d18c89354a67b8fc023bf3292265968c5"
+commit = "15e559ba94fcca1276380499c39bb39ff9923ac1"
 owners = [
     "reiichi001",
 	"goaaats",


### PR DESCRIPTION
This update addresses further pain caused by Discord changing things and not telling anyone about it.
- Maybe Discord can be more consistent about their API requirements to help prevent this in the future.
- The "Dalamud Discord Bridge" webhook has been renamed to "Dalamud Chat Bridge" so that Discord won't block it.
- GateWayIntents are now directly requested by the bot so that Discord knows we actually need Message intents for bot commands.

Let's hope Discord is happy now. Because I'm not.