### PR TITLE
DelvUI release 1.6.0.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "3473550801ce4ad0dece733cddc91dbd735e2fc4"
+commit = "899cc3aff36a2c415dc9a15f1b7d46fec48c142b"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added custom Nameplates:
    + Like other DelvUI components, enabling this feature won't automatically disable the game's counterpart.
    + You are supposed to manually hide the types of nameplates you don't want from either the game or DelvUI.

- Unit frames for NPCs with 1 max health points wont show health values if the "Hide Health if Possible" setting is enabled for the label (previously it only did it for units with no health points).
- Fixed issues with colors in unit frames for NPCs.


**Regarding Nameplates:**

- In general, if a nameplate from the game wouldn't be visible, a DelvUI Nameplate won't be visible either for that unit.
- Nameplates are drawn using ImGui like all other DelvUI elements. This means they will not interact with the 3D space the same way the real nameplates would.
- There are some systems in place to simulate the real behavior, but it will never be the same.
- Using DelvUI's Nameplates implies a tradeoff: You'll have more control on how the nameplates look, but you'll lose some "immersion" regarding how they will interact with the 3D space.
- For enemy units, the nameplates can display your debuffs, similar to what other plugins do.
- For ally units, we don't support the ability to display buffs nor debuffs. We believe this wouldn't be good for the game. Please don't ask for this because it won't happen.