### PR TITLE
Team Fortress Fantasy 1.1.1.0

### DIFF
--- a/stable/Tf2Hud/manifest.toml
+++ b/stable/Tf2Hud/manifest.toml
@@ -1,10 +1,14 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-hud-plugin.git"
-commit = "14924e2c0afd44da78e9c5bcfb228b53b2340118"
+commit = "2c7df503c289c54176eecc0a2dc6d7d62783a8a3"
 owners = ["Berna-L"]
 project_path = "Tf2Hud"
 changelog = """
-**Why are you teleporting away from me, my friend? You are _dead_ to me.**
-- Now, one of the voice lines (whose section starts with an L) will only play if you are inside a duty. \
-This prevents it from being played if you are in a party and everyone else teleports away. (Thanks HuiEtyud for the report!)
+[Win Panel]
+- Added option to have the Win Panel save the score per duty.
+  - This is the default behavior for new installations.
+  - Current users will be told about this through chat when updating the plugin.
+- Added window (accessible in the Win Panel configuration) to check the saved scores per duty.
+  - This window also has an option to copy the values as CSV to the clipboard and delete individual scores.
+- Fixed the MVP list closing when pressing ESC.
 """


### PR DESCRIPTION
[Win Panel]
- Added option to have the Win Panel save the score per duty.
  - This is the default behavior for new installations.
  - Current users will be told about this through chat when updating the plugin.
- Added window (accessible in the Win Panel configuration) to check the saved scores per duty.
  - This window also has an option to copy the values as CSV to the clipboard and delete individual scores.
- Fixed the MVP list closing when pressing ESC.