### PR TITLE
[Stable] GoodFriend v1.4.5.0

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,12 +1,12 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "13a79e382511cd427ddb30ab93323288d48a7505"
+commit = "74455052899bf49d413885d322ece8337677038d"
 owners = [
     "BitsOfAByte",
 ]
 project_path = "GoodFriend.Plugin"
 changelog = """
-- Fix plugin load error when using an API URL that does not exist
-- Fix 'API Notifications' not showing error notifications
-- Clarify localization strings
+- Add support for recieving friend notifications inside of content where the friends list is unavailable
+- Improve localization support for settings
+- Add new setting 'Friendslist Caching'
 """

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/GoodFriend.git"
-commit = "74455052899bf49d413885d322ece8337677038d"
+commit = "57aae3ee62515ffc4a705a0d11c74ff446ce0e3e"
 owners = [
     "BitsOfAByte",
 ]


### PR DESCRIPTION
**Features**
- Add support for receiving friend notifications inside of content where the friends list is unavailable (Like dungeons, trials, raids, eureka, etc) by using a cached friendslist when it is not available.
- Improve localization support for settings tabs
- Add new advanced setting "Friendslist Caching" to allow for reverting to the old behavior of not caching the friends list (and by extension not showing friend events in duties)