### PR TITLE
XIVDeck 0.2.15

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "e7bbaaf22909da337b03aad4b50dfa16915ca4ec"
+commit = "c2f24263898c84214cf59edabd0f72770afa21e6"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Valve just *had* to use the name "Steam Deck" for their console. If only they stopped to think how this would affect me, a tiny developer with a small project for some corner of the internet.

- Update some marketing text to clarify that this plugin is for the *Elgato* Stream Deck.
- Update some internal IPC logic to hopefully make things work a bit better with other plugins.

Thank you all so much for 10,000 downloads! It's been amazing being on this journey with all of you.

Full release notes and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.2.15).