### PR TITLE
XIVDeck 0.2.16

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "c2f24263898c84214cf59edabd0f72770afa21e6"
+commit = "2c395a6a4e824dcc4ec15902ce30e15b6c094869"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Elgato has announced the Stream Deck Plus, and with it, Stream Deck software 6.0.0 and some security changes. Apparently, my plugin only allowing local communication was still not deemed "secure enough," so we get an emergency hotfix.

* Enable CORS support in XIVDeck to satisfy Chrome's security requirements in software 6.0.0.

Full release notes and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.2.16).