### PR TITLE
Item Vendor Location v1.1.0.1

### DIFF
--- a/stable/ItemVendorLocation/manifest.toml
+++ b/stable/ItemVendorLocation/manifest.toml
@@ -1,13 +1,11 @@
 [plugin]
 repository = "https://github.com/electr0sheep/ItemVendorLocation.git"
-commit = "f509043a5782bbc0efabf4c6f2f60b4e37354fcc"
+commit = "67b03a138e26854ac33a68916a4e568d76d2fee2"
 owners = [
     "electr0sheep",
 ]
 project_path = "ItemVendorLocation"
 changelog = """
-- Add localization (should work across languages now)
-- Allow plugin to work in Supply Mission window
-- Allow plugin to work in Recipe Tree window
+- Remove localization (should still function in other languages, but with an English menu option)
 """
-version = "1.1.0.0"
+version = "1.1.0.1"


### PR DESCRIPTION
Removes CheapLoc, until I can figure out how to use it better.