### PR TITLE
[Testing] Player Tags v1.8.0.4

### DIFF
--- a/testing/live/PlayerTags/manifest.toml
+++ b/testing/live/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "17fff4449bf20ee6ec8bdcb5e0fb51edeb1caebe"
+commit = "01385d864a9182a7855b6a3239c8f270f0bc8b17"
 owners = [
     "Pilzinsel64",
 ]
@@ -23,6 +23,7 @@ There has been moved some code to a separated library in another repository for 
         - The plan for the future is to extend that feature and implement the ability to add a second icon beside the status icon.
     - Tags: Added Tag configuration templates
     - Tags: Choose for what chat type the Tag should applied to
+    - General: Gray out or completely ignore Tags for dead players
 - Other:
     - A lot minor adjustments and fixes, i don't remember yet
 - Under the hood:


### PR DESCRIPTION
- Optimized the handling for dead players ("Gray Out" does now include the Tag now, but use gray color if applied to whole nameplate elements)