### PR TITLE
Team Fortress Fantasy 1.1.2.0

### DIFF
--- a/stable/Tf2Hud/manifest.toml
+++ b/stable/Tf2Hud/manifest.toml
@@ -1,14 +1,8 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-hud-plugin.git"
-commit = "2c7df503c289c54176eecc0a2dc6d7d62783a8a3"
+commit = "d44ef7d5c93a6ad1c4525cc7fbe09e765fc8439f"
 owners = ["Berna-L"]
 project_path = "Tf2Hud"
 changelog = """
-[Win Panel]
-- Added option to have the Win Panel save the score per duty.
-  - This is the default behavior for new installations.
-  - Current users will be told about this through chat when updating the plugin.
-- Added window (accessible in the Win Panel configuration) to check the saved scores per duty.
-  - This window also has an option to copy the values as CSV to the clipboard and delete individual scores.
-- Fixed the MVP list closing when pressing ESC.
+Updated for 6.4.
 """


### PR DESCRIPTION
Updated for 6.4.

(No breakage in current version, just updating the module that checks augmentation tokens with the new Anabaseios ones)