### PR TITLE
[NET7] XIVDeck 0.3.2

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "2c395a6a4e824dcc4ec15902ce30e15b6c094869"
+commit = "ac0cb411a4dae086586c29bc3452c3509158a48b"
 owners = [
     "KazWolfe",
 ]

--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "e8bfd080b9896b9d99a3ee61b456131b084b6b0b"
+commit = "ac0cb411a4dae086586c29bc3452c3509158a48b"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
What? We knew when 6.3 was coming out and I didn't schedule my own development properly, causing me to have to panic and release 0.3 to the world a bit early? Absurd.

So, yes, this is XIVDeck 0.3.2, being shipped to production. For those of you already on staging, there are no notable changes from 0.3.1; this is just support for version 6.3 of the game. For those of you on the stable line, hoo boy:

* A new button, **Change Volume**, allows for quickly muting and unmuting audio channels with a push of a button! For those with a Stream Deck Plus, you can also use Change Volume to have an awesome dial to actually adjust the volume freely!
    * For those of you not on a Stream Deck Plus and wondering where *your* volume change function is, it's coming eventually, I promise.
* **Emote Actions** now allow you to choose whether you want to always send a log message, never send a log message, or defer to the game's settings.
* **Gearset Actions** now allow you to (optionally) override your linked glamour plate with a custom one. 
* A very large number of internal changes to hopefully make things work better and in a more stable fashion.
* Load translations for all of the above features (thank you, translators!!)

Because of the new features added to XIVDeck 0.3, the minimum Stream Deck Plugin version has been also increased. If you are upgrading from a stable release, you *will* need to download and install version 0.3.2 of the Stream Deck Plugin. 

Full release notes, testing notes, and downloads, as always, are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.2).