### PR TITLE
Add GentleTouch 1.10.2

### DIFF
--- a/stable/GentleTouch/manifest.toml
+++ b/stable/GentleTouch/manifest.toml
@@ -1,14 +1,17 @@
 [plugin]
 repository = "https://github.com/fitzchivalrik/gentletouch.git"
-commit = "a68e91393aeab2d4d9de8a727f519b2eb99e32d9"
+commit = "ba4f7cf2d735a4fef77058e9c0fb80345dbdef5b"
 owners = ["fitzchivalrik"]
 project_path = "GentleTouch"
 changelog = """
+- fix: Do not crash if DualSense is connected via bluetooth
 - feat: DualSense support via DS4 compatibility vibrations
 - feat(DualSense): Set resistance for Adaptive Triggers
 - feat(DS+DS4): Two extra macro buttons:
   Create (DualSense) / TouchPad (DualShock4) as Individual Macro #96,
   PS Button as Individual Macro #97
 - feat(DS+DS4): Option to /draw & /sheathe with PS button instead of Macro #97
+
 Check out the new settings tab, if you are using a DualSense/DualShock4.
+Only works if connected wired (same as the game's).
 """


### PR DESCRIPTION
- fix: Do not crash if DualSense is connected via bluetooth

Clarify, that DualSense/Shock4 support only works wired (same as the game's).