### PR TITLE
Hit it, Joe! (Formerly TF2-ish Critical Hits Plugin) 3.4.0.0

### DIFF
--- a/stable/Tf2CriticalHitsPlugin/manifest.toml
+++ b/stable/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,9 +1,13 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "54ee390e6dc42a11512edee6d24d132e2e973ff6"
+commit = "04c67c409ccbcba45e1a1342d036482521cc32f2"
 owners = ["Berna-L"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-- Fixed backup cleanup algorithm.
-- Cleared up error message when a sound file is not found. 
+[TF2-ish Critical Hits]
+- Add option per job to set a minimum time between sounds.
+  - For example, if you set the time as 1000 ms and a critical hit sound is played,
+  no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
+  - Keep it at 0 ms to use the current behavior.
+(Thanks to Grayve for the idea and everyone at the Discord thread for the feedback!)
 """

--- a/stable/Tf2CriticalHitsPlugin/manifest.toml
+++ b/stable/Tf2CriticalHitsPlugin/manifest.toml
@@ -7,7 +7,8 @@ changelog = """
 [TF2-ish Critical Hits]
 - Add option per job to set a minimum time between sounds.
   - For example, if you set the time as 1000 ms and a critical hit sound is played,
-  no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
+    no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
   - Keep it at 0 ms to use the current behavior.
+
 (Thanks to Grayve for the idea and everyone at the Discord thread for the feedback!)
 """


### PR DESCRIPTION
[TF2-ish Critical Hits]
- Add option per job to set a minimum time between sounds.
  - For example, if you set the time as 1000 ms and a critical hit sound is played,
    no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
  - Keep it at 0 ms to use the current behavior.

(Thanks to Grayve for the idea and everyone at the Discord thread for the feedback!)