### PR TITLE
Player Tags 1.9.2

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,11 +1,17 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "c47b9a39af994de79386360484a069e05f31993b"
+commit = "0be0a59cf7f410daed103b243e9f68840c8f5182"
 owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = """ Version 1.9.1
-- Add master switch via sub-command *--> /playertags enableglobal on|off|toggle*
-- Updated Translation
-"""
+changelog = """# Changes
+
+- Fixed Nameplates for Patch 6.4
+- Set default Nameplate Template to Empty for new users
+
+# Important Note to all users
+
+- The base functinality of Player Tags has been implemented in core FFXIV in Patch 6.4. Thank you a lot Square Enix!
+- Please consider to use the new features added by 6.4 (role & job icons, job prefix, role color) and turning them off in Player Tags (or just switch to the \"Empty\" Nampelate Template in Player Tags Nameplate settings.
+- Player Tags will not remove any feature (yet), so you can also continue to use Player Tags for role & job tags if you need deeper configuration."""


### PR DESCRIPTION
# Changes
- Fixed Nameplates for Patch 6.4
- Set default Nameplate Template to Empty for new users
# Important Note to all users
- The base functinality of Player Tags has been implemented in core FFXIV in Patch 6.4. Thank you a lot Square Enix!
- Please consider to use the new features added by 6.4 (role & job icons, job prefix, role color) and turning them off in Player Tags (or just switch to the \"Empty\" Nampelate Template in Player Tags Nameplate settings.
- Player Tags will not remove any feature (yet), so you can also continue to use Player Tags for role & job tags if you need deeper configuration.