### PR TITLE
Update Minimappingway for 6.4 (fixed bugs)

### DIFF
--- a/stable/MiniMappingway/manifest.toml
+++ b/stable/MiniMappingway/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/jaycewhite/MiniMappingway.git"
-commit = "2a05c700d6b681be22a368656dc788bd367112d7"
+commit = "34e7f2361a5b901441527c75b54db8af772a0aeb"
 owners = [
     "jaycewhite"
 ]
-changelog = "Bug fixes for occasionally not hiding during cutscenes, and not working while world visiting. Credit to Scrxtchy for fixing these!"
-version = "1.0.0.3"
+changelog = "Bugs fixed: friends not showing up; people still showing up on minimap if in party/alliance."
+version = "1.0.0.4"


### PR DESCRIPTION
Bugs fixed: friends not showing up; people still showing up on minimap if in party/alliance.