### PR TITLE
[Testing] Allagan Tools v1.3.0.1

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "d1fb491"
+commit = "db3ed0fa11ea564db622e4285c2acf33438432a5"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "The yolo release, this brings support for .net 7 and 6.3. Expect bugs, glamour chest will parse but highlighting is not fully complete. Please report any issues in the Allagan Tools help thread. If I can't get the testing version stabilised I will backport the 6.3 fixes to the live version and get that out but ideally I'd like to get this version made the live version."
-version = "1.2.0.12"
+changelog = "Adds a IPC for querying items, controlling filters, etc. Adds in basic support for mob drop data in the more information window. Adds in more options on how the tooltip location data is presented and limits the amount of data added to the tooltip."
+version = "1.3.0.1"


### PR DESCRIPTION
Adds a IPC for querying items, controlling filters, etc.  Adds in basic support for mob drop data in the more information window.  Adds in more options on how the tooltip location data is presented and limits the amount of data added to the tooltip.