### PR TITLE
GatherBuddy 3.1.7.1

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "721c98c8bf43b9a80a05eb03103be1c833700343"
+commit = "7570c2eb738709bdbec9ead91bf57fb5a15b2025"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Fix sorting after collectability or log status in FishTab not working
- Potentially fix fish timer values not being set after migration (should not really matter either way)
- Some further small fish data fixes by Amy.