### PR TITLE
Simple Tweaks 1.8.7.2

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "67c9563a79db8c7471ee16c11495eff3b5a35711"
+commit = "9bac65878862cc69094639f3e626da8679582df0"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***Tweak Changes***
- **`Custom Free Company Tags`** - Removed 'Hide in Duty' option from Wanderer. This is now a vanilla game option.

- **`Disable Auto Chat Inputs`** - Fixed game crash in 6.4

- **`Estate List Command`** - Fixed tweak not working in 6.4

- **`Hide Job Gauge`** - Fixed 'Show while weapon is drawn' option not working.

- **`Improved Duty Finder Settings`** - Fixed tweak not working in 6.4

