### PR TITLE
Allagan Tools v1.2.0.16

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "b8ca3b29dbaa446218e033853ab406ab33ce40dc"
+commit = "7538c671eea4ce1a4570caa332e59583d311bab3"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "Fixed retainer sort order crashing\nFixed configuration not saving on game exit"
-version = "1.2.0.15"
+changelog = "This is a bug fix release. Fixed some potential bugs with IPC initalisation, retainer sort scanning(rolled back to file monitoring for now) and an assembly related crash."
+version = "1.2.0.16"


### PR DESCRIPTION
This is a bug fix release. 
Fixed some potential bugs with IPC initalisation, retainer sort scanning(rolled back to file monitoring for now) and an assembly related crash.