### PR TITLE
DamageInfoPlugin 2.1.0.5 -> 2.2.0.0

### DIFF
--- a/stable/DamageInfoPlugin/manifest.toml
+++ b/stable/DamageInfoPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/DamageInfoPlugin.git"
-commit = "bc8a6162dbbf111dac6f67a37100a48fa7075a64"
+commit = "85a74e7a9020ae6520ed0ddce43580391b67f3ce"
 owners = [
     "lmcintyre",
 ]

--- a/stable/DamageInfoPlugin/manifest.toml
+++ b/stable/DamageInfoPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/DamageInfoPlugin.git"
-commit = "335e0038109ea4d929cdf9f1345ab5b101a5c5c0"
+commit = "bc8a6162dbbf111dac6f67a37100a48fa7075a64"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Adds support for disabling the new Damage Type indicators added in 6.3
- Renames references to "Darkness" damage to the official terminology, "Unique" damage
- Adds a button that quickly overwrites your damage color preferences to match the color of the new damage type icons for aesthetic purposes