### PR TITLE
[Testing] Player Tags v1.8.0.3

### DIFF
--- a/testing/live/PlayerTags/manifest.toml
+++ b/testing/live/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "6ec3a1a97077e305f5c95f79294f860366d15206"
+commit = "17fff4449bf20ee6ec8bdcb5e0fb51edeb1caebe"
 owners = [
     "Pilzinsel64",
 ]

--- a/testing/live/PlayerTags/manifest.toml
+++ b/testing/live/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "972f9e88196bb59fb2b26baadd9fa74ed2665b2e"
+commit = "6ec3a1a97077e305f5c95f79294f860366d15206"
 owners = [
     "Pilzinsel64",
 ]


### PR DESCRIPTION
- Added new option for Dead Player Handling in Nameplates
- Fixed job icon set not changeable
- Fixed status icon priorizing in some cases
- Added option to Status Icon Priorizer Settings: "Move Status Icon to Nameplate text if possible"