### PR TITLE
[Testing] RPBlurb v1.0.0.3 - Alt support

### DIFF
--- a/testing/live/RPBlurb/manifest.toml
+++ b/testing/live/RPBlurb/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/meoiswa/RPBlurb.git"
-commit = "e14c279d4b35c82d90770ff9f6463c4ef4b25083"
+commit = "7ace2b558389f207a282406e498c98246790bf9d"
 owners = [
     "meoiswa"
 ]
@@ -18,4 +18,8 @@ Version 1.0.0.1:
 
 Version 1.0.0.2:
  - Bugfix: ImGui text centering on other plugin windows under other specific scenarios. (For real this time)
+
+Version 1.0.0.3:
+ - Bugfix: Plugin breaks when switching to an alt. Altholics rejoice!
+ - Improvement: Descriptions can now be twice as long (512 characters).
 """


### PR DESCRIPTION
Version 1.0.0.3:
 - Bugfix: Plugin breaks when switching to an alt. Altholics rejoice!
 - Improvement: Descriptions can now be twice as long (512 characters).