### PR TITLE
Add build section to model

### DIFF
--- a/pyckager/models.py
+++ b/pyckager/models.py
@@ -1,11 +1,35 @@
 from re import compile
-from typing import Optional
+from typing import Optional, Literal
 
-from pydantic import BaseModel, Extra, validator
+from pydantic import BaseModel, Extra, validator, Field
 
 
 NUMBERS_ONLY = compile(r'^\d+$')
 VERSION = compile(r'^(\d+\.)+\d+$')
+
+Type = Literal['file']
+Image = Literal['base', 'extended']
+
+
+class Needs(BaseModel):
+    # Using a field alias here so we don't collide with the builtin `type()`
+    type_: Type = Field(alias='type')
+    # TODO: these are required if type=file, so further validation is needed
+    url: Optional[str]
+    dest: Optional[str]
+    sha512: Optional[str] # TODO: validate
+
+    class Config:
+        extra = Extra.forbid
+
+
+class Build(BaseModel):
+    image: Image = 'base'
+    needs: list[Needs]
+
+    class Config:
+        extra = Extra.forbid
+
 
 class Plugin(BaseModel):
     repository: str
@@ -36,6 +60,7 @@ class Plugin(BaseModel):
 
 
 class Manifest(BaseModel):
+    build: Optional[Build]
     plugin: Plugin
 
     class Config:


### PR DESCRIPTION
This adds the following fields that validates the following (via annotated `.toml`):

```toml
[build] # optional section
image = "extended" # required, must be 'extended' or 'base'

  # at least one is required if a [build] section is declared
  [[build.needs]]
  type = "file" # required, but must be 'file' for now
  # these next 3 are optional, but validators can be added to adjust these
  url = "https://example.com/"
  dest = "/foo/bar/baz"
  sha512 = "abcdef1234"

  [[build.needs]]
  type = "file"
  url = "https://example.com/"
  dest = "/foo/baz/bar"
  sha512 = "abcdef1323"

[plugin]
repository = "gh url"
commit = "abcdef"
owners = [ "foo - bar - baz" ]
project_path = "/relative"
changelog = "long changelog string"
version = "1.2.3.4"
```