### PR TITLE
[Testing] PartyIcons v1.0.9.7

### DIFF
--- a/testing/live/PartyIcons/manifest.toml
+++ b/testing/live/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "dac518d2249785431b54243f4352cc7c1f367f41"
+commit = "03b9ce7e6d2e9b7ca53e27dd1d3cfbd0cfa70586"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,8 +8,7 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-- For chat names, added the ability to toggle role colors on/off by context (overworld, dungeon, raid, etc.) (Thanks AkazaRenn)
-- Fixed a bug where having a pet out during an alliance raid caused party numbers to not appear
-- Reduced log output of the plugin
-- Second pass refactor. I haven't broken anything yet!
+- In the settings window, Testing Mode and the General tab now flash when enabled 
+- Fixed a bug when converting v1 to v2 config where Game Default chat settings resulted in role colors being enabled
+- Refactored UI code
 """


### PR DESCRIPTION
- In the settings window, Testing Mode and the General tab now flash when enabled
- Chat Name settings now respect Testing Mode
- Fixed a bug when converting v1 to v2 config where Game Default chat settings resulted in role colors being enabled
- Refactored UI code