### PR TITLE
[Testing] Beachcomber 1.0.3.0

### DIFF
--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "07ca95ce74357daf6a20e2f805bbbf48fcc57c68"
+commit = "da7070657d14823739af315d1b493bb823f1a752"
 owners = [
     "rosella500"
 ]
 project_path = "Beachcomber"
-changelog = "Rename plugin to Beachcomber for real"
+changelog = "Solver better accounts for missing early-week data or disparities between what you told it and what you did"


### PR DESCRIPTION
- If there's a difference between observed supply and expected supply, use observed (this helps if you forgot to select what you crafted in Beachcomber or selected it and forgot to craft it) 
- Add any combination of 4 hour crafts to schedules in the pattern of 4-4-6-4-6 
- Only estimate 1 day ahead if we're missing peak info (like from starting later in the week) 
- Don't require supply data if we know all the peaks already