### PR TITLE
[Stable] Update GoodFriend to v1.4.3.1

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,12 +1,12 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "fb89507ec10ea3c6197f675e61b1113684285aa9"
+commit = "04b86501bc1c0fc8b1c55b50306d4a4822444ab7"
 owners = [
     "BitsOfAByte",
 ]
 project_path = "GoodFriend.Plugin"
 changelog = """
-- Added the 'QuestMarker' notification type
-- Code cleanup
-- Fixed automatica localization updates
+- Change territory update logic
+- Add check to see if the plugin is running from a 3rd-party repository
+- Make sure that DatacenterID and WorldID are recieved from the server
 """

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "04b86501bc1c0fc8b1c55b50306d4a4822444ab7"
+commit = "ab4eba8367cff0514a836b7752a83da05d5c2676"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
- Change territory update logic
- Add check to see if the plugin is running from a 3rd-party repository
- Make sure that DatacenterID and WorldID are recieved from the server