### PR TITLE
[Stable] UsedName 0.8.1.2

### DIFF
--- a/stable/UsedName/manifest.toml
+++ b/stable/UsedName/manifest.toml
@@ -1,11 +1,13 @@
 [plugin]
 repository = "https://github.com/LittleNightmare/UsedName.git"
-commit = "091de0a22b9366dd3b31f25df4d5ff97bf75d95c"
+commit = "0da101a68141f5021fb4a9d7296a3d7755c25875"
 owners = [
     "LittleNightmare"
 ]
 project_path = "UsedName"
 changelog = """
-- update social list
-- support api8
+- Use memory instead of network packages for updates
+- Add a tiny control window, use '/pname main' to open it
+- fix cannot load store names after change dalamud config folder
+- add option to change store path
 """


### PR DESCRIPTION
- Use memory instead of network packages for updates
- Add a tiny control window, use '/pname main' to open it
- fix cannot load store names after change dalamud config folder
- add option to change store path