### PR TITLE
HimbeerToni Raid Tool 1.1.2.47

### DIFF
--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,5 +2,13 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "17dfe1494f33f1903fe628a630a5848b91edd1d8"
-changelog = "fix: loot results window sizing hid parts of text"
+commit = "44ae21bbb5e82a352a2414b9cfb264fec92a141b"
+changelog = """
++ new loot distribution
++ includes guarranteed drops (eg. books)
++ award items to players, no need to manually update them after loot distribution
+* revised lootsession Ui
++ Shows cost if an item is obtainable from a shop
+* reworked item source system
++ can track items in inventories
++ you can now evaluate loot for alt jobs"""


### PR DESCRIPTION
- General
  - tooltips now show if an item can be bought / exchanged
  - tooltiips now show the cost if an item is obtainable from a shop
  - tooltips now show "source" of an item for most items
- Group overview
  - Added the ability to manually track items in inventory
- Loot session (had a big rework)
  - now includes guarateed loot per player (eg. books) 
  - You can now reward items to players
    - Gear in the specific slot is replaced with the awarded item
    - Items awarded are considered for other loot distributed
    - This does not (yet?) do anything in-game 
  - Ui reworked: selecting loot should be more intuitive
  - you can use the loot session on Solo to evaluate for alt jobs
- Fixes
  - Fixed an issue with Bis/Need for upgrade items
  - Fixed tribe of character wasn't saved
-Known Issues
  - Paladin weapons miss osme information
