### PR TITLE
PartyIcons v1.0.9.4

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "28a363df894cec0ceb808e9c9e5ccc4adbd2d8ef"
+commit = "b035adc50b2a2c11a48be2a6cb64511e910e4e80"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,9 +8,7 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-Specific status icons now take priority over job icons.
-- In a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, and Idle
-- Outside of a duty, the following icons are prioritized: Disconnecting, Viewing Cutscene, Busy, Idle, Duty Finder, Party Leader, Party Member, and Role Playing
-
-Thanks to Ces for a simple approach to this problem!
+Quick fixes for status icons
+- Added Group Pose as a prioritized status icon both in and out of a duty
+- Added a configuration setting to enable or disable prioritized status icons
 """


### PR DESCRIPTION
- Added Group Pose as a prioritized status icon both in and out of a duty
- Added a configuration setting to enable or disable prioritized status icons