### PR TITLE
[Testing] TF2-ish Critical Hits 1.2.0.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "4a1083ffe9d3db4f1ff26e8fdfaf5344255485eb"
+commit = "c7ee5647d634f3f98f73c9756dc359dc4c0577c6"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
-changelog = "Adds option to preview sound in the configuration pane and fixes no sound playback."
+changelog = "Separates Direct Critical Hits from plain Critical Hits."


### PR DESCRIPTION
Separates Direct Critical Hits from plain Critical Hits for further customization.

For now, the flavor text of both Direct Critical Hits and plain Critical Hits use the same formatting (green italic).