### PR TITLE
[Stable] Update GoodFriend to v1.4.2.1

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "6a1199e6b9744037aa2a2518f3f2d1cd75f00826"
+commit = "7075d4735a918a8d0e0426c62b45475f702c370f"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
nofranz

I left a logging statement that outputs the received event + hash, and I probably shouldn't have it there so this removes it :)

(biggest change to a plugin ever)