### PR TITLE
Wordsmith v1.7.7

### DIFF
--- a/testing/live/Wordsmith/manifest.toml
+++ b/testing/live/Wordsmith/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/LadyDefile/Wordsmith-DalamudPlugin.git"
-commit = "cbd70bf28195033885578c709e8b8e9c87b0994b"
+commit = "f8e02daa14894cbb62faf36149e57a361d10ee26"
 owners = [
     "LadyDefile"
 ]

--- a/testing/live/Wordsmith/manifest.toml
+++ b/testing/live/Wordsmith/manifest.toml
@@ -5,4 +5,27 @@ owners = [
     "LadyDefile"
 ]
 project_path="Wordsmith"
-changelog = "Optimized several sections of code. Updated thesaurus to use Merriam-Webster API. Fixed several bugs."
+changelog = """# Wordsmith v1.7.7 Patch Notes
+
+## New Features:
+* Using Ctrl+C in the text input of a ScratchPad will now copy the unwrapped text. (This will not include headers)
+
+## UI Changes:
+* Open Scratch Pads in the ScratchPads tab of the Settings UI now has a minimum size. (See bug fixes 1)
+* Added a `Show Advanced Settings` option to the settings page to hide and show the more advanced settings of the plugin.
+* The `Bug?` button in Settings will now show a message box that gives the user an idea of what kind information to include in a bug report.
+* The `Bug?` button in Settings has been renamed to `Found A Bug?`
+* Added a tooltip to the `Buy Me A Ko-Fi` button that explains the nature of the button.
+* Redesigned the `Replace Text Suggestions` list
+
+## Bugs Fixed:
+1. The height of the `Open Scratch Pads` section in the ScratchPads tab of the Settings UI could become 0 if there was no room left in the window.
+2. Major performance loss with large text entries.
+3. Right clicking on the `Replace Text` input field would cause word wrapping to temporarily break.
+
+## Technical Stuff:
+* PadState class has been moved to the DataTypes.cs file
+* Added more error reporting in an attempt to catch a bug that was reported.
+* Adjusted the way UI is drawn in the ScratchPad (Switching away from tables. No visual difference should be noticeable)
+* Removed some unnecessary `if` statements from the saving settings process.
+* There was a minor calculation issue in the way text was displayed that was causing a massive drop in performance. By changing the way the calculation is handled I was able to bring massive performance gains to Wordsmith. I sincerely apologize to everyone for any performance issues they may have experienced with Wordsmith until this point."""


### PR DESCRIPTION
# Change log
* **Major** performance gain.
* Made changes to several files to use the new TextChunk.Words property type.

## Configuration.cs
* Added ShowAdvancedSettings

## DataTypes.cs
* Moved PadState class to here
* TextChunk.Words now returns a List<Word>
* Word.GetString(...) Does not automatically unwrap the string anymore.

## Wordsmith.csproj
* Updated version number to 1.7.7
* Removed a reference to a removed folder.

## Gui\
### ScratchPadUI.cs
* Moved PadState class out of file.
* Added more error reporting.
* Updated the UI drawing if a couple elements.
* Using Ctrl+C on a scratchpad input should now copy text unwrapped.
* Fixed a problem with DrawChunkItem that caused the text highlighting loop to use far too many resources.
* Fixed a bug that caused weird word wrapping issues after right-clicking the replace text bar.

### SettingsUI.cs
* Settings now have an advanced setting option to show more advanced options.
* Fixed an issue that caused the `Open Scratch Pads` list to sometimes draw with 0 height.