### PR TITLE
Simple Tweaks 1.7.9.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "28fd419f1e37fbf44edf58faf8e7c20e59987f19"
+commit = "0a5af1a938f5f9c9b9f950be570bf907fc6fbeff"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
New Tweak: `Emote Log Subcommand` - Adds a 'log' subcommand for emotes when emotelog is disabled.  `/yes log` (Counter to the `/yes motion` subcommand to not show a log message)

[`Show Desynthesis Skill`] Added option to colour display ( _JeffyW_ )
[`Hide Job Gauge`] Will no longer consider the Island Sanctuary as a duty for the `Show In Duty` option.
[`Improved Crafting Log`] Fixed bug causing switching to incorrect job when filtering the recipe list.
[`Sync Crafter Bars`] Will no longer attempt to function in Wolves Den Pier, I have no idea why you would setup your hotbars for crafters there, but just don't.