### PR TITLE
VFXEditor v1.7.2.5

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "eb3ffd25f75a7c55daae87f5a286a664c6f5904f"
+commit = "e1bd6f459fbf58ec76111cc007e3eddc01c552e1"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Updated npc files
- Added `Edit > Clean up` in VFX window to remove unused nodes
- Added checks and warnings when opening a `.tmb` file containing a TMFC
- Added folders to VFX node library
- TMB entries now display their Id
- Fixed node order sometimes being incorrect when undoing a deletion
- When deleting a track/actor, the entries they contain are now properly removed from the file
- Added ability to add/delete more parts of SCD files
- Added SCD loop start/end convertor
- `LoopStart` and `LoopEnd` tags are now respected when importing an `.ogg` file
- Added option to simulate the game's LoopStart/End when previewing an audio file