### PR TITLE
[Testing] Mappy v0.4.5.2

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "dc0224d39f0d4adcea1e0cb72ed84a650415bb2f"
+commit = "6b42ba757c0768b992f7a636c42e007e1e859226"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Rebuilt Flag/GatherArea systems, they now more closely resemble vanilla behavior.
Using the context menu to place a flag will insert `<flag>` into chat in the same way that vanilla game does.

Add Searchbox to Configuration Window, this search will only filter the modules names, it will not search the contents of a module.

Fix crash on load if you don't have penumbra installed (whoops!)
Should work fine for both penumbra and non penumbra users now.

I am working on a import/export system for quest blacklisting. There are far too many possible situations where a user may or may not want to see certain quests, and there are many quests that are not completable. I am one person, I can not possibly go through every single one of the 5000 quest (at this time) to determine if it should show or not.

With help from the community to build a blacklist of quests that are impossible to do, I will eventually add this as a default built in blacklist. There are many quests that exist, but due to changes in the game those quests may not be accessible anymore.