### PR TITLE
[Testing] TooltipNotes 0.1.07

### DIFF
--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -5,6 +5,6 @@ owners = ["Lerofni"]
 project_path = "TooltipNotes"
 changelog = """
 Fixed bug that wouldve wiped Notes upon a plugin update(hopefully). 
-If you already had Notes you will need to copy them to the plugin config at %appdata%/XIVLauncher\pluginConfigs\TooltipNotes
+If you already had Notes you will need to copy them to the plugin config at %appdata%/XIVLauncher/pluginConfigs/TooltipNotes
 also includes some QOL changes thanks to mrexodia
 """

--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,12 +1,10 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "5a3bedc759731e4f21ed775912da67844c2eaefc"
+commit = "90962831b636f97cca632603345109010ce99ed3"
 owners = ["Lerofni"]
 project_path = "TooltipNotes"
 changelog = """
-Initial Testing Release of TooltipNotes. 
-This is a plugin which lets you add custom notes to Itemtooltips. 
-Currently to have equipment duplicates have seperate notes they will need to be glamoured(they can be glamoured into themselves as any glamour is enoguh as long as it makes them unique) as a workaround until I get to inventory tracking at some point.
-Things like a proper mass notes editor and potentially semi custom colours are on the roadmap.
-Thanks to mrexodia for the big refactor!
+Fixed bug that wouldve wiped Notes upon a plugin update(hopefully). 
+If you already had Notes you will need to copy them to the plugin config at %appdata%/XIVLauncher\pluginConfigs\TooltipNotes
+also includes some QOL changes thanks to mrexodia
 """


### PR DESCRIPTION
Fixed bug that would've wiped Notes upon a plugin update(hopefully).
If you already had Notes you will need to copy them to the plugin config at %appdata%/XIVLauncher/pluginConfigs/TooltipNotes also includes some QOL changes thanks to mrexodia

If you never heard of the plugin since the last franzbot message didn't go out: It is a simple plugin which lets you add notes to itemtooltips and more information can be found in the plugin-help-forum