### PR TITLE
GatherBuddy 3.2.0.1

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "ffb6e3fba14d2fa7ee059fb4a47f9ef1faf069d5"
+commit = "89c782dd3d4ea92dc8891ef421f64b5f98640c6d"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Fix being able to set alarms for ocean fish that only depend on weather, which caused crashes.