### PR TITLE
[Testing] PartyIcons v1.0.9.3

### DIFF
--- a/testing/live/PartyIcons/manifest.toml
+++ b/testing/live/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "f29dad9a8a757efa063804202208617c4d0a52f2"
+commit = "54df53382d8d2d8b701ea3df910d84d4c8876d2c"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,5 +8,9 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-- Automatically fix old settings window sizes that were saved from before the fix to set default window size relative to the main viewport.
+Specific status icons now take priority over job icons.
+- In a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, and Idle
+- Outside of a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, Busy, Idle, Duty Finder, Party Leader, Party Member, and Role Playing
+
+Thanks to Ces for a simple approach to this problem!
 """


### PR DESCRIPTION
Specific status icons now take priority over job icons.
- In a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, and Idle
- Outside of a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, Busy, Idle, Duty Finder, Party Leader, Party Member, and Role Playing

Thanks to Ces for a simple approach to this problem!
![priorityicons](https://user-images.githubusercontent.com/99750849/197365027-1781a90e-e94b-47d5-a6b7-fe7c67c1c847.gif)