### PR TITLE
[Testing] Bozja Buddy v0.2.0.0

### DIFF
--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "b1fda00e1b9442ae30d53212b37590060a1868fd"
+commit = "a21e7a2b588e78b1addb1e624814282c292c7ff8"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """

--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,12 +1,14 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "be0f0276a8ff77e8e4d4ed4ce3c5953fa65a4d25"
+commit = "b1fda00e1b9442ae30d53212b37590060a1868fd"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """
 - Added Alarm for Bozja content.
 - Added a general options bar, with a button to open Alarm window, and a button to shut the alarm up.
 - Fix a bug in Extra information tab where FATE-chain would not show up in FATE extra info.
+- Added config options to change audio path and volume.
+- Added a config window button to Alarm window.
 ---
 - Alarm overview: 
 + Time-based: alarms which trigger at a specific time. Can only be created in Alarm window.

--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "d870b5df286f1e8acfaee7c5916e68089b5d4f35"
+commit = "be0f0276a8ff77e8e4d4ed4ce3c5953fa65a4d25"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """

--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "916fb15cf015eaa8cd7f1cdd0c7eba1dc880536f"
+commit = "d870b5df286f1e8acfaee7c5916e68089b5d4f35"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """

--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -3,7 +3,8 @@ repository = "https://github.com/kaleidocli/BozjaBuddy.git"
 commit = "5001b2d0641eb0bb4e9a6b001744870c722a7c1b"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
-changelog = "- Added Alarm for Bozja content.
+changelog = """
+- Added Alarm for Bozja content.
 - Added a general options bar, with a button to open Alarm window, and a button to shut the alarm up.
 - Fix a bug in Extra information tab where FATE-chain would not show up in FATE extra info.
 ---
@@ -11,4 +12,4 @@ changelog = "- Added Alarm for Bozja content.
 + Time-based: alarms which trigger at a specific time. Can only be created in Alarm window.
 + Weather-based: alarms which trigger at a specific weather at a specific time (ONCE), or every time the weather occurs (REPEAT). Can be created in Alarm window, or clicking on Weather bar.
 + FATE-based: alarms which trigger every time a FATE occurs (CEs not yet supported). Can be created in Alarm window, or click on Alarm column in Fate/CE table.
-- Alarm can be turned off, edited, deleted, or recycled once expire."
+- Alarm can be turned off, edited, deleted, or recycled once expire."""

--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "5001b2d0641eb0bb4e9a6b001744870c722a7c1b"
+commit = "916fb15cf015eaa8cd7f1cdd0c7eba1dc880536f"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """

--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,6 +1,14 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "cff0e2ecbe4d5424f40ba9973db10441781ef2ba"
+commit = "5001b2d0641eb0bb4e9a6b001744870c722a7c1b"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
-changelog = "Update loadout to show guide for (likely new) users on how to load recommended loadouts."
+changelog = "- Added Alarm for Bozja content.
+- Added a general options bar, with a button to open Alarm window, and a button to shut the alarm up.
+- Fix a bug in Extra information tab where FATE-chain would not show up in FATE extra info.
+---
+- Alarm overview: 
++ Time-based: alarms which trigger at a specific time. Can only be created in Alarm window.
++ Weather-based: alarms which trigger at a specific weather at a specific time (ONCE), or every time the weather occurs (REPEAT). Can be created in Alarm window, or clicking on Weather bar.
++ FATE-based: alarms which trigger every time a FATE occurs (CEs not yet supported). Can be created in Alarm window, or click on Alarm column in Fate/CE table.
+- Alarm can be turned off, edited, deleted, or recycled once expire."


### PR DESCRIPTION
- Added Alarm for Bozja content.
- Added a general options bar, with a button to open Alarm window, and a button to shut the alarm up.
- Fix a bug in Extra information tab where FATE-chain would not show up in FATE extra info. ---
- Alarm overview: 
+ Time-based: alarms which trigger at a specific time. Can only be created in Alarm window.
+ Weather-based: alarms which trigger at a specific weather at a specific time (ONCE), or every time the weather occurs (REPEAT). Can be created in Alarm window, or clicking on Weather bar.
+ FATE-based: alarms which trigger every time a FATE occurs (CEs not yet supported). Can be created in Alarm window, or click on Alarm column in Fate/CE table.
- Alarm can be turned off, edited, deleted, or recycled once expire.