### PR TITLE
Player Tags v1.9.4

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "a49b19831a096ab208ce91b8bd93fa8a1d14fe91"
+commit = "e8513c9988a7bba75af24d98a6a82c0d80002207"
 owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = """- Fixed Context Menu Integration (due Patch 6.4)"""
+changelog = """- Fixed /playertags command not showing the settings UI anymore"""


### PR DESCRIPTION
- Fixed /playertags command not showing the settings UI anymore