### PR TITLE
PriceCheck 2.4.0.0

### DIFF
--- a/stable/PriceCheck/manifest.toml
+++ b/stable/PriceCheck/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PriceCheck.git"
 owners = [ "kalilistic" ]
 project_path = "src/PriceCheck"
-commit = "e337ea2936f5493fd1f162987ab38ee78870bb33"
+commit = "5db9fea1a0128febf47d0dd36e29f37c4269bcd4"


### PR DESCRIPTION
- Update for net7 and api8.
- Add a note to check universalis when lookups are failing.