### PR TITLE
Update GatherBuddy

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "5683c9e17552fb5d48d690bb057a634fabf29884"
+commit = "721c98c8bf43b9a80a05eb03103be1c833700343"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Show number of displayed records in the fish records tab.
- Added (up to 10) automatic rolling backups that should increment on every GatherBuddy launch if some config is different than on the last launch.
- Enormously improve the speed of sorting tables (should only really matter for avid fishers and the record tab)
- Reworked the badly overengineered fish record files to be a single file and hopefully more stable. Migration should happen automatically. Please let me know ASAP if you have any problems with it - the automatic backup should run before the migration, so your data should be kept for at least 10 launches, assuming this works correctly.
- Update some fish data (thanks Amy and Zath)
- Reduced logging overhead (backend)