### PR TITLE
[Testing] StanleyParableXiv 1.2.4.0

### DIFF
--- a/testing/live/StanleyParableXiv/manifest.toml
+++ b/testing/live/StanleyParableXiv/manifest.toml
@@ -1,8 +1,11 @@
 [plugin]
 repository = "https://github.com/rekyuu/StanleyParableXiv.git"
-commit = "7b8fe0db4850935cedd5e22eb5271242fa02cbc9"
+commit = "e21e89103b9b48a52f70d80e4cda005ee952d188"
 owners = ["rekyuu"]
 project_path = "StanleyParableXiv"
 changelog = """
-- Fixed PvP countdown configuration not setting when standard countdown configuration is open 
+- Updated killing spree voice lines to be 30% quieter during playback
+- Implemented Duty Complete playback for guildhests
+- Disabled Duty Start and Duty Complete playback for solo quest instances
+- Prevented Duty Failure from playing during FC workshop craft cutscenes
 """

--- a/testing/live/StanleyParableXiv/manifest.toml
+++ b/testing/live/StanleyParableXiv/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/rekyuu/StanleyParableXiv.git"
-commit = "e21e89103b9b48a52f70d80e4cda005ee952d188"
+commit = "a1abf05c3287c7170c8151fc200c8e75ddfad89b"
 owners = ["rekyuu"]
 project_path = "StanleyParableXiv"
 changelog = """


### PR DESCRIPTION
- Updated killing spree voice lines to be 30% quieter during playback
- Implemented Duty Complete playback for guildhests
- Disabled Duty Start and Duty Complete playback for solo quest instances
- Prevented Duty Failure from playing during FC workshop craft cutscenes