### PR TITLE
[Testing] Allagan Tools v1.2.0.12

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "11dc0fc"
+commit = "d1fb491"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "Inventory and configuration saving are now run asynchronously except when the plugin is disposing to stop potential hitches. Fixed an issue with memory sort order parsing not actually being needed when the client is first started and no ITEMODR file exists. "
-version = "1.2.0.11"
+changelog = "The yolo release, this brings support for .net 7 and 6.3. Expect bugs, glamour chest will parse but highlighting is not fully complete. Please report any issues in the Allagan Tools help thread. If I can't get the testing version stabilised I will backport the 6.3 fixes to the live version and get that out but ideally I'd like to get this version made the live version."
+version = "1.2.0.12"


### PR DESCRIPTION
The yolo release, this brings support for .net 7 and 6.3. 
Expect bugs, glamour chest will parse but highlighting is not fully complete. Please report any issues in the Allagan Tools help thread. If I can't get the testing version stabilised I will backport the 6.3 fixes to the current live version and get that out but ideally I'd like to get this version made the live version.