### PR TITLE
[Testing] Hit it, Joe! (Formerly TF2-ish Critical Hits Plugin) 3.2.0.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,14 +1,12 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "d7f5c32f922cb1e356e5c5e5e32124050303f1c5"
+commit = "87ae21c7b6c63039c2149af453e5b9363b9d43a0"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-After update 3.0.0.0, we received a whispering at dawn from Eos and Selene, complaining that crediting the Scholar for their healing is unjust.
+Now, it's possible to have multiple Jams to play for the same countdown.
+- For this, any Jams other than the first must be configured to play at a specific mark.
+- Only the first Jam's cancel sound will play if the countdown is cancelled.
 
-We embraced these complaints and, after discussion with the fey union, decided on adding two more configuration submodules: \"Critical Healing from your own fairy\" (Scholar only) and \"Critical Healing from other players' fairies\". One of them gauged the implementation and gave it their official blessing.
-
-We thank both fairies for illuminating us on this matter.
-
-Also, this version was validated on 6.38 and contains fixes for the territory options not persisting.
+Thanks to GokaiSanyu for the feedback!
 """


### PR DESCRIPTION
Now, it's possible to have multiple Jams to play for the same countdown.
- For this, any Jams other than the first must be configured to play at a specific mark.
- Only the first Jam's cancel sound will play if the countdown is cancelled.

Thanks to GokaiSanyu for the feedback!