### PR TITLE
[Testing] Bozja Buddy 0.3.4.2

### DIFF
--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,13 +1,22 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "90ebfdb5e3203146535deb97662a6fe7e5053ef7"
+commit = "da3e261413a38864f34a64fedf000e5e936fe354"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """
-Bozja Buddy [0.3.2.4]
-- Added a config option to make the overlay on top of Resistance&Rank in-game window unclickable.
-- Hovering info for Fragment link now also display Lost action drops.
-- Minor adjustment in Loadout editing UI.
+Bozja Buddy [0.3.4.2]
+- Added Field note tab and related features to update field note progress.
+- Added grid view for Lost action table.
+- In tables, columns with active filtering will be highlighted.
+- In tables, a filtering input will have display a button to clear its input when active.
+- Icons for Lost Action and Field note is now a Link.
+- Adjustments to Custom loadout editing tab, with an addition of a grid table of Lost action below.
+- Adjustments to FateCe table, with an addition of Field Note column to filter FateCe by Field note.
 
-- Fix a bug that would crash the game upon having duplicating status effect.
+- Changes 'Lost Action' tab to 'Lost Action/Fragment' tab.
+- Adjustments to some icon buttons.
+- Adjustments to minimum main window height.
+- Fix a bug where the Lost Action Table would filter all actions that have infinite charges.
+- Fix a bug where Font of Magic does not appear in Lost action table when filtered as Caster.
+- Fix a bug where toggling 'Hiding rec. loadouts' does not apply to Loadout dropdowns + Search all results.
 """


### PR DESCRIPTION
Bozja Buddy 0.3.4.2

- Added Field note tab and related features to update field note progress.
- Added grid view for Lost action table.
- In tables, columns with active filtering will be highlighted.
- In tables, a filtering input will have display a button to clear its input when active.
- Icons for Lost Action and Field note is now a Link.
- Adjustments to Custom loadout editing tab, with an addition of a grid table of Lost action below.
- Adjustments to FateCe table, with an addition of Field Note column to filter FateCe by Field note.

- Changes "Lost Action" tab to "Lost Action/Fragment" tab.
- Adjustments to some icon buttons.
- Adjustments to minimum main window height.
- Fix a bug where the Lost Action Table would filter all actions that have infinite charges.
- Fix a bug where Font of Magic does not appear in Lost action table when filtered as Caster.
- Fix a bug where toggling "Hiding rec. loadouts" does not apply to Loadout dropdowns + Search all results.