### PR TITLE
Allagan Tools v1.5.0.1

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,19 +1,24 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "3dfd116989bfb070ef993a6b1c842fb70021f17b"
+commit = "0d9e53838749943e6732c301687658108091655a"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.4.1.4"
+version = "1.5.0.1"
 changelog = """\
-Retainer Venture Column/Filter
-Real Money Shop Column/Filter
-Added a window for viewing ventures + window for individual ventures
-Added a new search operator, having a single ! will show all items that are not empty
-Gil is now right aligned for easier reading
-Added more mob spawn data(thanks users for contributing)
-Fixed a copy json to clipboard crash for craft lists
-Added a Item ID column
-Added a Source World column
+**House Storage has arrived**
+So this took a while but it has finally come to fruition. A few things to note:
+
+- To have a house register with the plugin you must first enter it, have permission and then open the 'Indoor Furnishings' menu. This will allow for the plugin to see you own the house and add it to your 'Characters' list.
+- Once the house is registered due to the way the inventory data of each section is provided, you must enter each section to have it be parsed by the plugin. For Indoor and Outdoor Furnishings you must enter the storeroom tab before that data is collected.
+- For Interior Fixtures open the relevant section in the housing menu.
+- There's a lot of moving parts so if you run into issues, bugs or crashes hit up the #plugin-help-forum on discord.
+- I'll be working on making the 'Is Housing Item' filter a bit more reliable as this might be more important now.
+
+Other Fixes:
+Fix to workshop items not having the full set of materials in craft lists
+Stopped the FC name from being wiped out
+Added has been gathered column and filter
+New /moreinfo or /itemwindow command added that will accept either an item's name or ID and show the more item information window
 """


### PR DESCRIPTION
**House Storage has arrived**
So this took a while but it has finally come to fruition. A few things to note:

- To have a house register with the plugin you must first enter it, have permission and then open the 'Indoor Furnishings' menu. This will allow for the plugin to see you own the house and add it to your 'Characters' list.
- Once the house is registered due to the way the inventory data of each section is provided, you must enter each section to have it be parsed by the plugin. For Indoor and Outdoor Furnishings you must enter the storeroom tab before that data is collected.
- For Interior Fixtures open the relevant section in the housing menu.
- There's a lot of moving parts so if you run into issues, bugs or crashes hit up the #plugin-help-forum on discord.
- I'll be working on making the 'Is Housing Item' filter a bit more reliable as this might be more important now.

**Other Fixes:**
Fix to workshop items not having the full set of materials in craft lists 
Stopped the FC name from being wiped out
Added has been gathered column and filter
New /moreinfo or /itemwindow command added that will accept either an item's name or ID and show the more item information window