### PR TITLE
[Testing] Add RoleplayProfiles v0.1.0.0

### DIFF
--- a/testing/live/RoleplayProfiles/manifest.toml
+++ b/testing/live/RoleplayProfiles/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
 commit = "b0685cbd7767884bf6be7b143b52d03fcdf0c330"
-owners = ["Vielle Janlenoux"]
+owners = ["Maia-Everett"]
 project_path = "RoleplayProfiles"
 changelog = "Initial test release (displaying profiles from Chaos Archives)"

--- a/testing/live/RoleplayProfiles/manifest.toml
+++ b/testing/live/RoleplayProfiles/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
-commit = "0ed6d69904bf2ad140fd767c53f862b97f9ac701"
+commit = "a8a31254d1b9c92b0ffb6874828d4552944b408b"
 owners = ["Maia-Everett"]
 project_path = "RoleplayProfiles"
 changelog = "Initial test release (displaying and editing profiles from Chaos Archives)"

--- a/testing/live/RoleplayProfiles/manifest.toml
+++ b/testing/live/RoleplayProfiles/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
-commit = "b0685cbd7767884bf6be7b143b52d03fcdf0c330"
+commit = "e2154b425418178329d7a4a0efe0bd4f1c14f829"
 owners = ["Maia-Everett"]
 project_path = "RoleplayProfiles"
-changelog = "Initial test release (displaying profiles from Chaos Archives)"
+changelog = "Initial test release (displaying and editing profiles from Chaos Archives)"

--- a/testing/live/RoleplayProfiles/manifest.toml
+++ b/testing/live/RoleplayProfiles/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
-commit = "e2154b425418178329d7a4a0efe0bd4f1c14f829"
+commit = "0ed6d69904bf2ad140fd767c53f862b97f9ac701"
 owners = ["Maia-Everett"]
 project_path = "RoleplayProfiles"
 changelog = "Initial test release (displaying and editing profiles from Chaos Archives)"

--- a/testing/live/RoleplayProfiles/manifest.toml
+++ b/testing/live/RoleplayProfiles/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
+commit = "b0685cbd7767884bf6be7b143b52d03fcdf0c330"
+owners = ["Vielle Janlenoux"]
+project_path = "RoleplayProfiles"
+changelog = "Initial test release (displaying profiles from Chaos Archives)"


### PR DESCRIPTION
A plugin for Europe region roleplayers, displaying profiles from Chaos Archives (https://chaosarchives.org) for characters with the RP flag on.

Future releases will add the ability to edit your own character profile in-game, and later, possibly, extension to other regions.