### PR TITLE
DamageInfoPlugin 2.2.0.4 -> 2.2.0.5

### DIFF
--- a/stable/DamageInfoPlugin/manifest.toml
+++ b/stable/DamageInfoPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/DamageInfoPlugin.git"
-commit = "e1727da890d65c7f2b07281eed3a82dcb74debaa"
+commit = "389a95716b1bb8f983651e9c9252f341797de713"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Fixes an issue where heal source text was not displaying properly.