### PR TITLE
[Testing] CrossUp v0.4.2.0

### DIFF
--- a/testing/live/CrossUp/manifest.toml
+++ b/testing/live/CrossUp/manifest.toml
@@ -1,7 +1,14 @@
 [plugin]
 repository = "https://github.com/ItsBexy/CrossUp.git"
-commit = "3c60a6401b4e95be43944b35986a25a30968b57b"
+commit = "7ab44cba7818855c892086babf3a388731e0da4b"
 owners = [
     "ItsBexy",
 ]
-changelog = "Updated for Patch 6.35. Fixed an issue wherein the incorrect grid layout would sometimes be applied to standard hotbars."
+changelog = """
+- NOTICE: This update to CrossUp brings a number of changes to how the plugin's configurations are saved. The plugin will do its best to port over your prior configs, but you might notice that some have been reset.
+- The plugin can now save separate configurations for each HUD Layout slot. You can activate this feature in the "HUD Options" tab.
+- A new "Frame" style option has been added for the XHB selection backdrop. This is available within the "Look & Feel > Colors" tab.
+- The interface for Left/Right bar separation has been revised. While this feature is active, the Cross Hotbar's horizontal position will be locked to a point of your choice. This should resolve a bug that caused the bar to jump around unexpectedly with HUD changes.
+- When opening the main menu, the EXHB will now properly hide itself alongside the XHB.
+- You can now set a negative value for bar separation. The minimum value is now -142, which will place the Left/Right bars directly on top of each other.
+"""


### PR DESCRIPTION
Major feature updates and bugfixes.

Changelog:
- NOTICE: This update to CrossUp brings a number of changes to how the plugin's configurations are saved. The plugin will do its best to port over your prior configs, but you might notice that some have been reset.
- The plugin can now save separate configurations for each HUD Layout slot. You can activate this feature in the "HUD Options" tab.
- A new "Frame" style option has been added for the XHB selection backdrop. This is available within the "Look & Feel > Colors" tab.
- The interface for Left/Right bar separation has been revised. While this feature is active, the Cross Hotbar's horizontal position will be locked to a point of your choice. This should resolve a bug that caused the bar to jump around unexpectedly with HUD changes.
- When opening the main menu, the EXHB will now properly hide itself alongside the XHB.
- You can now set a negative value for bar separation. The minimum value is now -142, which will place the Left/Right bars directly on top of each other.