### PR TITLE
FPS Plugin 1.6.0.5

### DIFF
--- a/stable/FPSPlugin/manifest.toml
+++ b/stable/FPSPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/FPSPlugin.git"
-commit = "9e4b3f7ad64ccd557b89196aa0446b9722eab9e7"
+commit = "cc1c09e9bef15079126cdb14f307e7e7633d4617"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
nofranz

- Fixes plugin crashing when clicking Ko-Fi button
- Sets DTR bar as default.