### PR TITLE
Update Wotsit to 1.0.3.0

### DIFF
--- a/stable/Dalamud.FindAnything/manifest.toml
+++ b/stable/Dalamud.FindAnything/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/goaaats/Dalamud.FindAnything.git"
-commit = "e4c80f660b635fe1657be0f438f8fe6ca3af4d33"
+commit = "78d26585f78ef3bcb9a20fe8b47afe64938a0ec4"
 owners = [
     "goaaats",
 ]


### PR DESCRIPTION
* When searching in Japanese, all kana are now normalized. This means that whatever you use to search, be it hiragana or katakana, you will now get results for both.
* Selected search history entries will now be moved to the top of the history list.
* Fixes an issue wherein, under certain conditions, search history entries may have been lost.
* Fixes an issue wherein, under certain conditions, search history entries may have been duplicated incorrectly.
* Fixes an issue wherein, under certain conditions, the wiki mode shortcut may not have functioned correctly.
* Fixes an issue wherein search terms with leading or trailing spaces would cause the result picker to be unresponsive.
* Fixes an issue wherein the "Quick Select" key chosen in the settings would not apply correctly.

All of this was graciously contributed by @nebel. Thanks a bunch!