### PR TITLE
[Testing] XIVDeck 0.3.3

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "ac0cb411a4dae086586c29bc3452c3509158a48b"
+commit = "9ff51580c549a64f07e5a7bf22ae31d2437589a2"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Dalamud isn't even fully released yet (at time of writing), but that won't stop us from wolfing around with patches.

- Testers will now receive a slightly-less-gentle reminder to update the Stream Deck Plugin when it's outdated.
- The Actions Property Inspector will now properly sort actions in the dropdown
- The Actions Property Inspector will no longer show the internal Action ID
- Fixes a bug where all three GC emotes were displayed at once
- Some small internal changes that have the capability to mess up *a lot* of things.

I'm tweaking how the web server behaves a bit (again), which has the potential to cause some problems on certain systems. I don't think this will have any side effects, but please let me know if things start looking or feeling a bit weird or if buttons just randomly stop working.

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.3).