### PR TITLE
[Testing] MidoriKami Plugins Overhaul

### DIFF
--- a/testing/live/ChillFrames/manifest.toml
+++ b/testing/live/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "73adde0e099a150172a1ebfc0bd2819851e2a3b9"
+commit = "47d337238ce149a6de4b3e781c6f42d0174f4297"
 owners = ["MidoriKami"]
 project_path = "ChillFrames"

--- a/testing/live/ChillFrames/manifest.toml
+++ b/testing/live/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "3a4e079093cf45e21f47bbac38cb67ab4c37d8fb"
+commit = "73adde0e099a150172a1ebfc0bd2819851e2a3b9"
 owners = ["MidoriKami"]
 project_path = "ChillFrames"

--- a/testing/live/ChillFrames/manifest.toml
+++ b/testing/live/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "84214f8c3e39ac3f4d2d9c6aa183df2eafd901bb"
+commit = "a6aa86b9a64a62aa88c368c9d5ef0c6567fc4f44"
 owners = ["MidoriKami"]
 project_path = "ChillFrames"

--- a/testing/live/ChillFrames/manifest.toml
+++ b/testing/live/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "47d337238ce149a6de4b3e781c6f42d0174f4297"
+commit = "84214f8c3e39ac3f4d2d9c6aa183df2eafd901bb"
 owners = ["MidoriKami"]
 project_path = "ChillFrames"

--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "823733ad1c89780470284fc613b7f566f00659b4"
+commit = "513b0807027be3aa1046650247179543d81483d2"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"

--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "c15fd7a9b775a1da4667fa93d76a944f4b6fb3d2"
+commit = "823733ad1c89780470284fc613b7f566f00659b4"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"

--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "8db05dec351c43cba50830f436fb8238d029b5ad"
+commit = "c15fd7a9b775a1da4667fa93d76a944f4b6fb3d2"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"

--- a/testing/live/KitchenSync/manifest.toml
+++ b/testing/live/KitchenSync/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/KitchenSync.git"
-commit = "60bd707bcf5776ac7cd16aca4dd6191d499df7bc"
+commit = "ea8103aeb5bee9a2546a185f8a2527b7079f64be"
 owners = ["MidoriKami"]
 project_path = "KitchenSync"

--- a/testing/live/KitchenSync/manifest.toml
+++ b/testing/live/KitchenSync/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/KitchenSync.git"
-commit = "33e158196ca01e015519c4e2e04fbfb94104099d"
+commit = "02af691fee67da1f23b7a1a2296691f5fc2d69bb"
 owners = ["MidoriKami"]
 project_path = "KitchenSync"

--- a/testing/live/KitchenSync/manifest.toml
+++ b/testing/live/KitchenSync/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/KitchenSync.git"
-commit = "02af691fee67da1f23b7a1a2296691f5fc2d69bb"
+commit = "60bd707bcf5776ac7cd16aca4dd6191d499df7bc"
 owners = ["MidoriKami"]
 project_path = "KitchenSync"

--- a/testing/live/NoTankYou/manifest.toml
+++ b/testing/live/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "67b4e2cf63eb03ecf4f95423cf0527cd141f9045"
+commit = "5c9ec1ca5aa901527640614946fc997ea505c1a0"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"

--- a/testing/live/NoTankYou/manifest.toml
+++ b/testing/live/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "583bc956feb8007174a46fe5d13dff925bfb833e"
+commit = "50c917f0622f9e6a2c0f97282e6818e2704acc28"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"

--- a/testing/live/NoTankYou/manifest.toml
+++ b/testing/live/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "62f252def036b8c3817f00f40cce235d8e91da9a"
+commit = "67b4e2cf63eb03ecf4f95423cf0527cd141f9045"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"

--- a/testing/live/NoTankYou/manifest.toml
+++ b/testing/live/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "5c9ec1ca5aa901527640614946fc997ea505c1a0"
+commit = "583bc956feb8007174a46fe5d13dff925bfb833e"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
Updates ChillFrames to v1.6.0.0
Updates KitchenSync to v1.1.0.0
Updates NoTankYou to v5.1.0.0
Updates DailyDuty to v3.2.0.0

I have combined all of code features I have developed into one utility library called KamiLib, this allows me to bring the best features of each plugin, to all my  plugins at once.

All MidoriKami plugins now have a new command system, you can use `/{pluginname} help` to view all available commands and aliases via an automatically generated message.

Added "Suppression" feature to DailyDuty to snooze alerts until the next reset.

ChillFrames ZoneBlacklists will be reset, there is a super fancy, super easy to use new UI for blacklisting zones, so should be very easy to restore the blacklist.