### PR TITLE
[Testing] XIVDeck 0.3.7

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "8f3aff292a8a8ec5d603e39891662c71e82fc217"
+commit = "a37923540c165c0a0a39e3acaf4cebb4ff89c43e"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
So, there's this really cool thing called [IPv6](https://en.wikipedia.org/wiki/IPv6). It's been around since December 1995. Many ISPs *still* do not support it, or it breaks in really annoying ways. Some *operating systems*, even, somehow cannot handle IPv6 properly. It's only been 28 years, can we *please* get our act together?

- Works around a bug where certain systems may not be able to properly communicate with the game plugin thanks to (bad) IPv6 handling and DNS resolution.
- Some minor internal changes to make debugging things easier for me.

Assuming nobody complains about this release, I'll promote it to production in the near future.

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.7).