### PR TITLE
[Testing] TooltipNotes

### DIFF
--- a/stable/DeathRecap/manifest.toml
+++ b/stable/DeathRecap/manifest.toml
@@ -1,16 +1,8 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-deathrecap.git"
-commit = "d83d80b2b61055c860d06e28baa15b66543d4f6a"
+commit = "4db8fb41359ca96d05e9c1ca9bb4fc72fd612f72"
 owners = ["Kouzukii"]
 project_path = ""
 changelog = """
-- Added a row filter so you can hide buff/debuff/healing/damage events
-- Will now decode _rsv_ names used in savage and ultimate encounters to their actual names
-- Allow hiding and reordering columns in the event table
-- Added an experimental histogram view (still needs some visual improvements)
-- Recap window can now also be closed with /dr and /deathrecap
-- Added an option to immediatly open the recap on death
-- Allow collapsing the recap window
-- Will now display most recent status effects first in the status effect column
-- Fixed an issue causing -550 DoT events to be displayed
+Update for Patch 6.3
 """

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "c10ea3b7df6322b21d9fa012b2292caffa6f748e"
+commit = "b98d62faa9881afcce2d8da350a5d9d77f2ccbe4"
 owners = ["Lerofni"]
-project_path = "NotesPlugin"
+project_path = "TooltipNotes"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "378cd56bfa7b7f2ac3a94d380bf584c032567676"
+commit = "c03db5ec96e5ce6ac3ae557757b28b52f284f072"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "c03db5ec96e5ce6ac3ae557757b28b52f284f072"
+commit = "0723b7b0c8d3c28ca26d3daf0f612b011f0faf0b"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "0723b7b0c8d3c28ca26d3daf0f612b011f0faf0b"
+commit = "c9cbf2efaf9069f2e547f90e6e089338fd0f9c73"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "c9cbf2efaf9069f2e547f90e6e089338fd0f9c73"
+commit = "f333c9a74b84d72156fc87e8942721ba8a0b8259"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "3ee42796e680ed20198b360a722568ebc0bab5ac"
+commit = "b822d165310646e075a2b6fba409d8ac571bd358"
 owners = ["Lerofni"]
 project_path = "TooltipNotes"
 changelog = """

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "b822d165310646e075a2b6fba409d8ac571bd358"
+commit = "5a3bedc759731e4f21ed775912da67844c2eaefc"
 owners = ["Lerofni"]
 project_path = "TooltipNotes"
 changelog = """
@@ -8,4 +8,5 @@ Initial Testing Release of TooltipNotes.
 This is a plugin which lets you add custom notes to Itemtooltips. 
 Currently to have equipment duplicates have seperate notes they will need to be glamoured(they can be glamoured into themselves as any glamour is enoguh as long as it makes them unique) as a workaround until I get to inventory tracking at some point.
 Things like a proper mass notes editor and potentially semi custom colours are on the roadmap.
+Thanks to mrexodia for the big refactor!
 """

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,0 +1,5 @@
+[plugin]
+repository = "https://github.com/Lerofni/TooltipNotes.git"
+commit = "4f56b8362752c378540625ae7d2f25ab9e697bbd"
+owners = ["Lerofni"]
+project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,11 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "b98d62faa9881afcce2d8da350a5d9d77f2ccbe4"
+commit = "3ee42796e680ed20198b360a722568ebc0bab5ac"
 owners = ["Lerofni"]
 project_path = "TooltipNotes"
+changelog = """
+Initial Testing Release of TooltipNotes. 
+This is a plugin which lets you add custom notes to Itemtooltips. 
+Currently to have equipment duplicates have seperate notes they will need to be glamoured(they can be glamoured into themselves as any glamour is enoguh as long as it makes them unique) as a workaround until I get to inventory tracking at some point.
+Things like a proper mass notes editor and potentially semi custom colours are on the roadmap.
+"""

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "f333c9a74b84d72156fc87e8942721ba8a0b8259"
+commit = "c10ea3b7df6322b21d9fa012b2292caffa6f748e"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "e38ddf373f4e17b5ed964b9c296196402f09568a"
+commit = "378cd56bfa7b7f2ac3a94d380bf584c032567676"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "56ac6e42ab9e085221b36feb88473b7594744aa0"
+commit = "e38ddf373f4e17b5ed964b9c296196402f09568a"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "4f56b8362752c378540625ae7d2f25ab9e697bbd"
+commit = "56ac6e42ab9e085221b36feb88473b7594744aa0"
 owners = ["Lerofni"]
 project_path = "NotesPlugin"


### PR DESCRIPTION
Initial Submission 
Plugin which lets you add custom notes to the descriptions of itemTooltips by rightclicking them. Saving notes between launches/loads is done by shipping/creating a json with those notes that gets loaded upon pluginload. Saving different notes on duplicate equipment can currently only be done by glamouring one of them(glamouring into itself is fine) 

Features to come: 
*Proper mass note editing in ImGui (currently only possible by editing the json)
*customizable note colours
*implement inventory tracking to stop needing to use the glamour workaround for duplicate equipment