### PR TITLE
PlayerTags v1.7.4

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -5,7 +5,13 @@ owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = """ Version 1.7.3
+changelog = """ Version 1.7.4
+- Chat: Minor adjustments that sometimes cause weird behavior, like...
+    - The own username has been added to the start of the message text and not within
+    - The message get colored completely and not only the name
+    - Messages by ExtraChat looked weird sometimes
+
+Version 1.7.3
 - Chat: Optimize handling with abbreviated names in group and alliance chat
 
 Version 1.7.2


### PR DESCRIPTION
- Chat: Minor adjustments that sometimes cause weird behavior, like...
    - The own username has been added to the start of the message text and not within
    - The message got colored completely and not only the name
    - Messages by ExtraChat looked weird sometimes