### PR TITLE
Update FCNameColor to 3.0.2.0

### DIFF
--- a/stable/FCNameColor/manifest.toml
+++ b/stable/FCNameColor/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "15c185d4196219a225b68c6d449e6aacad4f2dbb"
+commit = "8013b9f28fefca2ce0cd25b57f08c979edb6072b"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
-- Resolve logging issue that was causing problems for other plugin developers.
+Changes:
+- Update NetStone
+  This should help with issues regarding fetching FC members, which was causing the plugin to stop working for some users.
 """


### PR DESCRIPTION
Changes:
- Update NetStone This should help with issues regarding fetching FC members, which was causing the plugin to stop working for some users.