### PR TITLE
DelvUI release 1.5.0.1

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "61a943a0fee147c0bd2e59dd0e27a7967ccb1957"
+commit = "19c79f1ec26d963c7a5f6f55635a66aa4889c869"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added Machinist's Dismantle to Party Cooldowns.
- Fixed Invulnerabilities and Raise Trackers' icons not being disableable.