### PR TITLE
[Testing] Wholist v0.3.2.0

### DIFF
--- a/testing/live/Wholist/manifest.toml
+++ b/testing/live/Wholist/manifest.toml
@@ -1,20 +1,24 @@
 [plugin]
 repository = "https://github.com/BitsOfAByte/Wholist.git"
-commit = "b705e4bb04b5b479dafce1a8aaeb718a4af8f076"
+commit = "7638a118a8fc15a6a4eb9dd4bed93e43b68dee3a"
 owners = [
     "BitsOfAByte",
 ]
 project_path = "Wholist"
 changelog = """
+**One of the last pre-releases before moving to a full stable release** 
+
 **New Features**
-- 'Search on Lodestone' player context menu item for quickly finding a player on the lodestone.
 
-**Translation Updates:**
-- French translation updates
+- The 'Nearby Players' list is now sorted alphabetically by default.
+- New configuration options have been added:
+	* 'Show known players first': display friends, party members & other known players on the top of the list
+
+**Improvements**
+
+- The 'Nearby Players' list will now sort by distance when finding players nearby to you. In practice, this means that when you've set the 'max players shown' to lower than the current nearby players, the people closest to you will be shown first.
+
+**Translation Updates**
+
 - German translation updates
-
-**Other Improvements**
-- Refactoring of underlying components to improve interface draw times
-- Restricted heading elements for better visual clarity
-- Separator between plugin context menu items and 3rd party integration items.
 """


### PR DESCRIPTION
**One of the last pre-releases before moving to a full stable release** 

**New Features**

- The 'Nearby Players' list is now sorted alphabetically by default.
- New configuration options have been added:
	* 'Show known players first': display friends, party members & other known players on the top of the list

**Improvements**

- The 'Nearby Players' list will now sort by distance when finding players nearby to you. In practice, this means that when you've set the 'max players shown' to lower than the current nearby players, the people closest to you will be shown first.

**Translation Updates**

- German translation updates