### PR TITLE
[Testing] EurekaHelper v0.0.0.3

### DIFF
--- a/testing/live/EurekaHelper/manifest.toml
+++ b/testing/live/EurekaHelper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "d48deac7ec61973a8faed080540e6b911aaf3b19"
+commit = "291d7691b4bc536b64ba0fbac7c1d1cf6d0426b4"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
 changelog = """

--- a/testing/live/EurekaHelper/manifest.toml
+++ b/testing/live/EurekaHelper/manifest.toml
@@ -1,6 +1,11 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "fb098ab923aef577a3a1ebd74ad654451ab2803d"
+commit = "d48deac7ec61973a8faed080540e6b911aaf3b19"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
-changelog = "Added for testing"
+changelog = """
+- Added feature to copy or shout to chat upon clicking custom chat payload
+- Added an option to show toast when an NM pops
+- Fixed some datacenter not being set correctly
+- Fixed connection not closing when unloading the plugin
+"""


### PR DESCRIPTION
Updated to v0.0.0.3
- Added feature to copy to clipboard or shout to chat upon clicking custom chat payload
- Added an option to show toast when an NM pops
- Fixed some datacenter not being set correctly
- Fixed connection not closing when unloading the plugin