### PR TITLE
[Testing] BetterMountRoulette 1.0.1.0

### DIFF
--- a/testing/live/BetterMountRoulette/manifest.toml
+++ b/testing/live/BetterMountRoulette/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "4be049924fed5e7dcc489091c7b9ad50db92ebaf"
+commit = "de250048930f26f6b7e5666704286f01516f9d72"
 owners = ["CMDRNuffin"]
 changelog = """Features:
 - Add mount groups

--- a/testing/live/BetterMountRoulette/manifest.toml
+++ b/testing/live/BetterMountRoulette/manifest.toml
@@ -1,5 +1,8 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "49e1c633cef76b52e8f01f8b90e608e64776aaeb"
+commit = "4be049924fed5e7dcc489091c7b9ad50db92ebaf"
 owners = ["CMDRNuffin"]
-changelog = "Fix: config would not be applied at boot"
+changelog = """Features:
+- Add mount groups
+- Associate each mount roulette with a separate mount group (or none at all)
+- Summon a mount from a specified group via /pmount <group name>"""


### PR DESCRIPTION
Features:
- Add mount groups
- Associate each mount roulette with a separate mount group (or none at all)
- Summon a mount from a specified group via /pmount <group name>