### PR TITLE
[Testing] NoTankYou v5.0.3.1

### DIFF
--- a/testing/live/NoTankYou/manifest.toml
+++ b/testing/live/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "975593a27c510a10330fbfa0e5c407a165e2a657"
+commit = "7e6127f1a104e30bc29627930ff536611b7ca9c8"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
This update fixes cutscene warnings showing for all players in the party, when only one member of the party is in a cutscene.

When `Check Alliance Members` is enabled, it will display a warning under your name if members of other alliances are in a cutscene.