### PR TITLE
DiscordBridge 14.2.1

### DIFF
--- a/stable/Dalamud.DiscordBridge/manifest.toml
+++ b/stable/Dalamud.DiscordBridge/manifest.toml
@@ -1,22 +1,13 @@
 [plugin]
 repository = "https://github.com/reiichi001/Dalamud.DiscordBridge.git"
-commit = "69f6eb236e88c27e675c784ef25096d1cf4b178e"
+commit = "80929aa4804a2b74d0f93fb50561d95e56835bab"
 owners = [
     "reiichi001",
 	"goaaats",
 ]
 project_path = "Dalamud.DiscordBridge"
 changelog = """
-New Changes:
-- Set fallback sendername value if there is none. This will be `FFXIV Bridge Worker <your character name>`
-
-Last Changes:
-- Fixed duplicate chat issue.
-- Added a classic embed fallback feature in case webhooks fail.
-- Fixes for NET7 / API 8
-- Updated library dependencies and switched to NetStone as submodule.
-- Switched to using full-width ＠ because Discord started enforcing username requirements on webhooks and @ isn't allowed there.
-
-
-**If your bot stopped working in September 2022, please enable Message Intents. See the setup guide for updated steps.**
+Adds the following new commands:
+- `xl!toggleembed` - Switches between Webhooks and classical Embeds
+- `xl!togglesender` - Toggles whether or not to include the sender name in the message content
 """


### PR DESCRIPTION
Adds the following new commands:
- `xl!toggleembed` - Switches between Webhooks and classical Embeds
- `xl!togglesender` - Toggles whether or not to include the sender name in the message content

Also removes WS4Net to use the default websockets provider again. Maybe this will fix recent wine issues.