### PR TITLE
Add ability to print out json-schema compatible schema

### DIFF
--- a/pyckager/__main__.py
+++ b/pyckager/__main__.py
@@ -28,8 +28,13 @@ def create_parser() -> ArgumentParser:
     parser = ArgumentParser()
     subparsers = parser.add_subparsers(help='action to perform', dest='action')
 
+    # validating manifests
     validate_parser = subparsers.add_parser('validate')
     validate_parser.add_argument('manifests', type=to_manifest_path, nargs='+', help='Path to the manifest to validate')
+
+    # print out json schema; don't need to add options for it at this time
+    # may consider adding an indent for niceness though
+    subparsers.add_parser('schema')
 
     return parser
 
@@ -62,6 +67,9 @@ def main() -> int:
         case 'validate':
             if validate_manifests(**vars(args)) is False:
                 return 1
+        case 'schema':
+            print(Manifest.schema_json(indent=2))
+            return 0
         case _:
             parser.print_help()
     return 0


### PR DESCRIPTION
Now with a `schema` action (i.e., `python -mpyckager schema`), it prints out a json schema. I don't know where you would host these files, but putting them up somewhere and versioning them would allow dev-side validation without installing python via tools like [even better toml](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml#completion-and-validation-with-json-schema) in vscode, or other tools that accept json-schema.

If accepted, this may prompt adding an optional root-level `$schema` key to the validation (see prior art example [here](https://starship.rs/config/#configuration)).