### PR TITLE
[Testing] XIVDeck 0.3.5

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "b96e03641782ef5b02bb92508e01ca871ff66818"
+commit = "8f3aff292a8a8ec5d603e39891662c71e82fc217"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Volume. Button. Volume buddon.

- Added the ability to set a Volume Button on a normal Stream Deck to Set, Mute, or Adjust the selected volume channel.
    - There will probably be more UI work for this coming Later:tm:, but at least the functionality exists now.
- Added class abbreviations to the Classes API. This is currently unused, but will likely have value in the near future.
    - No, I'm not doing a class switcher on a dial. Or... am I? 

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.5).