### PR TITLE
TitleEdit 2.2.6.7 -> 2.2.6.8

### DIFF
--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/TitleEditPlugin.git"
-commit = "62bc24f65dc1524143669c4110df234016ca9973"
+commit = "82dca59c4c948d41c1d26524cd1e3c3ada15389a"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Fixes an issue where a title screen notification would appear on the black screens before the actual title screen
- Fixes an issue where the plugin may not load fast enough to take effect