### PR TITLE
[Testing] Hit it, Joe! (Formerly TF2-ish Critical Hits Plugin) 3.0.2.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -5,7 +5,7 @@ owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
 - Fixes issues with loading configurations.
-  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, not using the rescue command will keep your current configuration as-is, and I'm sorry for the inconvenience.
+  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, there's no need to use the rescue command, and I'm sorry for the inconvenience.
   
 (Special thanks to a cute friend for helping with debugging!)
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,10 +1,9 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "8ffcf630e81f4747777fc915a0b644ed87d79d88"
+commit = "718bdd132df4c0201e64c9ba16c9b7da6c5f9239"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-- Fixed plugin littering the pluginConfig folder.
-  - The plugin should automatically delete any old configurations with a timestamp from 5 or more days of age.
-- Fixed config file being double the size it should've been.
+- Fixes issues with loading configurations.
+  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, there's nothing to be done, and I'm sorry for the inconvenience.
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,11 +1,15 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "d313b13b4ab3cbad406f8b91a47db381db091315"
+commit = "42a553aafd7340cf30a7e9ad46adf0b125fd0fe4"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
 - Fixes issues with loading configurations.
-  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, there's no need to use the rescue command, and I'm sorry for the inconvenience.
-  
-(Special thanks to a cute friend for helping with debugging!)
+  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning.\
+    If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it.\
+    The chat will tell you if it went OK or not (it should!).\
+    If you already redid your configuration, there's no need to use the rescue command, and I'm sorry for the inconvenience.
+  - (Special thanks to a cute friend for helping with debugging!)
+- Tentative fix for the share/export option in the Critical Hits module.
+  - (Special thanks to Orichalcum for the report!)
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -6,4 +6,6 @@ project_path = "Tf2CriticalHitsPlugin"
 changelog = """
 - Fixes issues with loading configurations.
   - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, not using the rescue command will keep your current configuration as-is, and I'm sorry for the inconvenience.
+  
+(Special thanks for a cute friend for helping with debugging!)
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -7,5 +7,5 @@ changelog = """
 - Fixes issues with loading configurations.
   - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, not using the rescue command will keep your current configuration as-is, and I'm sorry for the inconvenience.
   
-(Special thanks for a cute friend for helping with debugging!)
+(Special thanks to a cute friend for helping with debugging!)
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "718bdd132df4c0201e64c9ba16c9b7da6c5f9239"
+commit = "d313b13b4ab3cbad406f8b91a47db381db091315"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -5,5 +5,5 @@ owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
 - Fixes issues with loading configurations.
-  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, there's nothing to be done, and I'm sorry for the inconvenience.
+  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, not using the rescue command will keep your current configuration as-is, and I'm sorry for the inconvenience.
 """


### PR DESCRIPTION
- Fixes issues with loading configurations.
  - If you were affected by this issue (in version 3.0.1.0), the in-game chat will show a warning. If you want to rescue your pre-3.0.1.0 configuration, just use the command \"/rescuemejoe\" to try to rescue it. The chat will tell you if it went OK or not (it should!). If you already redid your configuration, there's no need to use the rescue command, and I'm sorry for the inconvenience.
  - (Special thanks to a cute friend for helping with debugging!)
- Tentative fix for the share/export option in the Critical Hits module.
  - (Special thanks to Orichalcum for the report!)