### PR TITLE
 [Testing] Hit it, Joe! (Formerly TF2-ish Critical Hits Plugin) 3.4.0.0

### DIFF
--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,11 +1,14 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "bc21edcd938d3b07f8c061b38aff14ec54824712"
+commit = "04c67c409ccbcba45e1a1342d036482521cc32f2"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-[Countdown Jams]
-- Add option to interrupt Jam when the countdown hits Start.
+[TF2-ish Critical Hits]
+- Add option per job to set a minimum time between sounds.
+  - For example, if you set the time as 1000 ms and a critical hit sound is played,
+  no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
+  - Keep it at 0 ms to use the current behavior.
 
-(Thanks to Verbose Mode for the idea!)
+(Thanks to Grayve for the idea and everyone at the Discord thread for the feedback!)
 """


### PR DESCRIPTION
[TF2-ish Critical Hits]
- Add option per job to set a minimum time between sounds.
  - For example, if you set the time as 1000 ms and a critical hit sound is played,
  no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
  - Keep it at 0 ms to use the current behavior.

(Thanks to Grayve for the idea and everyone at the Discord thread for the feedback!)