### PR TITLE
Promote RoleplayProfiles to stable (with minor update: 0.1.0.1 -> 0.1.0.2)

### DIFF
--- a/stable/RoleplayProfiles/manifest.toml
+++ b/stable/RoleplayProfiles/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
+commit = "4e60034167aefd74b2e7bdcebcb080ef15069a3d"
+owners = ["Maia-Everett"]
+project_path = "RoleplayProfiles"
+changelog = "Initial release (displaying and editing profiles from Chaos Archives)"


### PR DESCRIPTION
Changelog compared to testing version:
* The login/edit profile button is now shown only on player select, not on mouseover, just like the full profile button.