### PR TITLE
DeepDungeonDex 2.5.4

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "5d5230c03ae4474c9e5afaad74604e10ba493435"
-changelog = "### 2.5.3 (2023-03-25)\n\n\n### Bug Fixes\n\n* fix drawing of floor data which broke after EO addition (87d5c88)"
-version = "2.5.3"
+commit = "7388338a1ae8c194fc1713d9343600c6af108b12"
+changelog = "### 2.5.4 (2023-04-14)\n\n\n### Bug Fixes\n\n* crashing due to corrupt plugin directory (b198cbc)"
+version = "2.5.4"


### PR DESCRIPTION
### 2.5.4 (2023-04-14)


### Bug Fixes

* crashing due to corrupt plugin directory (b198cbc)