### PR TITLE
VFXEditor 1.7.0.1

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "2016cede69011e5bdf31548ef2bf6a39fcf06b1a"
+commit = "734016cb3b2acc8d8c97eb7798aa88e443bcf8c5"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Add Play/reset button for `.tmb` files
- Fixed issue with missing binder start properties
- Add double-click on timeline item to navigate to emitter, as well as other navigation buttons