### PR TITLE
[Stable] NamePlateDebuffs v1.0.0.0

### DIFF
--- a/stable/NamePlateDebuffs/manifest.toml
+++ b/stable/NamePlateDebuffs/manifest.toml
@@ -1,0 +1,13 @@
+[plugin]
+repository = "https://github.com/jherig/NamePlateDebuffs.git"
+commit = "0abedb281893cd35718c5e9a5d21a6c3123b65df"
+owners = [
+    "aers",
+    "JHerig",
+    "squidmade",
+]
+project_path = "NamePlateDebuffs"
+changelog = """
+- Updated for 6.28.
+- Fixed debuffs appearing on incorrect nameplates due to a memory layout change.
+"""

--- a/stable/NamePlateDebuffs/manifest.toml
+++ b/stable/NamePlateDebuffs/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/jherig/NamePlateDebuffs.git"
-commit = "0abedb281893cd35718c5e9a5d21a6c3123b65df"
+commit = "da41ad4aa7e936eaaa888302de3798559fa2979b"
 owners = [
     "aers",
     "JHerig",


### PR DESCRIPTION
Displays your debuffs on enemy nameplates.
- Updated for 6.28.
- Fixed debuffs appearing on incorrect nameplates due to a memory layout change.
- Thanks JHerig for letting me help out.
![preview](https://user-images.githubusercontent.com/99750849/200474693-deb9f45b-f05e-43d4-9bfe-a2fd54004580.gif)