### PR TITLE
VFXEditor v1.7.5.1

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "9a21c00310134182137a7c3c8fadb4b095d5fb16"
+commit = "4ce6bc618883b1159435a10dbaecc4b5353ec484"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Updated for patch 6.4
- Added popout documents window
- UI tweaks
- Prevent cyclical VFX node dependencies
- Expand and focus windows when opening
- Emitter vertexes for VFX models are now represented as pyramids in the 3D view and reflect the `Normal` parameter