### PR TITLE
DelvUI release 1.6.1.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "21f19cae449dc6c95ef4f52eccc3b37c24ce6693"
+commit = "be268c2cccac39c3f9749925be592ef76f014086"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added a new "Occlusion Type" setting for Nameplates:
    + This lets you control which kind of objects in the world will cover nameplates.
    + This setting's default value is "Walls".
    + In previous versions, the default was "Walls and Objects" which was causing a lot of unexpected behaviors.

- Fixed released minions in the Island Sanctuary not having a nameplate.
- Fixed elements in the enemies nameplates not being visible if both the Health Bar and Name Label were hidden.
- Fixed some game windows not covering DelvUI elements.
- Fixed Status Lists layout not being calculated correctly with high padding.