### PR TITLE
Say What? 1.0.2.0

### DIFF
--- a/stable/WhatDidYouSay/manifest.toml
+++ b/stable/WhatDidYouSay/manifest.toml
@@ -1,11 +1,10 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/WhatDidYouSay.git"
-commit = "9f131df7fc7524cafd78ea09e6b9dfcd93bf9aa1"
+commit = "35ad33864bebdfe910fe6beea1cd08bd32e5fc47"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "WhatDidYouSay"
 changelog = '''
-- Added configuration options to override configuration for specific zones.
-- Added text commands("/saywhat ban" and "/saywhat unban") to override settings for the current zone.  These are just simplified toggles for new the settings in the config window.
+- Added a default speaker name in the chat log for NPCs that lack real names.  This is "NPC" by default, but can be configured as desired in the settings window.
 '''


### PR DESCRIPTION
- Added a default speaker name in the chat log for NPCs that lack real names. This is "NPC" by default, but can be configured as desired in the settings window.