### PR TITLE
VFXEditor v1.7.4.7

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "5d5fbee279a15379c47d1cc856fa16637cfbfd82"
+commit = "0b5c30c3c066ac8a207fdd1ade7fb3a3b57debb6"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Add TMFC parsing
- Fix some PAP parsing issues with modded files (still looking into modded SCD files)
   - Note: in most cases this doesn't actually impact the functionality of VFXEditor and the files can be used safely. It just results from other modding tools not padding data in quite the same way that SE does