### PR TITLE
[Testing] Collector's Anxiety 0.0.5

### DIFF
--- a/testing/live/CollectorsAnxiety/manifest.toml
+++ b/testing/live/CollectorsAnxiety/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/CollectorsAnxiety.git"
-commit = "402962988e69a8b7d6eefed27638be3219ec3937"
+commit = "c03458e0ce7db540e869ac10dd6cce083101f2fd"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Once again I am forced to be reminded that I tried to make a plugin *without* a dependency on arcane hardware that only a few players have. As I'm still not sure how to make Collector's Anxiety dependent on some weird piece of hardware, I guess you can have a Patch 6.4 version of it.