### PR TITLE
VFXEditor v1.7.4.0

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "5e2893291f37f082ae42b4373065f72a1bc8bbe9"
+commit = "70112a60cc35aefd8048d515bc6638bba2435aaa"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Refactoring
- Added ULD editor
- Fixed a bug with certain VFX nodes not being properly saved to the Node Library
- Fixed a bug with the SCD/EID windows when opening old workspaces
- Added options to set the window color of each editor independently (found in `File > Settings`)