### PR TITLE
Simple Tweaks 1.7.9.1

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "0a5af1a938f5f9c9b9f950be570bf907fc6fbeff"
+commit = "909f07449b21a180e87ac80c7719f73345b86cab"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
[`Emote Log Subcommand`] Fix tweak not working under certain circumstances (Now uses `text` instead of `log`)
[`Custom Free Company Tags`] Add option to hide «»