### PR TITLE
[Testing] Beachcomber 1.0.3.3

### DIFF
--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "1f0be088043744d3e1dccb7f72bc4c68ab8cfb06"
+commit = "331cbc0c1aa93a3405d2ba01a6c213baae83dafd"
 owners = [
     "rosella500"
 ]
 project_path = "Beachcomber"
-changelog = "Fix bug where D7 doesn't initialize properly, again"
+changelog = "Allow for overwriting a rest day's value if advanced configuration option is checked"


### PR DESCRIPTION
- Allow for overwriting a day's value when it's automatically detected as a rest day (if advanced configuration option is checked)
- 	Note: This is a temporary feature while I work on getting more automatic detection in
- Fix slightly low workshop values in selection screen 
- Fix groove calculation when predicting future days