### PR TITLE
Create PAC-Nag

### DIFF
--- a/.github/workflows/PAC-Nag
+++ b/.github/workflows/PAC-Nag
@@ -1,5 +1,10 @@
-name: Run the code
-on: workflow_dispatch
+name: PAC periodic notification
+
+on: 
+  workflow_dispatch
+  schedule:
+    - cron:  '0 19 * * *'
+
 jobs:
   runjob:
     runs-on: ubuntu-latest
@@ -8,4 +13,4 @@ jobs:
       - uses: reiichi001/PAC-Nag@9d2c2133b22eada3d8012050a2de58806afe3f0a
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          discord_webhook: ${{secrets.DISCORD_WEBHOOK}}
+          discord_webhook: ${{secrets.PAC_DISCORD_WEBHOOK}}

--- a/.github/workflows/PAC-Nag
+++ b/.github/workflows/PAC-Nag
@@ -1,0 +1,11 @@
+name: Run the code
+on: workflow_dispatch
+jobs:
+  runjob:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: reiichi001/PAC-Nag@9d2c2133b22eada3d8012050a2de58806afe3f0a
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          discord_webhook: ${{secrets.DISCORD_WEBHOOK}}


### PR DESCRIPTION
Initial commit of PAC-Nag, a very basic github action that will generate a post to nag the Plugin Review/Approval Committee.

Stealing secrets Goat references elsewhere, but we should make a new webhook URL for the relevant channels].  Once this looks good, we can also transition it to run on a schedule.