### PR TITLE
[Testing] XIVDeck 0.3.0

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "767e9c5c268177d6a5eda0a6237a56e4f8e39c8c"
+commit = "7c4b2decc236f9c02e9229c16a97dadf005113db"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Standing there alone, the release is waiting. All systems go, "are you sure?" Control is not convinced, but QA has the evidence; no need to abort. The countdown starts...

XIVDeck 0.3.0 is now here, and has finally passed the "fever dream" stage of my mind. This is a big release, so let's get into it.

- Support for the Stream Deck Plus has landed! What works well on a dial? Well...
- We have a new action: **Change Volume**! For the SD+ users, you can now actually adjust the volume of independent game channels from the dials. For everyone _else_, pressing a sound channel button will quickly mute/unmute it!
- Emote actions now support setting chat log mode. This allows configuring certain actions to never (or always) log a message to chat, regardless of your game's settings.
- Gearset actions now support choosing a glamour plate override. 

This is a *breaking change* to XIVDeck, so users upgrading to 0.3.0 will need to ensure that they update their Stream Deck Plugin. Additionally, certain config files have changed slightly - there's no going back from this version. If you have any problems, please contact me in the [XIVDeck channel](https://discord.com/channels/581875019861328007/1019648519226806323) in Goat Place and I'll get it resolved ASAP.

Full release notes, **testing notes**, and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.0).