### PR TITLE
VFXEditor 1.7.5.0

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "d5f60e82030455b06baab6a6fbbae84cb8c9bbd0"
+commit = "9a21c00310134182137a7c3c8fadb4b095d5fb16"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Large UI refactor
- Reworked documents and renaming
  - Documents displayed as a tab bar rather than in a separate dialog
  - Documents can now be renamed by right-clicking the tab
  - Favorited selection items can be renamed by right-clicking
  - Nodes in the VFX library can be right-clicked to import/delete/rename
- TMB tweaks