### PR TITLE
Simple Tweaks 1.8.4.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "432cc37f662273d198ef9cc24fefa2b17a22a326"
+commit = "41ccb6943624f4e2408708a09995506c5ea22400"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***New Tweaks***
> **`Hide quality bar while crafting NO-HQ item.`** - Hides the quality bar in the Synthesis window while crafting an item that can not be HQ or Collectable.


***Tweak Changes***
> **`Expanded Currency Display`** - Added support for Collectibles

> **`Fade Unavailable Actions`**
> - Tweak now only applies to combat actions
> - Properly resets hotbar state on unload/disable

> **`Improved Duty Finder Settings`** - Fixed UI displaying on wrong monitor in specific circumstances. *(Aireil)*

> **`Set Option Command`**
> - Fixed issues when using gamepad mode
> - Re-added accidentally remove gamepad mode option
> - Added 'LimitMouseToGameWindow' and 'CharacterDisplayLimit'
> - Fixed 'DisplayNameSize' using incorrect values

> **`Simplified Equipment Job Display`** - Fixed tweak for Japanese clients.

