### PR TITLE
[Testing] Bozja Buddy 0.3.4.3

### DIFF
--- a/testing/live/BozjaBuddy/manifest.toml
+++ b/testing/live/BozjaBuddy/manifest.toml
@@ -1,22 +1,13 @@
 [plugin]
 repository = "https://github.com/kaleidocli/BozjaBuddy.git"
-commit = "da3e261413a38864f34a64fedf000e5e936fe354"
+commit = "bb6ea6205c6ee55553b659c21f778dfc3d337b7b"
 owners = ["kaleidocli"]
 project_path = "BozjaBuddy"
 changelog = """
-Bozja Buddy [0.3.4.2]
-- Added Field note tab and related features to update field note progress.
-- Added grid view for Lost action table.
-- In tables, columns with active filtering will be highlighted.
-- In tables, a filtering input will have display a button to clear its input when active.
-- Icons for Lost Action and Field note is now a Link.
-- Adjustments to Custom loadout editing tab, with an addition of a grid table of Lost action below.
-- Adjustments to FateCe table, with an addition of Field Note column to filter FateCe by Field note.
+Bozja Buddy [0.3.4.3]
+- Added Alternative layouts to the main window.
+- Added a button to toggle alternative layout. Can also be toggled by pressing key [Alt] while plugin main window is focused.
+- In Custom Loadout editor, added a ` + ` button on the holster title bar, on the right - which pops up the Lost action grid when clicked.
 
-- Changes 'Lost Action' tab to 'Lost Action/Fragment' tab.
-- Adjustments to some icon buttons.
-- Adjustments to minimum main window height.
-- Fix a bug where the Lost Action Table would filter all actions that have infinite charges.
-- Fix a bug where Font of Magic does not appear in Lost action table when filtered as Caster.
-- Fix a bug where toggling 'Hiding rec. loadouts' does not apply to Loadout dropdowns + Search all results.
+- Fix a bug where the Field note updates doesn't work properly.
 """


### PR DESCRIPTION
Bozja Buddy 0.3.4.3
- Added Alternative layouts to the main window.
- Added a button to toggle alternative layout. Can also be toggled by pressing key [Alt] while plugin main window is focused.
- In Custom Loadout edit, added a ` + ` button on the holster title bar, on the right - which pops up the Lost action grid when clicked.


- Fix a bug where the Field note updates doesn't work properly.