### PR TITLE
DelvUI release 1.5.3.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "b2cd93f6d5d67a5bf3db684081ddca0f3386d7e6"
+commit = "0f48297c30f462152307d6fca52da4dac5579fb8"
 owners = ["Tischel"]
 project_path = "DelvUI"

--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "0f48297c30f462152307d6fca52da4dac5579fb8"
+commit = "0d9557ee443b3671804532d7f961fda7e0aac0e8"
 owners = ["Tischel"]
 project_path = "DelvUI"

--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "584dccd27228899fe4b86cdc89e8db54c506cd95"
+commit = "b2cd93f6d5d67a5bf3db684081ddca0f3386d7e6"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Reworked name text tags:
    + A lot of existing text tags have been removed.
    + You can now specify the type of unit for a name text tag.
        * This allows to display player names and npc names differently on the same label.
        * Example: `[player_name:initials][npc_name]` would display the initials for a player, and the full name for an npc.
        * You can still use tags starting with `[name:` that work for both types of units.
    + Additionally you can now specify a cap for the length of the names by adding `.#` at the end.
        * Example: `[name.5]` would display `Tisch` for the name `Tischel`.

- Disabled Sign Icons from unit frames for non-combat NPCs (until I find a better fix).