### PR TITLE
PartyIcons v1.0.9.3

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "1e311a75ee4c2711bab9de601ccec6bf30fee412"
+commit = "28a363df894cec0ceb808e9c9e5ccc4adbd2d8ef"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,9 +8,9 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-2nd pass UI update
-- Ensure the tab bar remains visible when scrolling (helps in the Nameplates tab)
-- Rename the "Static Roles" tab to "Roles"
-- Move role-related settings from the General tab to the Roles tab
-- Adjust organization and appearance of items in the Roles tab
+Specific status icons now take priority over job icons.
+- In a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, and Idle
+- Outside of a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, Busy, Idle, Duty Finder, Party Leader, Party Member, and Role Playing
+
+Thanks to Ces for a simple approach to this problem!
 """


### PR DESCRIPTION
Specific status icons now take priority over job icons.
- In a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, and Idle
- Outside of a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, Busy, Idle, Duty Finder, Party Leader, Party Member, and Role Playing

Thanks to Ces for a simple approach to this problem!
![preview](https://user-images.githubusercontent.com/99750849/197698407-5caac2d6-ee8b-42ce-abee-efac43ba884f.gif)