### PR TITLE
Simple Tweaks 1.8.0.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "0fe9e3fa4d73b7ff8a3c8e4593ec06cb80a0d988"
+commit = "4976fa4bdf61819bff3e2cf7f17b437c4b3e8ddc"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "b9a3bf4b189c855e7af0652089c73338b0ff49e7"
+commit = "0fe9e3fa4d73b7ff8a3c8e4593ec06cb80a0d988"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "909f07449b21a180e87ac80c7719f73345b86cab"
+commit = "b9a3bf4b189c855e7af0652089c73338b0ff49e7"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
- Updates for 6.3
- New Tweak: `Hide Tooltips in Combat` - Allows hiding Action and/or Item tooltips while in combat.
- New Tweak: `Disable Mouse Camera Control` - Disable all control of the camera using the mouse.
- New Tweak: `Combat Movement Type Control` - Set movement type between Standard and Legacy when in/out of combat or when weapon is drawn/sheathed.
- New Tweak: Name Plate Icon Spacing - Increases the distance between status icons and character names on name plates.
- Removed some tweaks

**Changes:**
- [`Custom Free Company Tags`] Add option to hide «»
- [`Quick Sell Items`] Add option to sell from retainer inventory

