### PR TITLE
[Testing] Allagan Tools v1.4.0.1

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "bb5fd6fe20a74c6e887cec87102fa9393245601f"
+commit = "7cc428b76e4145ac4f675a0f729bfdc5a6b5fd2e"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-changelog = "New duties window, mob window, duty window, lots more item/boss/drop data, speed increases, bug fixes, airship/submarine drop data, general bug fixes, ui updates, see the full list in the Allagan Tools post in #plugin-help-forum on the xivlauncher discord."
-version = "1.4.0.0"
+changelog = "Add more npc location data, add more npc shops\nAdd submarine/airship unlock information\nAdded /submarines, /airships windows and popout windows for each\nMore shops will show even if they don't have location data(housing shops mostly)\nFix uppercase searching issue\nAdd tooltip display options for displaying plugin name and lines below and above tooltip content\nAdded manual data for certain loot items"
+version = "1.4.0.1"


### PR DESCRIPTION
Add more npc shop/location data
Add submarine/airship unlock information
Added /submarines, /airships windows and popout windows for each 
More shops will show even if they don't have location data(housing shops mostly) 
Fix uppercase searching issue
Add tooltip display options for displaying plugin name and lines below and above tooltip content
Added manual data for certain loot items