### PR TITLE
[Testing] A Realm Recorded v0.6.0.0

### DIFF
--- a/testing/live/ARealmRecorded/manifest.toml
+++ b/testing/live/ARealmRecorded/manifest.toml
@@ -1,6 +1,16 @@
 [plugin]
 repository = "https://github.com/UnknownX7/ARealmRecorded.git"
-commit = "209ff73a2cbb7222c6834271c0a467cd42d3e9d4"
+commit = "67bcabe81f4dabbc5e0d66fde32fd24e4aa968af"
 owners = [ "UnknownX7" ]
 changelog = '''
-'''
+- Added support for duties that contain datamining protected assets (By @Loskh)
+- Added a current pull time slider (By @Drahsid)
+- Added a sortable table to display the list of replays (By @Lollyde)
+- Added a setting to hide your own name while in a replay (By @Gamous)
+- Added options for changing how many replays will be kept automatically
+- Added archiving, this will place outdated replays from the main replay folder into a zip file to reduce menu load times and conserve disk space
+- Added informational tooltips to the replay list
+- Changed replays to be moved to the deleted folder instead once the max number of autorenamed replays is reached
+- Changed the final speed preset to be adjustable
+- Changed the UI (and unstuck button) to appear if the replay gets stuck while loading
+- Fixed an issue with copying replays to slots'''


### PR DESCRIPTION
- Added support for duties that contain datamining protected assets (By @Loskh)
- Added a current pull time slider (By @Drahsid)
- Added a sortable table to display the list of replays (By @Lollyde)
- Added a setting to hide your own name while in a replay (By @Gamous)
- Added options for changing how many replays will be kept automatically
- Added archiving, this will place outdated replays from the main replay folder into a zip file to reduce menu load times and conserve disk space
- Added informational tooltips to the replay list
- Changed replays to be moved to the deleted folder instead once the max number of autorenamed replays is reached
- Changed the final speed preset to be adjustable
- Changed the UI (and unstuck button) to appear if the replay gets stuck while loading
- Fixed an issue with copying replays to slots