### PR TITLE
VFXEditor 1.7.0.0

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "6077d6ce12f7944391d2686cc00a2a86ddc89839"
+commit = "2016cede69011e5bdf31548ef2bf6a39fcf06b1a"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Added animation preview for `.pap` files
- Added undo/redo (located in the "Edit" menu or configured with keybinds in "File > Settings")
- Added copy/paste for `.tmb` and `.pap` files (previously only for vfx)
- Added configurable delay for vfx paths disappearing in the live overlay
- Fixed issue with renaming particles/emitters/etc. not being saved
- Major refactor to all parsing code

https://user-images.githubusercontent.com/18051158/202793877-89aaea22-dadf-4362-9512-1dc2ada6b171.mp4

