### PR TITLE
[Testing] Collector's Anxity 0.0.3

### DIFF
--- a/testing/live/CollectorsAnxiety/manifest.toml
+++ b/testing/live/CollectorsAnxiety/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/CollectorsAnxiety.git"
-commit = "1a14578e7a3602f79c5a04ae3e526e0379a60cd3"
+commit = "49eec2962d087fdadf4bc3c1b0b145c5c005b68a"
 owners = [
     "KazWolfe",
 ]

--- a/testing/live/CollectorsAnxiety/manifest.toml
+++ b/testing/live/CollectorsAnxiety/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/CollectorsAnxiety.git"
-commit = "43a00a2414b97e7ce7a60d21578a8c15a079f74d"
+commit = "1a14578e7a3602f79c5a04ae3e526e0379a60cd3"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
This plugin still works? Wait, this plugin still *exists?* Apparently. I know, I know. It's a shock to me too.

Release 0.0.3 finally removes Collector's Anxiety from the pit that is known as "Developer Preview." What this means for you is that what you see will probably not change *too much* between now and the final release. Probably. Maybe.

This release also adds tracking for Framer's Kits, because those are becoming a thing now. Framer's Kits will not count against your Collector's Parse™©℠, as a significant percentage of kits appear to not be available to those that didn't get them at just the right moment.