### PR TITLE
[Testing] Allagan Tools 1.3.0.4

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "34c05f65de5c5a2e96788e72b25850d26261e8d3"
+commit = "50d479f949bd0aab9ec2aa6e3cb4f528ed8211f5"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "This is purely a crash fix release, nothing else bar the crash has been fixed. You may still encounter a crash until you restart the game."
-version = "1.3.0.3"
+changelog = "Added partial matching filter with ~\nFixed crash with can be desynthed filter\nTrack retainer/character source world and added source filter\nFixed a yield issue with crafting calculations\nCompleting a craft that yields more than 1 item will actually count as the amount completed rather than 1\nThe applicable classes for gear was not being calculated correctly\nA lot more coffers will have information for what items can be acquired from them(not all of them though)"
+version = "1.3.0.4"


### PR DESCRIPTION
Added partial matching when using text fields, prefix your search with ~to find partial matches 
Fixed crash with can be desynthed filter
Track retainer/character source world and added source filter 
Fixed a yield issue with crafting calculations
Completing a craft that yields more than 1 item will actually count as the amount completed rather than 1 
The applicable classes for gear was not being calculated correctly 
A lot more coffers will have information for what items can be acquired from them(not all of them though)
Fixed an issue where the tooltip would not display the correct amount of items you had if you had over your set maximum - thanks to Faye Y. for this one 