### PR TITLE
DeepDungeonDex 2.5.0

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "cab984e31af7e245a341c729c25adbd8828a08f6"
-changelog = "## 2.4.0 (2023-01-24)\n\n\n### Features\n\n* Add deprecation warning on legacy window. (1615417)\n* add full unknown status on new targets if no data exists (25891cb)"
-version = "2.4.0"
+commit = "4e0c2355e29b690c478cf4f25fc1defc3dc06989"
+changelog = "## 2.5.0 (2023-03-07)\n\n\n### Features\n\n* add EO as a territory to Deep Dungeons List (ae3053b)\n\n\n### Bug Fixes\n\n* Improve idle times when not in a Deep Dungeon (4fd9724)"
+version = "2.5.0"


### PR DESCRIPTION
## 2.5.0 (2023-03-07)


### Features

* add EO as a territory to Deep Dungeons List (ae3053b)


### Bug Fixes

* Improve idle times when not in a Deep Dungeon (4fd9724)

Will throw some errors to the log that are a non issue while EO data isn't fully populated.