### PR TITLE
[Testing] TF2-ish Critical Hits 1.1.0.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "3562f6256e3348f16abf00a75ef959a3f8cc65ad"
+commit = "9136841894c0f015f857abe3df819ed97d1e8483"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
-changelog = "Initial release."
+changelog = "Fixes no sound playback."

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "9136841894c0f015f857abe3df819ed97d1e8483"
+commit = "6b6ea36d7f90aadfc1c838778e32f860714f1b96"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
-changelog = "Fixes no sound playback."
+changelog = "Adds option to preview sound in the configuration pane and fixes no sound playback."

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "6b6ea36d7f90aadfc1c838778e32f860714f1b96"
+commit = "4a1083ffe9d3db4f1ff26e8fdfaf5344255485eb"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = "Adds option to preview sound in the configuration pane and fixes no sound playback."


### PR DESCRIPTION
Now, you can preview your sound file directly in the configuration pane.

Also, fixes not playing the sound at all (which is, like, 75% why someone would install this plugin).