### PR TITLE
[Testing] PartyIcons v1.0.9.6

### DIFF
--- a/testing/live/PartyIcons/manifest.toml
+++ b/testing/live/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "28cf424562a406b300fc9bb485a903ea9b43b993"
+commit = "dac518d2249785431b54243f4352cc7c1f367f41"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,7 +8,8 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-- Fixed null reference exceptions in order to prevent spam in dalamud.log
-- First pass refactor, please @ Mei or whatever if you run into any issues
-- Thank you plugin testers
+- For chat names, added the ability to toggle role colors on/off by context (overworld, dungeon, raid, etc.) (Thanks AkazaRenn)
+- Fixed a bug where having a pet out during an alliance raid caused party numbers to not appear
+- Reduced log output of the plugin
+- Second pass refactor. I haven't broken anything yet!
 """


### PR DESCRIPTION
- For chat names, added the ability to toggle role colors on/off by context (overworld, dungeon, raid, etc.) (Thanks AkazaRenn)
- Fixed a bug where having a pet out during an alliance raid caused party numbers to not appear
- Reduced log output of the plugin
- Second pass refactor. I haven't broken anything yet!