### PR TITLE
FlyTextFilter 4.1.3.2

### DIFF
--- a/stable/FlyTextFilter/manifest.toml
+++ b/stable/FlyTextFilter/manifest.toml
@@ -1,8 +1,7 @@
 [plugin]
 repository = "https://github.com/Aireil/FlyTextFilter.git"
-commit = "f80a53fdbefe3abbe8fa45817212dac3fa560220"
+commit = "14d4651ecc1e5447da3c28ca3c4cd723b99ec1e8"
 owners = [
     "Aireil",
 ]
 project_path = "FlyTextFilter"
-changelog = "4.1.3.1:\n   - Add a setting to help find unknown types, this is disabled by default, please go in the misc tab for more info.\n4.1.3.0:\n   - Rename types to clearer names.\n- Add an help button for the type table."


### PR DESCRIPTION
- Update the "Help to find unknown types" feature, 4 types were found, 4 to go. Feel free to enable it in the Misc tab; thank you to everyone helping!
- Fix an issue where it would change scaling and positions even if they are not modified when disabling the plugin.
- Known issue: default scaling values are not correct, this is due to an issue in Dalamud since the 6.35 patch, it will fix itself once Dalamud gets fixed.