### PR TITLE
[Testing] Clarity In Chaos 1.2.0.0

### DIFF
--- a/testing/live/ClarityInChaos/manifest.toml
+++ b/testing/live/ClarityInChaos/manifest.toml
@@ -1,8 +1,19 @@
 [plugin]
 repository = "https://github.com/meoiswa/ClarityInChaos.git"
-commit = "d07432a098f805fe42ffcced45d0ad1299f6d7ad"
+commit = "b7ea862dbf6f4cac632e45b6c89b5f8cb42c9ad6"
 owners = [
     "meoiswa"
 ]
 project_path = "ClarityInChaos"
-changelog = "1.1.2.0 Improvements as suggested by The Team"
+changelog = """
+Version 1.2.0.0:
+ - UI Polish pass
+  - Active section's header now renders in green
+  - Current BattleEffects now render in varying colors
+ - No longer renders in-game Battle Effects settings unusable
+  - Changes to in-game Battle Effects settings apply to the active section
+  - Also applies to `/bfx` commands
+ - Saved In-Game Settings (previously known as Backup) is now a configurable section
+ - Restores Saved In-Game Settings when disabled or uninstalled
+ - Removed superfluous Debug option "Print to chat"
+"""


### PR DESCRIPTION
This PR delivers on the promised fix to the "issue" where the in-game battle effects settings menu was rendered un-usable while the plugin was Enabled.

- Introduced a new Section: Saved In-Game Settings. This was previously used as a Backup for restoring the user's settings when the plugin was removed. This now applies when the plugin's Master enable is disabled, too.
- Changing Battle Effect settings via the in-game menu, or the chat command (/bfx) now applies the change to the currently active section (Solo/Light Party/Full Party/Alliance/Saved In-Game Settings).
- General UI polish pass, removing the warning message and highlighting the active section.