### PR TITLE
TitleEdit 2.2.6.8 -> 2.2.6.9

### DIFF
--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/TitleEditPlugin.git"
-commit = "82dca59c4c948d41c1d26524cd1e3c3ada15389a"
+commit = "8b591cf5c977470150ecbfbffc3867efb16102be"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Fixes the regression where title screens would not apply properly after log out
- Implements a new method of withholding the title screen notification until the title screen is visible