### PR TITLE
[Testing] Beachcomber v1.2.1.0

### DIFF
--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "837671453bb90e5672f89f0b982cfdc826a23643"
+commit = "41141d0a6fdf45853e4d4feb5452dbcaf2a756c1"
 owners = [
     "rosella500"
 ]
 project_path = "Beachcomber"
-changelog = "Various fixes, can show time next to craft names"
+changelog = "Fix peaks not being set once they're known"

--- a/testing/live/Beachcomber/manifest.toml
+++ b/testing/live/Beachcomber/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/rosella500/IslandWorkshopSolver.git"
-commit = "41141d0a6fdf45853e4d4feb5452dbcaf2a756c1"
+commit = "00216e652b516be5927a3f88e46b0e578fc5944b"
 owners = [
     "rosella500"
 ]
 project_path = "Beachcomber"
-changelog = "Fix peaks not being set once they're known"
+changelog = "Async peak calculation. Include 6-craft schedules."


### PR DESCRIPTION
- Fix bug where peaks aren't set correctly if they're already in the CSV
- Remove unnecessary schedules from solver (this makes solving faster)
- Change peak calculation to be asynchronous so it doesn't hang the game
- Calculate the value of 6-craft schedules (this makes solving slower but can be turned off in config if this is too intensive)