### PR TITLE
Eureka Linker 1.3.0.0

### DIFF
--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,14 +1,16 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "2309ff14d67e0b9741b7948eca44969e84aa6d06"
+commit = "6d955d84b82e65651eec263891220d3f6f881f56"
 owners = [
     "Infiziert90",
     "electr0sheep",
 ]
 project_path = "EurekaTrackerAutoPopper"
 changelog = """
+- Added Fairy Lifecycle, the plugin will now track if a fairy died that you have seen before (only works nearby)
+- Added Fairy Map Markers, this allows you place map markers on all known fairies (button in the fairy tab)
 - Added 'Time in Eureka' to the stats
-- Added localization (DE full, FR small parts, JA missing)
+- Added localization (DE and FR ... JP needs translater)
 - Fixed a bug that prevented stats from counting correctly in rare case
 - All fates coords are now perfectly centered (without randomize)
 - Added more chests to Hydatos, low level pyros and pagos

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "72c977ae6b64efb21a198838d07b32d6dae029ef"
+commit = "2309ff14d67e0b9741b7948eca44969e84aa6d06"
 owners = [
     "Infiziert90",
     "electr0sheep",
@@ -11,5 +11,5 @@ changelog = """
 - Added localization (DE full, FR small parts, JA missing)
 - Fixed a bug that prevented stats from counting correctly in rare case
 - All fates coords are now perfectly centered (without randomize)
-- Added more chests to low level pyros and pagos
+- Added more chests to Hydatos, low level pyros and pagos
 """

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "3704650dc5452996b225b2cabc0ab56eba2baea4"
+commit = "eba9b13e585e4164f5d52469bb79492ffb2fc210"
 owners = [
     "Infiziert90",
     "electr0sheep",

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,17 +1,13 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "1fb2f9c8bc45aedbd5a487c8328f0fb711692f14"
+commit = "2731bc4df9bdd688da6e60cecfbd62a7f9327166"
 owners = [
     "Infiziert90",
     "electr0sheep",
 ]
 project_path = "EurekaTrackerAutoPopper"
 changelog = """
-- Added stats tab
-- Added 2 new commands / buttons
-  > Adds/Removes coffer marker to all known coffer locations on the current map
-- More Pyros and Pagos locations
-
-There is the possibility that the plugin will inform you about a new chest location,
-feel free to post the message you get into the plugin-forum linked in the About Tab
+- Added time to stats
+- Added localization (wip)
+- Fixed bug preventing stats counting in rare case
 """

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "eba9b13e585e4164f5d52469bb79492ffb2fc210"
+commit = "16648136f93bf05cdf49ec2d331e0358f4154e88"
 owners = [
     "Infiziert90",
     "electr0sheep",

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "2731bc4df9bdd688da6e60cecfbd62a7f9327166"
+commit = "51ae2e23bf9032adae3f8183e5bae9971f579b54"
 owners = [
     "Infiziert90",
     "electr0sheep",

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,14 +1,15 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "18066ce80ae5275fbde0542708b51e610b043cc0"
+commit = "72c977ae6b64efb21a198838d07b32d6dae029ef"
 owners = [
     "Infiziert90",
     "electr0sheep",
 ]
 project_path = "EurekaTrackerAutoPopper"
 changelog = """
-- Added time to stats
-- Added localization (wip)
-- Fixed bug preventing stats counting in rare case
-- All fates coords should now be centered (without randomize)
+- Added 'Time in Eureka' to the stats
+- Added localization (DE full, FR small parts, JA missing)
+- Fixed a bug that prevented stats from counting correctly in rare case
+- All fates coords are now perfectly centered (without randomize)
+- Added more chests to low level pyros and pagos
 """

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,17 +1,25 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "6d955d84b82e65651eec263891220d3f6f881f56"
+commit = "3704650dc5452996b225b2cabc0ab56eba2baea4"
 owners = [
     "Infiziert90",
     "electr0sheep",
 ]
 project_path = "EurekaTrackerAutoPopper"
 changelog = """
-- Added Fairy Lifecycle, the plugin will now track if a fairy died that you have seen before (only works nearby)
+[New]
+- Added Fairy Lifecycle, the plugin will now track if a fairy died (only works nearby)
 - Added Fairy Map Markers, this allows you place map markers on all known fairies (button in the fairy tab)
 - Added 'Time in Eureka' to the stats
 - Added localization (DE and FR ... JP needs translater)
-- Fixed a bug that prevented stats from counting correctly in rare case
-- All fates coords are now perfectly centered (without randomize)
 - Added more chests to Hydatos, low level pyros and pagos
+
+[Changes]
+- All fates coords are now perfectly centered (without randomize)
+- Main Window can now be collapsed
+- Limit on the chat message format increased from 30 to 64
+
+[Bug Fixes]
+- Fixed a bug that prevented stats from counting correctly in rare case
+- The dot will now stay inside the game window
 """

--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "51ae2e23bf9032adae3f8183e5bae9971f579b54"
+commit = "18066ce80ae5275fbde0542708b51e610b043cc0"
 owners = [
     "Infiziert90",
     "electr0sheep",
@@ -10,4 +10,5 @@ changelog = """
 - Added time to stats
 - Added localization (wip)
 - Fixed bug preventing stats counting in rare case
+- All fates coords should now be centered (without randomize)
 """


### PR DESCRIPTION
Most of the changes are localization json or related to it

[New]
- Added Fairy Lifecycle, the plugin will now track if a fairy died (only works nearby)
- Added Fairy Map Markers, this allows you place map markers on all known fairies (button in the fairy tab)
- Added 'Time in Eureka' to the stats
- Added localization (DE and FR ... JP needs translater)
- Added more chests to Hydatos, low level pyros and pagos

[Changes]
- All fates coords are now perfectly centered (without randomize)
- Main Window can now be collapsed
- Limit on the chat message format increased from 30 to 64

[Bug Fixes]
- Fixed a bug that prevented stats from counting correctly in rare case
- The dot will now stay inside the game window