### PR TITLE
PennyPincher v1.6.0.0

### DIFF
--- a/stable/PennyPincher/manifest.toml
+++ b/stable/PennyPincher/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/tesu/PennyPincher.git"
-commit = "b553f5bd4b95779344b7dbb6d6e228d327a55820"
+commit = "04190b4f0e24710b9ae74627b4aaba2ac798eded"
 owners = [
     "tesu",
 ]
-changelog = ".NET 7 update"
+changelog = "automatically undercut HQ when listing HQ item; don't try to undercut own retainers"


### PR DESCRIPTION
Two new features:
* Automatically undercut HQ when listing an HQ item (turn off HQ mode to use this new functionality)
* Avoid undercutting your own retainers

Big thanks to @carvelli for implementing both of these features (I didn't do anything).