### PR TITLE
[Testing] Update FCNameColor to 3.0.2.0

### DIFF
--- a/testing/live/FCNameColor/manifest.toml
+++ b/testing/live/FCNameColor/manifest.toml
@@ -1,13 +1,9 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "717a4f263e3b5f9997762499b08ed512bd13965a"
+commit = "8013b9f28fefca2ce0cd25b57f08c979edb6072b"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
-Changes:
-
-- Update for 6.2
-- Use different hooking mechanism
-
-This may end up causing issues with other plugins that change nameplates (PartyIcons, SimpleTweaks, etc) as well as some potential performance issues. Let me know if you run into any major issues on GitHub or on Discord.
+- Update NetStone
+  This should help with issues regarding fetching FC members, which was causing the plugin to stop working for some users.
 """


### PR DESCRIPTION
- Update NetStone This should help with issues regarding fetching FC members, which was causing the plugin to stop working for some users.