### PR TITLE
[Testing] WAIA 0.0.1.3

### DIFF
--- a/testing/live/WhereAmIAgain/manifest.toml
+++ b/testing/live/WhereAmIAgain/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/cassandra308/WhereAmIAgain.git"
-commit = "3e5571bd7491657f19a5e0f110d262c97aad087f"
+commit = "4af7f30270f0485074b7541cf9683a361878d0af"
 owners = [
 	"cassandra308",
 	"reiichi001",
 	"MidoriKami"
 ]
 project_path = "WhereAmIAgain"
-changelog = "Major refactor by MidoriKami. \nVast performance improvements and a new configurable UI. \nAlso can do instance numbers now."
+changelog = "Major refactor by MidoriKami. \nNow makes the string update when editing in the configuration window."


### PR DESCRIPTION
Fixes an issue wherein adjusting the config string would not update the DTR bar.

DTR length has also been limited to 35 characters. In the event that you load every template, you may hit the limit.
