### PR TITLE
DaCoblyn 1.0.2.1

### DIFF
--- a/testing/live/DaCoblyn/manifest.toml
+++ b/testing/live/DaCoblyn/manifest.toml
@@ -1,6 +1,13 @@
 [plugin]
 repository = "https://github.com/thatismunn/xiv-coblyn.git"
-commit = "048dffc08c0487563e9ef88889502f3a1aba9a67"
+commit = "a1ef11f0309772e946c2b2d2afecba57c322c7c6"
 owners = [ "thatismunn" ]
 project_path = "Plugin/DaCoblyn"
-changelog = "Add auto translate chat to target language"
+changelog = """
+Version 1.0.1.7:
+- Replace text command /tl to interactive window.
+- Fix switch language that can't be switching when source language is Automatic
+Version 1.0.2.1:
+- Fixing deprecated "Open window" method.
+- Fixing "Low confident" alert when the language is ignored in the configuration. thatismunn/xiv-coblyn#2
+"""


### PR DESCRIPTION
[1.0.1.7]
- Replace text command /tl to interactive window.
- Fix switch language that can't be switching when source language is Automatic
Preview for translate interaction menu:
![image](https://user-images.githubusercontent.com/32958839/218024454-dfc2f217-d338-4087-b432-c97443822665.png)

[1.0.2.1]
- Fixing deprecated "Open window" method.
- Fixing "Low confident" alert when the language is ignored in the configuration. thatismunn/xiv-coblyn#2
