### PR TITLE
Simple Tweaks 1.8.2.1

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "c7fe36bf457128976a9702989ca91b488093b019"
+commit = "23ef0f5ea5513fadfbaad2c53c60aeb8014518b2"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "23ef0f5ea5513fadfbaad2c53c60aeb8014518b2"
+commit = "94dbcb8240c411d3b09bce87a22c8d3ca09b3520"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
New Tweak: `Keep Windows Open` - Prevents certain windows from hiding under specific circumstances.
New Tweak: `Loot Window Duplicate Indicator` - Recolors unique items that you already have in the loot window. (_MidoriKami_)

Fixed a potential tweak crash in `Improved Crafting Log` that kept players in crafting state.