### PR TITLE
[Testing] DaCoblyn 1.0.2.2

### DIFF
--- a/testing/live/DaCoblyn/manifest.toml
+++ b/testing/live/DaCoblyn/manifest.toml
@@ -1,13 +1,9 @@
 [plugin]
 repository = "https://github.com/thatismunn/xiv-coblyn.git"
-commit = "a1ef11f0309772e946c2b2d2afecba57c322c7c6"
+commit = "7bb62be013921fbad18d0908de56ff0eb9b25118"
 owners = [ "thatismunn" ]
 project_path = "Plugin/DaCoblyn"
 changelog = """
-Version 1.0.1.7:
-- Replace text command /tl to interactive window.
-- Fix switch language that can't be switching when source language is Automatic
-Version 1.0.2.1:
-- Fixing deprecated "Open window" method.
-- Fixing "Low confident" alert when the language is ignored in the configuration. thatismunn/xiv-coblyn#2
+Hotfix 1.0.2.2:
+- Add "force stop plugin" when the plugin not successfully connect to server.
 """


### PR DESCRIPTION
Hotfix 1.0.2.2:
- Add "force stop plugin" when the plugin not successfully connect to server.