### PR TITLE
ResLogger2 0.0.2.2 -> 0.0.2.3

### DIFF
--- a/stable/ResLogger2.Plugin/manifest.toml
+++ b/stable/ResLogger2.Plugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/ResLogger2.git"
-commit = "8f299367a1115e53b0b2ac40ea1bfa78807a89cd"
+commit = "dffed7ef62d97aa951875ecfe32fc038596cfc0b"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Fixes an issue where latent broken files from TexTools meddling would cause the plugin to silently fail to load, resulting in the /reslog command not working