### PR TITLE
[Testing] TextToTalk v1.23.0

### DIFF
--- a/testing/live/TextToTalk/manifest.toml
+++ b/testing/live/TextToTalk/manifest.toml
@@ -1,8 +1,12 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "6f3f26e3342e6e2f095c3e20b0aa7bbedca97d0a"
+commit = "0be89c5fc68c7447f05076fc4826941903e95465"
 project_path = "src"
 owners = ["karashiiro"]
 changelog = """\
-- Fixes TTS for the System backend.
+- Fixed some minor UI glitches when switching backends
+- Fixed the plugin toggle keybind interfering with the chat preset keybinds
+- Fixed a "no presets" warning not displaying in the chat
+- Fixed a bunch of weird settings interactions
+- Cleaned up a ton of core code to prep for new features
 """


### PR DESCRIPTION
- Fixed some minor UI glitches when switching backends
- Fixed the plugin toggle keybind interfering with the chat preset keybinds
- Fixed a "no presets" warning not displaying in the chat
- Fixed a bunch of weird settings interactions
- Cleaned up a ton of core code to prep for new features