### PR TITLE
Simple Tweaks 1.8.3.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "9547c729d4e21f3918bc09fc9e7a29e474ed2a69"
+commit = "335c29c896599bcc2d71c2dd7b59583632a69008"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "94dbcb8240c411d3b09bce87a22c8d3ca09b3520"
+commit = "9547c729d4e21f3918bc09fc9e7a29e474ed2a69"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "9b4f9935502e304cb928b37359542cb4655750b1"
+commit = "417cc959350d7fabcf62e3a88d1c2b989e4d5f71"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "335c29c896599bcc2d71c2dd7b59583632a69008"
+commit = "9b4f9935502e304cb928b37359542cb4655750b1"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***General Changes***
> Added a changelog
> Fixed graphical issue when resizing windows on clear blue theme.

***New Tweaks***
> **`Echo Party Finder`** - Prints Party Finder description to chat upon joining a group. *(MidoriKami)*

> **`Expanded Currency Display`** - Allows you to display extra currencies. *(MidoriKami)*

> **`Extended Macro Icons`** - Allow using specific Icon IDs when using '/macroicon # id' inside of a macro.

> **`Hide Unwanted Banners`** - Hide information banners such as 'Venture Complete', or 'Levequest Accepted' *(MidoriKami)*

> **`Improved Duty Finder Settings`** - Turn the duty finder settings into buttons. *(Aireil)*

> **`Improved Interruptable Castbars`** - Displays an icon next to interruptable castbars *(MidoriKami)*

> **`Keyboard Gaming Mode`** - Block Alt-Tab and other keys to keep you in the game. *(KazWolfe)*

> **`Simplified Equipment Job Display`** - Hides classes from equipment tooltips when their jobs are unlocked.

> **`Target Castbar Countdown`** - Displays time remaining on targets ability cast. *(MidoriKami)*

> **`Track Gacha Items`** - Adds the collectable checkmark to gacha items, such as Triple Triad card packs, when all potential items have been obtained.


***Tweak Changes***
> **`Enhanced Loot Window`** - Rebuilt tweak to use images

> **`Enhanced Loot Window`** - Fixed tweak not checking armory and equipped items

> **`Enhanced Loot Window`** - Added 'Lock Loot Window' feature

> **`Enhanced Loot Window`** - Added configuration options

> **`Fix '/target' command`** - Fixed tweak not working in french. *(Aireil)*

> **`High Resolution Screenshots`** - Added option to hide dalamud UI for screenshot.

