### PR TITLE
[Stable] PartyIcons v1.0.9.9

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "5a0f5f0c27b4c61c48e821a8acc880b1daa4f48b"
+commit = "123270af6fabe336bdefddbe9c32d8d06ca1e820"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,13 +8,6 @@ owners = [
 ]
 project_path = "PartyIcons"
 changelog = """
-Features
-- For chat names, added the ability to toggle role colors on/off by territory type (overworld, dungeon, raid, etc.) (Thanks AkazaRenn)
-- Added the yellow In a Duty icon to the priority list for forays (Bozja etc.) so that you can tell who is not in a party
-- In the settings window, testing mode and the tab its in now flash when testing mode is enabled
-
-Bug Fixes
-- Fixed an error when a local player is unavailable that would spam dalamud.log during a crash
-- Fixed a bug where having a pet out during an alliance raid caused party numbers to not appear
-- Fixed a bug when converting v1 to v2 config where Game Default chat settings resulted in role colors being enabled
+- Changed the display name of the plugin to improve discoverability.
+- Fixed errors in log when in hunt train as SCH or SMN with pet out.
 """


### PR DESCRIPTION
- Changed the display name of the plugin to improve discoverability.
- Fixed errors in log when in hunt train as SCH or SMN with pet out.