### PR TITLE
[Testing] Hit it, Joe! (Formerly TF2-ish Critical Hits Plugin) 3.0.1.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "8b84b755d0eff8c4fb19a2f447cdbcadad5eb96a"
+commit = "8ffcf630e81f4747777fc915a0b644ed87d79d88"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """


### PR DESCRIPTION
- Fixed plugin littering the pluginConfig folder.
  - The plugin should automatically delete any old configurations with a timestamp from 5 or more days of age.
- Fixed config file being double the size it should've been.