### PR TITLE
Wordsmith v1.7.3

### DIFF
--- a/stable/Wordsmith/manifest.toml
+++ b/stable/Wordsmith/manifest.toml
@@ -1,8 +1,25 @@
 [plugin]
 repository = "https://github.com/LadyDefile/Wordsmith-DalamudPlugin.git"
-commit = "f948da0f974d0b10e2b1147991e07926a7708b6c"
+commit = "fa4a2a511615123630e20e725d3c6ea2f53a364f"
 owners = [
     "LadyDefile"
 ]
 project_path="Wordsmith"
-changelog = "Optimized several sections of code. Updated thesaurus to use Merriam-Webster API. Fixed several bugs."
+changelog = """Bug Fixes: 
+    [x] Aliases not fixing header properly
+    [x] Scale issue causing buttons to be cut off at bottom of Scratchpad.
+    [x] "Close" button showing incorrectly for history.
+    [x] Aliases being parsed is leaving an extra space after.
+    [x] Aliases for linkshells not working properly.
+    [x] Confirm Scratch Pad Delete not functional on Auto-Delete
+    [x] Typing a capital letter into the thesaurus could cause the thesaurus to fail to load result
+    [x] Wordsmith failing to load dictionary manifest due to HTML response 304 even with retries.
+    [x] Wordsmith failing to load dictionary.
+
+Notes:
+    [x] Reworked handling of header parsing to use Regex to better identify headers including aliased headers.
+    [x] Scale issue resolved. The issue was caused by adding frame padding to expected header/footer size prior to applying scale which threw off calculation.
+    [x] "Close" button was inside unclosed history child frame causing it to load in the wrong location.
+    [x] Refactored Global.cs. Many objects in the Global file did not need global scope and were instead moved to the files where they were actually used.
+    [x] The retries for loading the manifest failed to reset the IfModifiedSince flag due to a scoping issue. Wordsmith should now load the dictionary more reliably.
+    [x] The dictionary could fail to load from error 304. Added retries in the same way that was done to loading manifest. Wordsmith should now load the dictionary more reliably."""


### PR DESCRIPTION
Bug Fixes:
    [x] Aliases not fixing header properly
    [x] Scale issue causing buttons to be cut off at bottom of Scratchpad.
    [x] "Close" button showing incorrectly for history.
    [x] Aliases being parsed is leaving an extra space after.
    [x] Aliases for linkshells not working properly.
    [x] Confirm Scratch Pad Delete not functional on Auto-Delete
    [x] Typing a capital letter into the thesaurus could cause the thesaurus to fail to load result
    [x] Wordsmith failing to load dictionary manifest due to HTML response 304 even with retries.
    [x] Wordsmith failing to load dictionary.

Notes:
    [x] Reworked handling of header parsing to use Regex to better identify headers including aliased headers.
    [x] Scale issue resolved. The issue was caused by adding frame padding to expected header/footer size prior to applying scale which threw off calculation.
    [x] "Close" button was inside unclosed history child frame causing it to load in the wrong location.
    [x] Refactored Global.cs. Many objects in the Global file did not need global scope and were instead moved to the files where they were actually used.
    [x] The retries for loading the manifest failed to reset the IfModifiedSince flag due to a scoping issue. Wordsmith should now load the dictionary more reliably.
    [x] The dictionary could fail to load from error 304. Added retries in the same way that was done to loading manifest. Wordsmith should now load the dictionary more reliably.