### PR TITLE
PlayerTags v1.7.4

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "71d0c9e77199c5fdd3d5c8a7d1cf613eef86ec42"
+commit = "c6a4891852642b72082a65b7bf6a76689ccb6ef8"
 owners = [
     "Pilzinsel64",
 ]

--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -5,7 +5,13 @@ owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = """ Version 1.7.3
+changelog = """ Version 1.7.4
+- Chat: Minor adjustments that sometimes cause weird behavior, like...
+    - The own username has been added to the start of the message text and not within
+    - The message get colored completely and not only the name
+    - Messages by ExtraChat looked weird sometimes
+
+Version 1.7.3
 - Chat: Optimize handling with abbreviated names in group and alliance chat
 
 Version 1.7.2

--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "c6a4891852642b72082a65b7bf6a76689ccb6ef8"
+commit = "b0210a940fe30eee482b8bf75498a2ed6a847e50"
 owners = [
     "Pilzinsel64",
 ]

--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "152a381072db7ba8ef3fd75c344a12e659b615ce"
+commit = "71d0c9e77199c5fdd3d5c8a7d1cf613eef86ec42"
 owners = [
     "Pilzinsel64",
 ]


### PR DESCRIPTION
- Chat: Minor adjustments that sometimes cause weird behavior, like...
    - The own username has been added to the start of the message text and not within
    - The message got colored completely and not only the name
    - Messages by ExtraChat looked weird sometimes