### PR TITLE
ChatBubbles 2.1.3.1

### DIFF
--- a/stable/ChatBubbles/manifest.toml
+++ b/stable/ChatBubbles/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Haplo064/ChatBubbles.git"
-commit = "6a8513ab08da327bf3ac37bd26c6657c3cd01e70"
+commit = "23c40195867480d6cc977ca0c5dc465fdf5167fa"
 owners = ["Haplo064", "MKhayle"]
 project_path = "ChatBubbles"
 changelog = """[Bugfixes] 
-- Bubbles showing ontop of incorrect player (thanks meoiswa!)
+- Bubbles showing ontop of incorrect player in raids (thanks meoiswa!)
 - Handle null reference exception (thanks NPittinger!)
+- Bubbles showing ontop of incorrect players when using <t> / <tt>
 
 Let's hope that nothing breaks with 6.4"""

--- a/stable/ChatBubbles/manifest.toml
+++ b/stable/ChatBubbles/manifest.toml
@@ -1,6 +1,10 @@
 [plugin]
 repository = "https://github.com/Haplo064/ChatBubbles.git"
-commit = "6363ac26ef0801aa535f0d63fecf34c7a4cd172e"
+commit = "6a8513ab08da327bf3ac37bd26c6657c3cd01e70"
 owners = ["Haplo064", "MKhayle"]
 project_path = "ChatBubbles"
-changelog = "Update for 6.3, added API 8 compatibility"
+changelog = """[Bugfixes] 
+- Bubbles showing ontop of incorrect player (thanks meoiswa!)
+- Handle null reference exception (thanks NPittinger!)
+
+Let's hope that nothing breaks with 6.4"""


### PR DESCRIPTION
[Bugfixes] 
- Bubbles showing ontop of incorrect players when using `<t>` / `<tt>`
- Bubbles showing ontop of incorrect player in raids (thanks meoiswa!)
- Handle null reference exception (thanks NPittinger!)

Let's hope that nothing breaks with 6.4