### PR TITLE
Add GentleTouch 1.10.1

### DIFF
--- a/stable/GentleTouch/manifest.toml
+++ b/stable/GentleTouch/manifest.toml
@@ -1,8 +1,14 @@
 [plugin]
 repository = "https://github.com/fitzchivalrik/gentletouch.git"
-commit = "fcdf3bdd05a7a74f7215e284b149ebea4365c621"
+commit = "a68e91393aeab2d4d9de8a727f519b2eb99e32d9"
 owners = ["fitzchivalrik"]
 project_path = "GentleTouch"
 changelog = """
-- fix: Do not vibrate on already attuned Aether Currents
+- feat: DualSense support via DS4 compatibility vibrations
+- feat(DualSense): Set resistance for Adaptive Triggers
+- feat(DS+DS4): Two extra macro buttons:
+  Create (DualSense) / TouchPad (DualShock4) as Individual Macro #96,
+  PS Button as Individual Macro #97
+- feat(DS+DS4): Option to /draw & /sheathe with PS button instead of Macro #97
+Check out the new settings tab, if you are using a DualSense/DualShock4.
 """


### PR DESCRIPTION
(Moving from testing to stable)

- feat: DualSense support via DS4 compatibility vibrations
- feat(DualSense): Set resistance for Adaptive Triggers
- feat(DS+DS4): Two extra macro buttons: Create (DualSense) / TouchPad (DualShock4) as Individual Macro Nr. 96, PS Button as Individual Macro Nr. 97
- feat(DS+DS4): Option to /draw & /sheathe with PS button instead of Macro Nr. 97
 
Check out the new settings tab, if you are using a DualSense/DualShock4.