### PR TITLE
[Testing] XIVDeck 0.3.12

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "748ceefb11472e78238279e614da6e4a912d3310"
+commit = "d4a8470c9f23d5f5f50975ddf3a12f6bba8cd5c4"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
A long time ago, I decided to start what I thought was a simple project to learn both C# and how to mod games. This project was called XIVDeck. As a result of my inexperience writing code, I made a few very fatal decisions, such as putting a web server in the game to provide an API. These decisions haunt me to this very day.

- Switch the default web server back to EmbedIO.
- Force all API communication to happen over IPv4 to get around [a frustrating bug](https://github.com/unosquare/embedio/issues/576).
- Hopefully fix some macOS and Linux compatibility issues.
    - NOTE: macOS users will now be able to install the Stream Deck plugin, but it likely *will not work* at this time. I am not offering support for macOS or Linux users yet.
- Some other internal nonsense.

If XIVDeck doesn't work for you after this release for some reason, please check the [release page](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.12) for troubleshooting steps and ping me in the [XIVDeck thread](https://discord.com/channels/581875019861328007/1019648519226806323).

Full release notes, ***testing notes***, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.12).