### PR TITLE
XIVDeck 0.3.11

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "3dbe4ec1a3df06badb98c151fbfa2771d5722768"
+commit = "bd76af4a47ca2f50666fcc0b0d43d810ef377cc3"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
I am pleased to announce that this release of XIVDeck is sponsored by Microsoft's Windows division. In accordance with our sponsor's wishes, we are releasing a minimally-tested version to the general public. Because, after all, the best QA is *everyone*.

- Do some work to make translations better and easier on me in the future.
- Completely redesign the "Getting Started" window to be more pleasant and friendly.
- Fix a small edge case issue with Penumbra IPC that may have not caused icons to load for some users.
- Break a bunch of translation strings. Sorry, translators!

Full release notes, **testing notes**, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.11).