### PR TITLE
Tidy Chat v1.2.4 - "/hmm broke everything edition"

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "15205e57a115fd2a453666ffadef4c94eab58b65"
+commit = "d49ba4efb0b512487089799a39eb8a74d5d46ac9"
 owners = [
     "NadyaNayme",
 ]
 project_path = "TidyChat"
-changelog = "Updated for FFXIV 6.3 and Dalamud API 8"
+changelog = "Fix Emotes filter"


### PR DESCRIPTION
- Fixes Emote Filter (sorry everyone!) 

I've had a single report that the condensed commendations improved message was not working - I was not able to replicate this issue. The setting is not enabled by default so please be sure the setting has been enabled if expecting this behavior after installation.

I've also had a single report that the Loot spam filters were not working - I was not able to replicate this issue either. Please note that due to how Tidy Chat works players with the first or last name "You" will bypass certain filters. 

If anyone encounters either of the above two issues - please either report it to Tidy Chat's Github with a screenshot of the message and your relevant settings or DM me directly on Discord at #Nyu0117. 