### PR TITLE
Update DeathRecap to 1.9.0.0

### DIFF
--- a/stable/DeathRecap/manifest.toml
+++ b/stable/DeathRecap/manifest.toml
@@ -1,8 +1,16 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-deathrecap.git"
-commit = "1a907d7bfaa88a0d0b29553a5552991b6905eac2"
+commit = "d83d80b2b61055c860d06e28baa15b66543d4f6a"
 owners = ["Kouzukii"]
 project_path = ""
 changelog = """
-Signatures for 6.2
+- Added a row filter so you can hide buff/debuff/healing/damage events
+- Will now decode _rsv_ names used in savage and ultimate encounters to their actual names
+- Allow hiding and reordering columns in the event table
+- Added an experimental histogram view (still needs some visual improvements)
+- Recap window can now also be closed with /dr and /deathrecap
+- Added an option to immediatly open the recap on death
+- Allow collapsing the recap window
+- Will now display most recent status effects first in the status effect column
+- Fixed an issue causing -550 DoT events to be displayed
 """


### PR DESCRIPTION
- Added a row filter so you can hide buff/debuff/healing/damage events
- Will now decode `_rsv_` names used in savage and ultimate encounters to their actual names
- Allow hiding and reordering columns in the event table
- Added an experimental histogram view (still needs some visual improvements)
- Recap window can now also be closed with /dr and /deathrecap
- Added an option to immediatly open the recap on death
- Allow collapsing the recap window
- Will now display most recent status effects first in the status effect column
- Fixed an issue causing -550 DoT events to be displayed

