### PR TITLE
Item Vendor Location v1.1.0.2

### DIFF
--- a/stable/ItemVendorLocation/manifest.toml
+++ b/stable/ItemVendorLocation/manifest.toml
@@ -1,11 +1,11 @@
 [plugin]
 repository = "https://github.com/electr0sheep/ItemVendorLocation.git"
-commit = "67b03a138e26854ac33a68916a4e568d76d2fee2"
+commit = "2af78ce25eecd0a9f95e5cc08e68ed77a2557141"
 owners = [
     "electr0sheep",
 ]
 project_path = "ItemVendorLocation"
 changelog = """
-- Remove localization (should still function in other languages, but with an English menu option)
+- Fix for crash on plugin load
 """
-version = "1.1.0.1"
+version = "1.1.0.2"

--- a/stable/ItemVendorLocation/manifest.toml
+++ b/stable/ItemVendorLocation/manifest.toml
@@ -1,13 +1,11 @@
 [plugin]
 repository = "https://github.com/electr0sheep/ItemVendorLocation.git"
-commit = "f509043a5782bbc0efabf4c6f2f60b4e37354fcc"
+commit = "67b03a138e26854ac33a68916a4e568d76d2fee2"
 owners = [
     "electr0sheep",
 ]
 project_path = "ItemVendorLocation"
 changelog = """
-- Add localization (should work across languages now)
-- Allow plugin to work in Supply Mission window
-- Allow plugin to work in Recipe Tree window
+- Remove localization (should still function in other languages, but with an English menu option)
 """
-version = "1.1.0.0"
+version = "1.1.0.1"


### PR DESCRIPTION
Removes `Loc.ExportLocalizable();`.

I tried setting up similar permission so my game directory isn't writable, and was able to reproduce the bug I introduced with my first localization attempt. When I remove this line, no file writes occur, and as far as I can tell, everything is working.