### PR TITLE
[Testing] Mappy v0.3.0.0

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "9cdf65c2cb9013a13764bea74a361e1255d5ff79"
+commit = "dfa4aca3a3a62a70c8c7c54f189402c663cb13cd"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "456f1150f2c8caf540b459aae5b324f89b742ca8"
+commit = "78067a60efca628dc6a80df4e5095186bbb1adb7"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "dfa4aca3a3a62a70c8c7c54f189402c663cb13cd"
+commit = "456f1150f2c8caf540b459aae5b324f89b742ca8"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "78067a60efca628dc6a80df4e5095186bbb1adb7"
+commit = "aaac77f49e9206f3333be49fbaf9622439d86eb1"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
`Configuration Window` - Add information about why Mappy cannot render below the native game UI
`FATEs` - Add Option to color FATEs that are about to expire with a configurable early warning time and color
`MapMarkers` - Improve Performance
`Map Window` - Add "Hide Between Areas" option to hide the map during zone changes, and automatically reshow it afterwards
`Map Toolbar` - Fix Scaling Issues

`Integrations` - Added option to redirect vanilla map functions to Mappy
These integrations ***replace*** the vanilla behavior.
If a flag would be placed on the vanilla map, Mappy opens and places a flag.
If a gathering marker would be placed on the vanilla map, Mappy opens and places a gathering marker.
If a hotkey or button or command would open the vanilla map, Mappy will open the plugin map.

These integrations will automatically and forcibly disable upon entering PvP.
They will re-enable according to your settings upon Leaving PvP.

Known Issues:
Missing Housing Icons
Missing Quest Icons (both claimed quests, and unclaimed quests)