### PR TITLE
Update PositionalGuide (stable)

### DIFF
--- a/stable/PositionalGuide/manifest.toml
+++ b/stable/PositionalGuide/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/PrincessRTFM/PositionalAssistant.git"
 owners = [ "PrincessRTFM",]
 project_path = ""
-commit = "b51b7a2db9523396699eb2995271d23ca7389771"
-changelog = "Implemented partial tether lines and target rings"
+commit = "01611586aceb345a2d81c38fd366c5a8720df99e"
+changelog = "In certain circumstances, based on the user's configuration, the target circle feature could previously attempt to read an index beyond that bounds of an array, causing per-frame errors and breaking the feature. The bug in question has been found and fixed."


### PR DESCRIPTION
In certain circumstances, based on the user's configuration, the target circle feature could previously attempt to read an index beyond that bounds of an array, causing per-frame errors and breaking the feature. The bug in question has been found and fixed.