### PR TITLE
[Testing] Allagan Tools v1.2.0.8

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "cc3fff1"
+commit = "8964604"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "Fix a potential crash in the inventory scanner. If items stop updating can you take a look in /xllogs and if you see any errors please shoot them to me."
-version = "1.2.0.7"
+changelog = "Updated logging, fixed hire order parsing and retainer bag clearing. If item updating stops working, can you turn on DEBUG logging, go in and out of your retainer a few times then send me the contents of the log."
+version = "1.2.0.8"


### PR DESCRIPTION
Updated logging, fixed hire order parsing and retainer bag clearing. If item updating stops working, can you turn on DEBUG logging(gear icon), go in and out of your retainer a few times then send me the contents of the log.