### PR TITLE
Orchestrion 1.8.4.6 -> 1.8.4.7

### DIFF
--- a/stable/orchestrion/manifest.toml
+++ b/stable/orchestrion/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/OrchestrionPlugin.git"
-commit = "9d51a3aabc97d177a1c1988496ed501f3555956d"
+commit = "36072b1f884f62dc116ff5a568d88198fe8a1af6"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Fixes a bug where a song replacement may cause chat messages to repeatedly appear despite BGM not actually changing
- Adds an extremely simple replacement editing flow
Special thanks to the Dalamud Testers who found and helped narrow down a reproduction of this bug.