### PR TITLE
[Testing] Mounting Party v1.0.0.0

### DIFF
--- a/testing/live/MountingParty/manifest.toml
+++ b/testing/live/MountingParty/manifest.toml
@@ -1,0 +1,8 @@
+[plugin]
+repository = "https://github.com/meoiswa/MountingPartyPlugin.git"
+commit = "572d44d8732f0166e3639171d21dcb7f7448eebc"
+owners = [
+    "meoiswa"
+]
+project_path = "MountingParty"
+changelog = "Initial Release"


### PR DESCRIPTION
 This simple plugin overrides Mount Roulette to spawn a randomly picked multi-seater mount the user has unlocked, whenever they are in a Party