### PR TITLE
[Testing] Mappy v0.4.1.0

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "3444143fa9ea9b150e82bc98cd410c422f6e41c3"
+commit = "c072ec16726617622b7bafb6772585ceb4f8d93d"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "9910a8607c16a6b3589292f58163b286a50c7b55"
+commit = "9046a380bd6661f7daea74c9b7299201e1d0cc53"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "2c2d02afeaf1906bcb558645465c17c888505549"
+commit = "dd9333bd239ab40fddc23fc032baea7a3f8ed490"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "6bf7ac25955bb0ee3aa02be2560971ddb5e58285"
+commit = "3444143fa9ea9b150e82bc98cd410c422f6e41c3"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "c072ec16726617622b7bafb6772585ceb4f8d93d"
+commit = "77683fe55664abb57a196051f18b037708a53ece"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "77683fe55664abb57a196051f18b037708a53ece"
+commit = "2c2d02afeaf1906bcb558645465c17c888505549"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "dd9333bd239ab40fddc23fc032baea7a3f8ed490"
+commit = "9910a8607c16a6b3589292f58163b286a50c7b55"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Housing Markers - Added new module, shows icons for small, medium, and large houses in housing districts

Treasures - Show markers for nearby treasure chests of any kind
(Max visibility is limited to 20 units above and below the player, should prevent showing up on wrong layer)

Configuration Window - Refactored internal systems
(the order the options are shown now reflects draw order, as in things on top draw over things below it)

Map Window - Disable window docking. 
(docking is not supported, there's too many custom mouse interactions to make it work nicely)
Map Window - Added Map X,Y coordinates to toolbar

Commands - Added dynamic helptext `/mappy help` will show all registered commands
(this system will automatically update with new commands when they are added)
(so check `/mappy help` after an update to see new commands)

Commands - Added `/mappy goto ## ##` command
(this command will center the map on the specified map coordinates)

Party Members - Don't draw player as a party member

Quest Markers - Major Performance Increase for drawing claimed quests
Quest Markers - Add Missing MSQ icon
Quest Markers - Add remove from blacklist feature to Configuration Window
Quest Markers - Add hide repeatable option
Quest Markers - Refresh unclaimed quests when changings settings

Map Markers - Fix icons ignoring enabled/disabled setting

Waymarks - Fix using wrong icons

FATEs - Fixed circle changing colors for a second once time expires
