### PR TITLE
Resizable HUD 1.1.7

### DIFF
--- a/stable/ResizableHUD/manifest.toml
+++ b/stable/ResizableHUD/manifest.toml
@@ -1,10 +1,14 @@
 [plugin]
 repository = "https://github.com/Drahsid/ResizableHUD.git"
-commit = "db220cc1dba1e4b8356b9d2b7f793377abbe14f1"
+commit = "33329c857313d9209e66722f2847f58835ee026f"
 owners = ["Drahsid"]
 project_path = ""
-changelog = """1.5.0
+changelog = """1.1.5
 - Bumped version numver
-1.6.0
+1.1.6
 - Added opacity option
+1.1.7
+- Fix scaling being disabled by default on new entries (should have been opacity)
+- Added option to update values to on screen values
+- Fixed version numbers in changelog
 """


### PR DESCRIPTION
Just some bugfixes and an addition: fixed scaling being disabled by default on new entries, added option to update values to on screen values, fixed bug where the attachment text box wouldn't show the attachment after rebooting, fixed version numbers in changelog (oops)