### PR TITLE
XIVDeck 0.3.10

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "7cc1990cdf027bf7fa1e52ce57ba49b3bf915de6"
+commit = "3dbe4ec1a3df06badb98c151fbfa2771d5722768"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Who let Settingway access the codebase? I know the parties in... *that place*... are important, but really? Did you have to leave a mess for the rest of us to clean up?!

- Fix an incompatibility with 6.35's volume configuration settings.

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.10).