### PR TITLE
Update to 1.3.0.0

### DIFF
--- a/testing/live/ClarityInChaos/manifest.toml
+++ b/testing/live/ClarityInChaos/manifest.toml
@@ -1,22 +1,16 @@
 [plugin]
 repository = "https://github.com/meoiswa/ClarityInChaos.git"
-commit = "35fdfcc7b5a876888f169de3cdd7dac459697806"
+commit = "dc73c07d25fe13d80d99f15be5700a82401fb4a9"
 owners = [
     "meoiswa"
 ]
 project_path = "ClarityInChaos"
 changelog = """
-Version 1.2.0.0:
- - UI Polish pass
-  - Active section's header now renders in green
-  - Current BattleEffects now render in varying colors
- - No longer renders in-game Battle Effects settings unusable
-  - Changes to in-game Battle Effects settings apply to the active section
-  - Also applies to `/bfx` commands
- - Saved In-Game Settings (previously known as Backup) is now a configurable section
- - Restores Saved In-Game Settings when disabled or uninstalled
- - Removed superfluous Debug option "Print to chat"
-
-Version 1.2.0.1:
- - Fixed: Applicable section gets overwritten with In-Game Settings on startup
+Version 1.3.0.0:
+ - Renamed "Alliance" to "Alliance Raids"
+ - "Only In Duty" options for Group Sizes.
+  - When enabled, the next smaller group is used when outside of duties.
+  - If no groups are eligible, "Saved In-Game Settings" are used.
+  - Alliance Raids are always "Only In Duty" (Detection logic relies on this)
+ - ⚠️ Major refactor of Configuration, may break existing configurations. If experiencing issues, try "Reset plugin configuration and reload" from the Plugin Installer.
 """


### PR DESCRIPTION
Version 1.3.0.0:
 - Renamed "Alliance" to "Alliance Raids"
 - "Only In Duty" options for Group Sizes.
  - When enabled, the next smaller group is used when outside of duties.
  - If no groups are eligible, "Saved In-Game Settings" are used.
  - Alliance Raids are always "Only In Duty" (Detection logic relies on this)
 - ⚠️ Major refactor of Configuration, may break existing configurations. If experiencing issues, try "Reset plugin configuration and reload" from the 

![image](https://user-images.githubusercontent.com/1486542/234841261-7f951d8f-580e-4661-8675-a3f6653bc8bf.png)
