### PR TITLE
[Stable] Update GoodFriend to v1.3.0.0

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "c7837f70e025d3a43f742835a22d054f76ff6d0f"
+commit = "d9ea502273e87e3057c98950eb90308443b80a02"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
**Features**
- Support bearer token authentication within the plugin for use with 3rd-party APIs that may wish to enforce token authentication globally
- Show the `APIClient` version on the connection page to help diagnose API compatibility issues
- Send `HomeworldID` and `TerritoryID` with login/logout requests so that it can be used by GoodFriend in the future (or other plugins using the API)
- Requirement of sending a session-identifier to help prevent API abuse and store session specific preferences, this token is randomly chosen on each launch of the plugin so it cannot be used to identify you across connections.
- All logs are now way cleaner and will be easier to read when debugging.
- The ability for the API to ban specific user-agents (eg. outdated plugin versions) if they are causing problems; if this happens the client will simply fail to connect with a `Forbidden` error in the logs.

**Fixes**
- Fix a bug where if two players were not apart of any free company, they would not be able to see notifications for eachother if they had "Hide FC Members" enabled.
- Fix the naming of the "Settings" window.

Full Changelog can be found [here.](https://github.com/BitsOfAByte/GoodFriend/compare/v1.2.3.1...v1.3.0.0)

--- 

*Planned Ideas*
- The ability to ignore all players who do not share the same homeworld as you
- The ability to ignore all players who are not in the same zone as you (or perhaps a allow/block list of zones to show)

Your feedback matters on any/all of the changes above, as well as new idea suggestions. Feel free to reach out if you'd like to see something in-scope for the project!