### PR TITLE
[Testing] Beachcomber v1.2.0.1

### DIFF
--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "cd907271506a12056fa4f3b5da0fa731eafe2a3b"
+commit = "837671453bb90e5672f89f0b982cfdc826a23643"
 owners = [
     "rosella500"
 ]

--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "dd4d3843ea7108ea1436f33dbb56681ea7a3db62"
+commit = "cd907271506a12056fa4f3b5da0fa731eafe2a3b"
 owners = [
     "rosella500"
 ]
 project_path = "Beachcomber"
-changelog = "Read peaks from external database to improve accuracy with missed days"
+changelog = "Various fixes, can show time next to craft names"


### PR DESCRIPTION
- Add option to show craft time in schedule suggestions
- Fix bug where solver crashes if you don't have enough materials
- Change all references of "day" to "cycle"
- Fix bug where previous schedules can be attributed to the wrong days