### PR TITLE
[Testing] XIVDeck 0.3.1

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "7c4b2decc236f9c02e9229c16a97dadf005113db"
+commit = "e8bfd080b9896b9d99a3ee61b456131b084b6b0b"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
With Patch 6.3 around the corner, I thought it would be a _great_ idea to release my own changes. Poke it, tap it, turn it, press it, it should all work now. Hopefully.

XIVDeck 0.3.1 is a relatively minor release, but should be productive nonetheless. In no particular order:

- The Change Volume action now will mute/unmute the selected channel on touch screen tap (for Stream Deck Plus users)
- Fix a bug where version 0.3.0 was somehow older than version 0.2.16 to the update checker.
- Fix a bug where volume bars were stuck with "disabled" coloring.
- Some small internal changes to make things prettier and prep for some Dalamud updates.

Crowdin should now have record of the strings added in 0.3, so if you're interested in helping out, please consider [contributing translations](https://crwd.in/xivdeck) to the project! All new translations will be merged in before 0.3 hits stable. I've also enabled Chinese and Korean support for our non-global client friends in addition to the already-existing German, French, and Japanese languages.

Full release notes, testing notes, and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.1).