### PR TITLE
Update Doorbell - Add Silence

### DIFF
--- a/stable/Doorbell/manifest.toml
+++ b/stable/Doorbell/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/SoyaX/Doorbell.git"
-commit = "dd160b8ba772b9b8b96c67ff68f5395b9d0c2fe"
+commit = "3669f50a8f7967e8ea3c25e65c32e4cc317ef052"
 owners = [
     "SoyaX"
 ]


### PR DESCRIPTION
- Adds commands to temporarily disable doorbell alerts.
```
/doorbell silence       - Disable alerts until leaving a house.
/doorbell silence <min> - Disable alerts for a specified number of minutes.
```
