### PR TITLE
Hit it, Joe! (Formerly TF2-ish Critical Hits Plugin) 3.1.0.0

### DIFF
--- a/stable/Tf2CriticalHitsPlugin/manifest.toml
+++ b/stable/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,17 +1,11 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "860305a9720aeffe340c3812ae8a8db6ece1e86c"
+commit = "d7f5c32f922cb1e356e5c5e5e32124050303f1c5"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-New name: *Hit it, Joe!*
-- Since the plugin hit version 3, keeping the name Valve-related would cause crashes.
-
-[Countdown Jams]
-- New module.
-- Set sounds to be played when a countdown starts.
-
-[TF2-ish Critical Hits]
-- New algorithm to differentiate your heals from other players'. (Thanks, Aireil!)
-  - Also considers heals from your fairy as yours.
+After update 3.0.0.0, we received a whispering at dawn from Eos and Selene, complaining that crediting the Scholar for their healing is unjust.
+We embraced these complaints and, after discussion with the fey union, decided on adding two more configuration submodules: \"Critical Healing from your own fairy\" (Scholar only) and \"Critical Healing from other players' fairies\". One of them gauged the implementation and gave it their official blessing.
+We thank both fairies for illuminating us on this matter.
+Also, this version was validated on 6.38 and contains fixes for the territory options not persisting.
 """


### PR DESCRIPTION
After update 3.0.0.0, we received a whispering at dawn from Eos and Selene, complaining that crediting the Scholar for their healing is unjust.

We embraced these complaints and, after discussion with the fey union, decided on adding two more configuration submodules: "Critical Healing from your own fairy" (Scholar only) and "Critical Healing from other players' fairies". One of them gauged the implementation and gave it their official blessing.

We thank both fairies for illuminating us on this matter.

(This is the same hash as testing 3.1.0.0, aka #1596 — I'll keep 3.2.0.0 on testing for a few more days.)