### PR TITLE
DiscordBridge 1.4.0.0

### DIFF
--- a/stable/Dalamud.DiscordBridge/manifest.toml
+++ b/stable/Dalamud.DiscordBridge/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/reiichi001/Dalamud.DiscordBridge.git"
-commit = "dc0a71b1f3bf23c0f51313c64f424f0e46f96905"
+commit = "afa799486d3368ef13ea67fc21ec76fbfdf9a9c6"
 owners = [
     "reiichi001",
 	"goaaats",
 ]
 project_path = "Dalamud.DiscordBridge"
-changelog = "New Changes:\n- Fixes for NET7 / API 8\n- Updated library dependencies and switched to NetStone as submodule.\n\nLast Changes:\n- Switched to using full-width ＠ because Discord started enforcing username requirements on webhooks and @ isn't allowed there.\n- If your bot stopped working in September 2022, please enable Message Intents. See the setup guide for updated steps."
+changelog = "New Changes:\n-Fixed duplicate chat issue.\n-Added a classic embed fallback feature in case webhooks fail.\n\nLast Changes:\n- Fixes for NET7 / API 8\n- Updated library dependencies and switched to NetStone as submodule.\n- Switched to using full-width ＠ because Discord started enforcing username requirements on webhooks and @ isn't allowed there.\n- If your bot stopped working in September 2022, please enable Message Intents. See the setup guide for updated steps."


### PR DESCRIPTION
New Changes:
- Fixed duplicate chat issue.\n-Added a classic embed fallback feature in case webhooks fail.

Last Changes:
- Fixes for NET7 / API 8
- Updated library dependencies and switched to NetStone as submodule.
- Switched to using full-width ＠ because Discord started enforcing username requirements on webhooks and @ isn't allowed there.


**If your bot stopped working in September 2022, please enable Message Intents. See the setup guide for updated steps.**
