### PR TITLE
Wordsmith 1.7.2

### DIFF
--- a/stable/Wordsmith/manifest.toml
+++ b/stable/Wordsmith/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/LadyDefile/Wordsmith-DalamudPlugin.git"
-commit = "cbd70bf28195033885578c709e8b8e9c87b0994b"
+commit = "f948da0f974d0b10e2b1147991e07926a7708b6c"
 owners = [
     "LadyDefile"
 ]


### PR DESCRIPTION
Fixed a major bug that could hide the entire Dalamud UI.