### PR TITLE
[Testing] Beachcomber 1.0.4.0

### DIFF
--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "a73c9ae2fddc59deb843622c38fec51241ba883d"
+commit = "269810d1a38aafabe72ce1d6e5558fb78dd9dfbd"
 owners = [
     "rosella500"
 ]

--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "269810d1a38aafabe72ce1d6e5558fb78dd9dfbd"
+commit = "f33dd3a1f15903f6d76868137ebb53ef8ac1dc24"
 owners = [
     "rosella500"
 ]

--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "09699af051e5b0f2c4db6a9f9071dee82a98c3e9"
+commit = "a73c9ae2fddc59deb843622c38fec51241ba883d"
 owners = [
     "rosella500"
 ]
 project_path = "Beachcomber"
-changelog = "Add 4-6-6-8 patterns to solver"
+changelog = "Many bug fixes including future groove calculation, material allocation, and problems with resting day 7"


### PR DESCRIPTION
- Include materials yet to be used in current day's crafts in material allocation lists 
- Improved quality of recommendations and rest day values when "Must have rare materials" is checked. 
- Improve extra groove value calculations
- Fix error where resting D7 caused Problems
- Fix bug where previous day's crafts were not included in today's supply data 
- Fix bug where supply data could be declared invalid if observed later in the day 
- Fix bug where manually entering data for days accidentally counted as rest displays way higher total cowries than it should
- Moved Enforce Rest Days option to advanced configuration since it should no longer be relevant to most users