### PR TITLE
Update Orange Guidance Tomestone to 1.7.0

### DIFF
--- a/stable/OrangeGuidanceTomestone/manifest.toml
+++ b/stable/OrangeGuidanceTomestone/manifest.toml
@@ -1,9 +1,8 @@
 [plugin]
 repository = 'https://git.anna.lgbt/ascclemens/OrangeGuidanceTomestone.git'
-commit = '1e68b679c85a354b84ee196584aa0ccdd904bc10'
+commit = 'ce2011ce33e61afbc6142f1f55de239c9d63b49b'
 owners = [ 'ascclemens' ]
 project_path = 'client'
 changelog = """\
-- Fix a crash because Dalamud can't handle exceptions
-- Fix an exceedingly rare potential crash to satisfy someone
+- Housing areas now have messages separated by ward/plot.
 """

--- a/stable/OrangeGuidanceTomestone/manifest.toml
+++ b/stable/OrangeGuidanceTomestone/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = 'https://git.anna.lgbt/ascclemens/OrangeGuidanceTomestone.git'
-commit = 'ce2011ce33e61afbc6142f1f55de239c9d63b49b'
+commit = '73fdfd326341edd31189b7b3ccb1faf793ea9fa9'
 owners = [ 'ascclemens' ]
 project_path = 'client'
 changelog = """\


### PR DESCRIPTION
The whining may finally stop: housing locations are separated by ward (and plot/apt/wing where applicable). Leave me alone ;-;