### PR TITLE
DamageInfoPlugin 2.2.0.3 -> 2.2.0.4

### DIFF
--- a/stable/DamageInfoPlugin/manifest.toml
+++ b/stable/DamageInfoPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/DamageInfoPlugin.git"
-commit = "a4108c768a557630002656782657d5ece170d533"
+commit = "e1727da890d65c7f2b07281eed3a82dcb74debaa"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Fixes a bug where disabling the damage type icon broke literally everything ever