### PR TITLE
DailyDuty v4.0.1.3

### DIFF
--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "d839758a70184e6606ef850afee2a924d315b48c"
+commit = "b636cbfe2d98d6a3bd0b5dfc2f4dcc53389b1586"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
`Grand Company (Squadron)` - Fix resetting mission status on weekly reset

Updated translations. Everything should be fully translated now.

DailyDuty and my other plugins are no longer in active development.
I am taking an extended break from FFXIV and Plugin Development.

All my plugins were designed from the ground up for this eventuality, and thus should not break with game updates.