### PR TITLE
[Testing] XIVDeck Release 0.3.4

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "9ff51580c549a64f07e5a7bf22ae31d2437589a2"
+commit = "b96e03641782ef5b02bb92508e01ca871ff66818"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Ah, bugs. Sometimes they're caused by developers being careless. Sometimes they're caused by inexplicable eldritch nightmares of code. Sometimes they just... are. Anyways, they're all fun to squish.

- Fix a bug where the version check system would improperly compare versions.
- Fix a bug where certain hotbar buttons may flicker under specific conditions.
- Make hotbar buttons on the Stream Deck side update more intelligently
- Improve the Force Update Nag Window a bit.

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.4).