### PR TITLE
[Testing] TF2-ish Critical Hits 2.3.0.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,9 +1,12 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "de72b90a4697d7f9a065359e4c19c16160c07c90"
+commit = "a4b9f08bb5ef90712ba766ad95f378d2c3f8a74b"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
 - Changed logic that checks if a fly text is for damage or heal.
     - This should fix any conflicts with DamageInfo. If they persist, send feedback through Dalamud or on the Discord.
+- Reordered options
+    - Now all damage types come first, then all heal types.
+- Fixed options about PvP (for Direct Damage) and using the game's sound effect volume not being copied between jobs. (Thanks, Grayve!)
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "9f19c64460eca35387205908b03d6aa1ad074a77"
+commit = "de72b90a4697d7f9a065359e4c19c16160c07c90"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-- Now should work for Second Wind and Bloodbath self critical heals. (Can Bloodbath even crit heal? I don't know, but it's now fixed!)
-- The configuration window sidebar is now resizable, thanks to MidoriKami.
+- Changed logic that checks if a fly text is for damage or heal.
+    - This should fix any conflicts with DamageInfo. If they persist, send feedback through Dalamud or on the Discord.
 """


### PR DESCRIPTION
- Changed logic that checks if a fly text is for damage or heal.
    - This should fix any conflicts with DamageInfo. If they persist, send feedback through Dalamud or on the Discord.
- Reordered options
    - Now all damage types come first, then all heal types.
- Fixed options about PvP (for Direct Damage) and using the game's sound effect volume not being copied between jobs. (Thanks, Grayve!)