### PR TITLE
DelvUI release 1.5.4.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "aa06c74c539e7a409338fa0df8ab98ec8aeabaa8"
+commit = "3473550801ce4ad0dece733cddc91dbd735e2fc4"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Implemented format groups for labels:
    + This allows you to have entirely different formats for players and NPCs.
    + The format is `{unitType=<text>}`. Anything inside the brackets will only be shown for units of that `unitType`.
    + Valid unitTypes are `player` and `npc`.
    + The text inside a group can have text tags.
    + Example `{player=Lv [level]  [name:initials]}{npc=[distance]y  [name]}`:
        * This will display "Lv 90  J. D." for a level 90 player named "John Doe".
        * This will display "30y  Striking Dummy" for a Striking Dummy NPC that is 30 yalms away from you.

- Removed some text tags: `[health:current-max]`, `[health:current-max-short]`, `[mana:current-max]`, `[mana:current-max-short]`.
    + These can easily be replaced by combining other existing tags.
    + Example: `[health:current] | [health:max]`.

- Updated text tag `[time-till-max-gp]`:
    + New format is `mm:ss` (the parenthesis were removed).

- Fixed experience text tags not showing in the text tags list.