### PR TITLE
GatherBuddy 3.1.7.2

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "7570c2eb738709bdbec9ead91bf57fb5a15b2025"
+commit = "768e0c43e4138cbce065ac2b8723dff88206a751"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Add an option to make the Fishing Timer Window clickthrough instead of allowing for context menus (by quisquous).
- The Fish Timer Window updates automatically on availability changes (by quisquous).
- Fixed an issue with the second numbers not showing in the Fish Timer Window on spots that have 10 fish available.
- Fixed an issue with asymmetric shadowed text.