### PR TITLE
NOTED release 1.1.1.0

### DIFF
--- a/stable/NOTED/manifest.toml
+++ b/stable/NOTED/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/NOTED.git"
-commit = "8c205b1b32ffe63cbeb380b69d58cd1871c57e58"
+commit = "68db287f59dd766b05ee27d63004f974a3be4a51"
 owners = ["Tischel"]
 project_path = "NOTED"
-changelog = "- Added some visibility settings.\n- Added keybind to toggle notes on/off.\n- Added keybinds to cycle through notes."
+changelog = "- Combined all duties from The Masked Carnivale into a single entry.\n\t+ Each challenge was treated as a different duty before, but since the internal ID is the same it was creating issues."


### PR DESCRIPTION
- Combined all duties from The Masked Carnivale into a single entry.
    + Each challenge was treated as a different duty before, but since the internal ID is the same it was creating issues.