### PR TITLE
[Testing] TF2-ish Critical Hits 1.4.0.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "12e9163531e4d6f350cd84b7887e72b70554a402"
+commit = "3a12b6a0ff964fabb680bcee85f373d09a40866a"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
-changelog = "Adds option to disable sounds for autoattacks."
+changelog = "Bumps max. text length to 40 characters."

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "3a12b6a0ff964fabb680bcee85f373d09a40866a"
+commit = "96f019e682431eef5adefd9997b3b6448c2b5fa8"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = "Bumps max. text length to 40 characters."


### PR DESCRIPTION
Bumps maximum text length to 40 characters.

> But the feedback asked for 24, why **double** it instead of just adding four more characters?

Do you know what uses **exactly** 40 characters?

![image](https://user-images.githubusercontent.com/6826264/215746253-6a683095-d7e6-431f-8604-d1cea7a6b4c5.png)
