### PR TITLE
[Testing] TooltipNotes 0.1.1.1

### DIFF
--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,9 +1,12 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "c3145195a0782fd17372dbda7390770594a41f4b"
+commit = "a03aaf9fda3d4e21309fc5706b19592aa432ff4e"
 owners = ["Lerofni"]
 project_path = "TooltipNotes"
 changelog = """
+0.1.1.1 cchanges: fix empty notekey bug
+
+0.1.1.0 changes:
 BIIG Changes thanks to mrexodia once again.
 **NOTE**
 This update will invalidate your current notes, but fret not! in the new config Window you can now with the press of a Button migrate your existing notes into the new format.


### PR DESCRIPTION
fixed the empty noteky bug. New notes should now be addable and editable again.