### PR TITLE
DailyDuty v3.0.7.2

### DIFF
--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "b0c52f90487e6e2307dafa6f22277381a997fdf7"
+commit = "6c98762d6c126a626dd88c0cd386e8ba282cb84f"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"

--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "6c98762d6c126a626dd88c0cd386e8ba282cb84f"
+commit = "99057146b7fe1869c82cec15c4e845727923fa3a"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
nofranz

Potentially fix a null reference exception on opening the duty finder.

This exception is non-fatal, and is handled gracefully currently. It also seems to only happen once per game session.