### PR TITLE
DelvUI release 1.5.1.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "e61801328d3e5ed3df2f4f510b74621556b5959d"
+commit = "cfb2a30d93e71e70a7678b007321813906e267df"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
Features:
- Added Sign Icons to all Unit Frames, Party Frames and Enemy List.
- Reworked Machinist's Overheat Bar:
    + It now uses chunks for the 5 stacks.
    + The label displays the remaining duration of the buff.
    + Due to these changes, the settings for this bar will be reset.

Fixes:
- Fixed tooltips sometimes cutting off.
- Fixed Machinist Automaton Queen Bar's choppiness.