### PR TITLE
NoTankYou v5.1.2.0

### DIFF
--- a/stable/NoTankYou/manifest.toml
+++ b/stable/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "745b6748560b2203708c7d8bf90c7b0ba43564df"
+commit = "ba9e1656dd5fb931ff8f8b80a90dca113170397b"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
NoTankYou will now disable warnings whenever you are `Transformed`.
Prevents warnings from showing when you can't use your role specific actions anyways.

Add death grace period, warnings for recently raised people will be suppressed for 3 seconds.
This gives people a chance to re-summon their pets before warnings appear.