### PR TITLE
[Stable] Update GoodFriend to v1.4.4.0

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "abe0211f6b3ee3ef95ccbf0c10365039cbd25bcf"
+commit = "63280095182d97b81c0db08eaa9b2fde1d6b1956"
 owners = [
     "BitsOfAByte",
 ]
@@ -9,4 +9,5 @@ changelog = """
 - Change territory update logic
 - Add check to see if the plugin is running from a 3rd-party repository
 - Make sure that DatacenterID and WorldID are recieved from the server
+- Add additional security when generating hashes to prevent the server reciving the same one twice, increasing anonimity.
 """

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "ab4eba8367cff0514a836b7752a83da05d5c2676"
+commit = "abe0211f6b3ee3ef95ccbf0c10365039cbd25bcf"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
- Fixes bug when checking if installed from official repository or not.
- Add additional security when generating hashes to prevent the server reciving the same one twice, increasing anonymity.