### PR TITLE
[Testing] XIVDeck 0.3.9

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "a37923540c165c0a0a39e3acaf4cebb4ff89c43e"
+commit = "748ceefb11472e78238279e614da6e4a912d3310"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Can a Manderville man patch a plugin before Dalamud is released to the public? Of course a Manderville man can! Am I a Manderville man? Unfortunately no, but I do have a Manderville Weapon, so... close enough.

- Fix a bug where unusable Main Commands were selectable on the Stream Deck.

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.9).

(Edit: Damn, submitted too late. I opened the PR before we released testing, but too late for it to be looked at/approved before the public beta was released. Oh well, guess having a Manderville Weapon isn't enough.)