### PR TITLE
[Testing] Bozja Buddy 0.3.2.1

### DIFF
--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,15 +1,18 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "0f26d49d06d85da63d8d43b0e68f913118e75b65"
+commit = "8c74560729ea4bc3537d3ad0f9e56f095b614ccd"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """
-Bozja Buddy 0.3.1.0
+Bozja Buddy 0.3.2.1
+- Added Character Stats window:
++ Character stats (require character to at least be in Bozja/Zadnor/Delubrum content once)
++ User's Lost find Cache, with alert for actions that are running low.
+- Added configs for the abovementioned alert.
+- Added a button in upper top General bar to open the Character Stats window.
+- Added a number next to Lost action links, showing the amount of Lost action in player's possession.
 
-- Search all box: Search everything related to Bozja without having to navigate through the tabs.
-- Added Search all box to top section of main window.
-- Added an overlay paired with the in-game window Resistance&Rank. This overlay contains a search all box, and a shortcut button to open main window.
-- Added a config option in Config > General, which toggles the abovementioned overlay.
-- Hovering tooltip for clickable links now displays quick info about the link.
-- RMB on a link for Action now also provides an option to look up marketboard price based on its fragment.
+- Revision of many tooltip texts.
+- Fix an issue where the game will crash under the following condition: Open Config > UI Assist > [A] and let the drop down open for 30s or more.
+- Fix an issue where the button in Active Loadout bar in main window would not sync with the one on top of in-game Lost Find Cache window.
 """


### PR DESCRIPTION
Bozja Buddy 0.3.2.1
- Added Character Stats window:
+ Character stats (require character to at least be in Bozja/Zadnor/Delubrum content once)
+ User's Lost find Cache, with alert for actions that are running low.
- Added configs for the abovementioned alert.
- Added a button in upper top General bar to open the Character Stats window.
- Added a number next to Lost action links, showing the amount of Lost action in player's possession.

- Revision of many tooltip texts.
- Fix an issue where the game will crash under the following condition: Open Config > UI Assist > [A] and let the drop down open for 30s or more.
- Fix an issue where the button in Active Loadout bar in main window would not sync with the one on top of in-game Lost Find Cache window.