### PR TITLE
PlayerTags v1.8.0.1

### DIFF
--- a/testing/live/PlayerTags/manifest.toml
+++ b/testing/live/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "3e347e2bcafe91fcfd2571b62d8aff66bbe5c37d"
+commit = "972f9e88196bb59fb2b26baadd9fa74ed2665b2e"
 owners = [
     "Pilzinsel64",
 ]


### PR DESCRIPTION
- Added missing handler for obsulate properties "IsIconVisibleInChat" and "IsIconVisibleInNameplate" to ensure full compatibility with all old config files