### PR TITLE
[Testing] Wordsmith v1.8.1

### DIFF
--- a/testing/live/Wordsmith/manifest.toml
+++ b/testing/live/Wordsmith/manifest.toml
@@ -1,53 +1,34 @@
 [plugin]
 repository = "https://github.com/LadyDefile/Wordsmith-DalamudPlugin.git"
-commit = "5e5ae8c1049acd24cd1cec68ade713ffef724931"
+commit = "672b0e101798bff547d70dd933ed869f4e1592e5"
 owners = [
     "LadyDefile"
 ]
 project_path="Wordsmith"
-changelog = """# Wordsmith v1.8.0 Patch Notes
+changelog = """# Wordsmith v1.8.1 Patch Notes
 
 ## New Features:
- * Added another placeholder for marker text `#r` is replaced with the number of remaining chunks.
- * Added an entire new marker system that allows the user to insert marks with several customization options.
+  * When adding a word to the custom dictionary it should now automatically remove all detected spelling errors with that word in all scratch pads.
+  * Roman numerals (capital letters only) will no longer be detected as a spelling error.
+  * Alias `+` button now disabled by default until valid information entered.
 
 ## UI Changes:
- * Added a `Marks & Tags` Category to scratch pad settings.
- * Moved `OOC` Options to `Marks & Tags` category.
- * Added an option to enable `OOC` by default to `Marks & Tags`.
- * Added a marks list to `Marks & Tags` category.
- * Added a `New Marker` section to `Marks & Tags` category list.
- * Changed the tooltip for `OOC` toggle in Scratch Pads to say `OOC markers` instead of `OOC double parenthesis`
- * Scratch Pad maximum size increased to `float.MaxValue`
+  * `Custom Dictionary Entries` is now written in a table header not a text object.
 
-## Bugs:
- [FIXED] `Punctuation Cleaning List` in advanced spell check settings does not reset.
- [FIXED] `Punctuation Cleaning List` not saving with settings.
- [FIXED] Chunk data not updating when settings saved.
- [FIXED] The text input box could scroll to the right on accident with no way to scroll back.
- [FIXED] Error window could fail if an IntPtr was included in the dump data.
+## Bugs Fixed:
+  [FIXED] Incorrect spelling error detections and word alignment.
+  [FIXED] Contractions are counted as a spelling error.
+  [FIXED] Unable to add words to custom dictionary
+  [FIXED] Scratch Pad doesn't always split on sentence.
+  [FIXED] Deleting a search item from the thesaurus could cause an error to occur.
+  [FIXED] Chunks sometimes formed at strange locations.
+  [FIXED] Selecting `Copy Text To Clipboard` for a history item would cause a CTD.
+  [FIXED] Spelling suggestions giving garbage results at times.
 
 ## Technical Stuff:
- * Sealed `PadState` class
- * Added `ChunkMarker` class to `DataType.cs`
- * `TextChunk.CompleteText` removed. This has been refactored as a new method `CreateCompleteText(TextChunk)` in `ScratchPadUI.cs`
- * Added more error dumping to all UI forms.
- * `ScratchPadUI.DrawChunkDisplay()` now factors in `ChunkMarker`'s
- * `ScratchPadUI.DrawChunkItem()` Completely refactored to include `ChunkMarker`'s in the correct places
- * `ScratchPadUI.DrawHistoryItem()` Now grabs `ChunkMarker`'s from settings.
- * `ChatHelper.FFXIVify()` Now factors in all markers.
- * Added more debug commands.
- * Added a `ReplacePlaceholders()` extension method for strings to `Extensions.cs` to ensure predictable behavior.
- * Moved global usings to `Wordsmith.cs`
- * Moved global fields to `Wordsmith.cs`
- * Moved `Global.BUTTON_Y_SCALED` to extension method as int.Scale()
- * Changed the way that settings were reset from a custom reset function to simply replacing the Configuration object with `new()` and saving.
- * Removed several unused members from `ScratchPadUI.cs`
- * Reorganized `ScratchPadUI.cs` members into more logical code regions.
- * Removed `ScratchPadUI.cs` alert system in favor of error window system. Spelling errors are now the only error shown.
- * Added a wrapper method `ImGuiExt.SetHoveredTooltip(string)` for `ImGui.SetTooltip(string)` that bundles the `if (ImGui.IsItemHovered())` check
- * Removed unused packages.
- * Spell checking is no-longer done on its own thread.
- * Added another console command to edit spell check settings.
- * Commented many lines of code that didn't have it and summarized many properties, methods, and functions.
-"""
+  * Incorrect spelling error detection caused by not unwrapping string before running spellcheck. The solution was to unwrap the string.
+  * Contractions were counted as spelling errors because the text was used in spellchecking not the Regex match value.
+  * Adding words to dictionary was not unwrapping the string first leading to unwanted behaviors.
+  * Found an issue with calculating where to split the chunks that could lead to not breaking on a sentence terminator when one is available and managed to fix it.
+  * Found an issue where deleting a thesaurus item could cause an error dump due to a modified collection exception.
+  * Found an infinite loop in `Copy Text To Clipboard`."""


### PR DESCRIPTION
# Wordsmith v1.8.1 Patch Notes

## New Features:
  * When adding a word to the custom dictionary it should now automatically remove all detected spelling errors with that word in all scratch pads.
  * Roman numerals (capital letters only) will no longer be detected as a spelling error.
  * Alias `+` button now disabled by default until valid information entered.

## UI Changes:
  * `Custom Dictionary Entries` is now written in a table header not a text object.

## Bugs Fixed:
  [FIXED] Incorrect spelling error detections and word alignment.
  [FIXED] Contractions are counted as a spelling error.
  [FIXED] Unable to add words to custom dictionary
  [FIXED] Scratch Pad doesn't always split on sentence.
  [FIXED] Deleting a search item from the thesaurus could cause an error to occur.
  [FIXED] Chunks sometimes formed at strange locations.
  [FIXED] Selecting `Copy Text To Clipboard` for a history item would cause a CTD.
  [FIXED] Spelling suggestions giving garbage results at times.

## Technical Stuff:
  * Incorrect spelling error detection caused by not unwrapping string before running spellcheck. The solution was to unwrap the string.
  * Contractions were counted as spelling errors because the text was used in spellchecking not the Regex match value.
  * Adding words to dictionary was not unwrapping the string first leading to unwanted behaviors.
  * Found an issue with calculating where to split the chunks that could lead to not breaking on a sentence terminator when one is available and managed to fix it.
  * Found an issue where deleting a thesaurus item could cause an error dump due to a modified collection exception.
  * Found an infinite loop in `Copy Text To Clipboard`.