### PR TITLE
XIVDeck 0.3.13

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "bd76af4a47ca2f50666fcc0b0d43d810ef377cc3"
+commit = "203abb50688eaa4c0af51b0ff0cb0ef8ce336517"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
It is said that long ago, a force rose up to shake the lands of Dalamud. We spoke in hushed tones, afraid to wake the beast, for it brought an upheaval once and threatened to do so again. This beast? Patch 6.4.

* Adds support for Patch 6.4 and some changes it brought.
* Add gearset IDs back to the Gearset Action.
* Add a nag message when multiboxing is detected.

For those of you who aren't on testing, there are a few other changes:

* Set the Stream Deck software to connect to 127.0.0.1 instead of localhost to hopefully make connections a bit more resilient.
* Swap back (again!!!) to the EmbedIO HTTP listener to try to fix some arcane networking issues.
* Hopefully more resilient Linux support.

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.13).

(Did you like the TOTK reference? I'm trying to be more "culturally relevant" with my patch notes.)