### PR TITLE
[Testing] NoTankYou v5.0.3.3

### DIFF
--- a/testing/live/NoTankYou/manifest.toml
+++ b/testing/live/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "7e6127f1a104e30bc29627930ff536611b7ca9c8"
+commit = "bb77151916f304cf47ce74271243b8a26d964d15"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
I am experimenting with a method to prevent warnings from flickering when moving between areas.
I changed the warning system to only display a warning after a player has been targetable for at least 2seconds
I have also added a suppression for the `jumping` condition to prevent warnings from showing while jumping/sliding to new areas.

These features are more specifically targeting jobs with pets such as Scholar and Summoner. Please @MidoriKami if you experience any weird behavior with this update.

Misc: Use new `IsDead` property to check if a player is properly alive or dead.