### PR TITLE
[Testing] Bozja Buddy 0.3.1.0

### DIFF
--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,15 +1,15 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "3daf957f0fbaaa3ad10ccf33be239d32e3e21aac"
+commit = "0f26d49d06d85da63d8d43b0e68f913118e75b65"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """
-Bozja Buddy 0.3.0.3
+Bozja Buddy 0.3.1.0
 
-- Added option for Fate/CE alarms to be set to all FATEs, all CEs, all FATE/CEs, and can be filtered by zone (e.g. Zadnor zone 3). These options exclude CLL, Dalriada, Delubrum Reginae Normal & Savage.
-
-- Fixed a bug in Custom loadout tab where the whole tab would be unavailable upon using any Custom loadout Filter related features.
-- Fixed a bug in Custom loadout tab where disabling rec. loadouts would also hide user's loadouts.
-- Fixed a bug (hopefully) in Custom loadout tab where the Import from Clipboard button would not work properly. 
-- Fixed a bug where Fate/CEs would be assigned incorrect Area.
+- Search all box: Search everything related to Bozja without having to navigate through the tabs.
+- Added Search all box to top section of main window.
+- Added an overlay paired with the in-game window Resistance&Rank. This overlay contains a search all box, and a shortcut button to open main window.
+- Added a config option in Config > General, which toggles the abovementioned overlay.
+- Hovering tooltip for clickable links now displays quick info about the link.
+- RMB on a link for Action now also provides an option to look up marketboard price based on its fragment.
 """


### PR DESCRIPTION
Bozja Buddy 0.3.1.0

- Search all box: Search everything related to Bozja without having to navigate through the tabs.
- Added Search all box to top section of main window.
- Added an overlay paired with the in-game window "Resistance&Rank". This overlay contains a search all box, and a shortcut button to open main window.
- Added a config option in Config > General, which toggles the abovementioned overlay.
- Hovering tooltip for clickable links now displays quick info about the link.
- RMB on a link for Action now also provides an option to look up marketboard price based on its fragment.