### PR TITLE
GatherBuddy 3.2.0.0

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "768e0c43e4138cbce065ac2b8723dff88206a751"
+commit = "ffb6e3fba14d2fa7ee059fb4a47f9ef1faf069d5"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Add Ellipses for fishing spot names in the fishing timer, if the name is too long (by quisquous)
- Prevent some gather actions from occuring during loading screens or when not logged in.
- Add hover tooltips to fishing timer (they are only available when clickthrough is not enabled)
- Add some support for ocean fishing. Rudimentary check for ocean times for the fish tab and availability-checks for current weather/time per route. This was mostly done by quisquous and was not tested by myself except for some rudimentary checks and looking through the code, since I don't ocean fish. Please let us know if something doesn't work correctly.
- Some fish data updates.