### PR TITLE
[Testing] Mappy v0.4.5.1

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "9046a380bd6661f7daea74c9b7299201e1d0cc53"
+commit = "7d231c644eaa26abcf95e01e2e1207811e4c62f0"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "7d231c644eaa26abcf95e01e2e1207811e4c62f0"
+commit = "dc0224d39f0d4adcea1e0cb72ed84a650415bb2f"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
New Feature - Clicking on a quest map link, via journal or duty list ui element, will center the viewport on one of the current tasks for that quest. No more having to navigate through 2+ views before you can see where you quests are.

New Feature - Penumbra integration
**Note: Once Mappy Loads a modified texture from penumbra, changes within Penumbra will not be reflected in Mappy**
*You must either restart your game or disable/re-enable mappy to load a new texture*

Map Window - Saves and restores last viewport position when revisiting a map you've already seen this session

Map Toolbar - Highlights the layer you are currently in

Commands - Added help text to all commands
Commands - Validate `goto` coordinates before moving viewport
Commands - Print `Command Successful` after a command is executed

Quests - Added quest ID to "Remove From Blacklist" section of configuration window
Quest - Fixed minor logic error on IsQuestLocked check

Configuration - Changed default value for `hide in duties` to false