### PR TITLE
Eureka helper 1.4.0.0

### DIFF
--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "65ba0990f88fe8484e300475398e60b0ffeee279"
+commit = "b114551144f6dac40ae07f13751ab3df6ba8c30a"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
 changelog = """

--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "c8ccde20fc2b499291187fdaa0ae5ac535354ee0"
+commit = "727c222160d9e09eadd79194b275e710ecd9c96d"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
 changelog = """

--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,11 +1,14 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "ec3f2d6202f39760cdbef9b6735b56d8ea1916ec"
+commit = "65ba0990f88fe8484e300475398e60b0ffeee279"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
 changelog = """
-Tracker Changes
-- Allow "Respawn In" column to be sortable
+Relic Helper - NEW
+- Add new window to show all available Eureka relics
+- Display number of items needed to complete the relic stage
+- Display number of items you currently have
+- Linkable item to "try on"
 
 Elemental Manager
 - Add crowdsourced known positions to plugin

--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "b114551144f6dac40ae07f13751ab3df6ba8c30a"
+commit = "c8ccde20fc2b499291187fdaa0ae5ac535354ee0"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
 changelog = """


### PR DESCRIPTION
Relic Helper - NEW
- Add new window to show all available Eureka relics
- Display number of items needed to complete the relic stage
- Display number of items you currently have
- Linkable item to "try on"

Elemental Manager
- Add crowdsourced known positions to plugin

Opt-in and assist to crowdsource all the Elemental positions
Post new positions on GitHub pinned issue or through Discord DM