### PR TITLE
EurekaHelper 1.4.3.1

### DIFF
--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,17 +1,14 @@
 [plugin]
 repository = "https://github.com/snooooowy/EurekaHelper.git"
-commit = "ed9547dd42479ed0d9974135131c9fa1c7e6afcb"
+commit = "08a5ce2968756707e28cbcf20ab12f5e48482c4a"
 owners = ["snooooowy"]
 project_path = "EurekaHelper"
 changelog = """
-Tracker
-- Added an option to auto pop NM if the cooldown is less than 5 minutes
+Relic Helper
+- Now allows you to mark relic as complete
 
 Elemental Manager
 - Add crowdsourced known positions to plugin
-
-Misc
-- Added new dropdown option to Payload Options (thanks KangasZ)
 
 Opt-in and assist to crowdsource all the Elemental positions
 Post new positions on GitHub pinned issue or through Discord DM


### PR DESCRIPTION
Relic Helper
- Now allows you to mark relic as complete

Elemental Manager
- Add crowdsourced known positions to plugin

Opt-in and assist to crowdsource all the Elemental positions
Post new positions on GitHub pinned issue or through Discord DM