### PR TITLE
Waymark Preset Plugin 1.4.4.2

### DIFF
--- a/stable/WaymarkPresetPlugin/manifest.toml
+++ b/stable/WaymarkPresetPlugin/manifest.toml
@@ -1,11 +1,10 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/WaymarkPresetPlugin.git"
-commit = "49e1f6d56abb89bbe2c454b43e7591edd4992ec7"
+commit = "04bc1cd116ee58e9dcf11667c6303d9d96da129c"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "WaymarkPresetPlugin"
 changelog = '''
-- Updated for patch 6.3 (increased number of save slots in-game).
-- Updated for Dalamud API 8.
+- Fixes an issue where the configuration window would expand indefinitely with certain Dalamud font settings.
 '''


### PR DESCRIPTION
- Fixes an issue where the configuration window would expand indefinitely with certain Dalamud font settings.