### PR TITLE
Distance 1.0.1.3

### DIFF
--- a/stable/Distance/manifest.toml
+++ b/stable/Distance/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/Distance.git"
-commit = "8fa727595f58285a5cbfd4bc3356cca49b99e3d9"
+commit = "01e4bea31c1703f8cb624bbda8875cf5dde15b0f"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "Distance"
 changelog = '''
-- Reduce potential for log spamming.
+- Updated for FFXIV patch 6.4.
 '''


### PR DESCRIPTION
[nofranz]

- Updated for 6.4

I pulled the updated sig from Redirect, which has already been merged.  I am unable to test this myself, but I have been told that the plugin is functional with the new sig (https://github.com/PunishedPineapple/Distance/issues/16#issuecomment-1562079844).  Up to you whether you want to merge this or wait.  The old version will throw during initialization.  If you prefer to ban version 1.0.1.2 of the plugin and wait for Dalamud to be up publicly for me to test this, that is fine too.