### PR TITLE
[NET7] Release: BetterMountRoulette 1.0.1.7

### DIFF
--- a/stable/BetterMountRoulette/manifest.toml
+++ b/stable/BetterMountRoulette/manifest.toml
@@ -1,6 +1,8 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "8458529ccee52dadd28528b42773d6d1f1614fab"
+commit = "40424915226702fe454b2a1a263c759f80c6d2b6"
 owners = ["CMDRNuffin"]
-changelog = """Feature: Add support for legacy action Flying Mount Roulette
-Fix: Trying to use the mount roulette when you can't no longer eats the next cast bar"""
+changelog = """Features:
+- Add mount groups
+- Associate each mount roulette with a separate mount group (or none at all)
+- Summon a mount from a specified group via /pmount <group name>"""

--- a/stable/BetterMountRoulette/manifest.toml
+++ b/stable/BetterMountRoulette/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "40424915226702fe454b2a1a263c759f80c6d2b6"
+commit = "a7bba570c8aff661b94c7a3e6c490a034f0da2c8"
 owners = ["CMDRNuffin"]
 changelog = """Features:
 - Add mount groups


### PR DESCRIPTION
Features:
- Add mount groups
- Associate each mount roulette with a separate mount group (or none at all)
- Summon a mount from a specified group via /pmount <group name>