### PR TITLE
TextToTalk v1.21.4

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "02fad9f816aa53d203171c7de7dedc1041c0755b"
+commit = "e1647b00720e22808099ff632949fe87a7c4eebe"
 project_path = "src"
 owners = ["karashiiro"]
 changelog = """\
-- Fixes WebSocket backend being completely broken
+- Fixes text not being sent over the WebSocket backend
+- Fixes error spam in the log when disconnecting from a WebSocket server
 """


### PR DESCRIPTION
- Fixes text not being sent over the WebSocket backend
- Fixes error spam in the log when disconnecting from a WebSocket server