### PR TITLE
[Stable] Bump UsedName to v0.7.6.7

### DIFF
--- a/stable/UsedName/manifest.toml
+++ b/stable/UsedName/manifest.toml
@@ -1,12 +1,11 @@
 [plugin]
 repository = "https://github.com/LittleNightmare/UsedName.git"
-commit = "042c9be8c131d25ee7785ada1d05bb113c5bdb39"
+commit = "9d5d151200d31c5cdb4af8fc9ed2c57cc5742b09"
 owners = [
     "LittleNightmare"
 ]
 project_path = "UsedName"
 changelog = """
-- first time put plugin in stable
-- Add icon
-- reset hint logic
+- fix not save change immediately
+- fix potential transfer data issues
 """


### PR DESCRIPTION
A plugin developed for the case of FFXIV without a note name. Currently, it is possible to record used names and add nicknames. The used names can be updated automatically through the network package. (When opening the list)

**Supported**
Party List, Friend List, Player Search

if you want more support range, please make a issue

**Bug Fixes**
- fix not save change immediately
- fix potential transfer data issues

**About Issue**

Please go to https://github.com/LittleNightmare/UsedName/issues, i sometimes may ignore some discord information