### PR TITLE
[Testing] Slice is Right 5.1

### DIFF
--- a/testing/live/SliceIsRight/manifest.toml
+++ b/testing/live/SliceIsRight/manifest.toml
@@ -1,0 +1,4 @@
+[plugin]
+repository = "https://github.com/carvelli/Slice-Is-Right.git"
+commit = "1d99adf2b17c9ca48f873cdc75a3e909e6c35b3d"
+owners = ["carvelli", "mabako"]


### PR DESCRIPTION
New plugin - adds overlays to the Slice of Right GATE to see where you need to go. 

The overlays should render roughly around the same time as the bamboo cut animation happens.

Example:

![grafik](https://user-images.githubusercontent.com/24593801/191950638-0e6c37e4-675e-45d6-a225-8817c97c923e.png)
