### PR TITLE
ResLogger2.Plugin 0.0.1.5 -> 0.0.2.0

### DIFF
--- a/stable/ResLogger2.Plugin/manifest.toml
+++ b/stable/ResLogger2.Plugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/ResLogger2.git"
-commit = "71373466a5d6423b11199aaec5a8631fc1677a0f"
+commit = "6e87fc62f161c5fbfcdccae135d8ac451e1c8664"
 owners = [
     "lmcintyre",
 ]

--- a/stable/ResLogger2.Plugin/manifest.toml
+++ b/stable/ResLogger2.Plugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/ResLogger2.git"
-commit = "2a10d096e0e4628c07502c458d4d655a60b0f0d1"
+commit = "71373466a5d6423b11199aaec5a8631fc1677a0f"
 owners = [
     "lmcintyre",
 ]

--- a/stable/ResLogger2.Plugin/manifest.toml
+++ b/stable/ResLogger2.Plugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/ResLogger2.git"
-commit = "9f9e97c48e56b25b39b2c3dd33924b73fcdc2ad4"
+commit = "2a10d096e0e4628c07502c458d4d655a60b0f0d1"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
Finished a complete web server rewrite and increased reliability in the plugin.
  - [Web only] Reworked the web server to further prevent hash collisions and include information from old game versions more accurately
  - [Web only] Added new methods of obtaining crowdsourced path data from the web server.
  - Reworked the database in the plugin to further prevent hash collisions.
  - Added a stats window to the plugin, showcasing path progress for the current game version and the total amount of paths found.
  - Added a new command to open the stats window.
  - Added a new command to perform XIV's crc32 on a given string.
  - Added a new tooltip to the path list window, showing the path's hashes.