### PR TITLE
[Testing] Better Targeting System

### DIFF
--- a/testing/live/BetterTargetingSystem/manifest.toml
+++ b/testing/live/BetterTargetingSystem/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lynesth/BetterTargetingSystem.git"
-commit = "4459d1db1bfa8d445cc1e52be95b47695abc9a8f"
+commit = "27ffb252fd187200c9220c188611269e773b846d"
 owners = ["Lynesth"]
 project_path = "BetterTargetingSystem"
 changelog = "Initial submission"

--- a/testing/live/BetterTargetingSystem/manifest.toml
+++ b/testing/live/BetterTargetingSystem/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/Lynesth/BetterTargetingSystem.git"
+commit = "fc570e8affc5dd7f5b570ea1f1b87a949caa25c7"
+owners = ["Lynesth"]
+project_path = "BetterTargetingSystem"
+changelog = "Initial submission"

--- a/testing/live/BetterTargetingSystem/manifest.toml
+++ b/testing/live/BetterTargetingSystem/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lynesth/BetterTargetingSystem.git"
-commit = "c49711475cb98a72b0fe7d344323fcc5f1708276"
+commit = "27eaac89b0ca1198565ceed8c5d0f3d7c8e46476"
 owners = ["Lynesth"]
 project_path = "BetterTargetingSystem"
 changelog = "Initial submission"

--- a/testing/live/BetterTargetingSystem/manifest.toml
+++ b/testing/live/BetterTargetingSystem/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lynesth/BetterTargetingSystem.git"
-commit = "fc570e8affc5dd7f5b570ea1f1b87a949caa25c7"
+commit = "86c98bf52abd6fe7fdf1cc9dbbdc31872b5f7ec7"
 owners = ["Lynesth"]
 project_path = "BetterTargetingSystem"
 changelog = "Initial submission"

--- a/testing/live/BetterTargetingSystem/manifest.toml
+++ b/testing/live/BetterTargetingSystem/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lynesth/BetterTargetingSystem.git"
-commit = "86c98bf52abd6fe7fdf1cc9dbbdc31872b5f7ec7"
+commit = "4459d1db1bfa8d445cc1e52be95b47695abc9a8f"
 owners = ["Lynesth"]
 project_path = "BetterTargetingSystem"
 changelog = "Initial submission"

--- a/testing/live/BetterTargetingSystem/manifest.toml
+++ b/testing/live/BetterTargetingSystem/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Lynesth/BetterTargetingSystem.git"
-commit = "27ffb252fd187200c9220c188611269e773b846d"
+commit = "c49711475cb98a72b0fe7d344323fcc5f1708276"
 owners = ["Lynesth"]
 project_path = "BetterTargetingSystem"
 changelog = "Initial submission"


### PR DESCRIPTION
This plugin tentatively aims at improving the tab targeting in the game by following simple rules and using fallbacks (like targeting an enemy in your enemy list if there's nothing to target on screen, etc).

It doesn't - or at least shouldn't - allow you to targeting anything not targetable the vanilla way.

It also adds a keybind to target the lowest health enemy visible on screen.

`/bts` provides options to configure the keybinds.