### PR TITLE
Update XIVChat and ChatTwo

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = 'https://git.anna.lgbt/ascclemens/ChatTwo.git'
-commit = '3d399f11224a2c6e7c084cf4dd59a5a75103dd7e'
+commit = '3e45a005646f6b2feb5b950cb370755137a336ab'
 owners = [ 'ascclemens' ]
 changelog = """\
 - Update for 6.4

--- a/stable/XIVChat/manifest.toml
+++ b/stable/XIVChat/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = 'https://git.anna.lgbt/XIVChat/XIVChat.git'
-commit = 'df4f7dcbf684393cd08b6f066cd01ec69b8a1456'
+commit = '6966c61f60c85741a1252ae53f80ebaf5a9e53a2'
 owners = [ 'ascclemens' ]
 project_path = 'XIVChatPlugin'
 changelog = """\


### PR DESCRIPTION
Quick workaround for vanilla party icons. Didn't originally test these in battle content...

Party icons text colours don't work right now, but otherwise it works fine.