### PR TITLE
Simple Tweaks 1.8.1.1

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "ae81e4f94121a02351d488b389db19f1bdeceb27"
+commit = "371ada21a6a2ef15bc3f227dca8a2baaec523181"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "371ada21a6a2ef15bc3f227dca8a2baaec523181"
+commit = "c25da5de329897a64c49a751131db3904df34761"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
[`Improved Crafting Action Tooltips`] Fixed tweak not disabling properly.
[`Adjust Equipment Positions`] Fixed widget display in standard quality UI.
[`Parameter Bar Adjustments`] Add option to center HP bar when MP bar is hidden.
[`Estate List Command`] Allow partial matching
[`Hide Job Gauge`] Stop hiding if a job tutorial notice is displayed
[`Target HP`] Add option to align text to the left
