### PR TITLE
Himbeertoni Raid Tool 1.3.0.2

### DIFF
--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,7 +2,9 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "1a3a32a8c544fda42d0c2f5222d0cc31e808536a"
+commit = "e44bbe3d9ab6d177ca26d52865ffdb3ff0c71279"
 changelog = """
-BiS: Added available BiS sets
-Bugfix: Ring coffer now actually contains rings"""
+Fix: Corrected loot for Anabaseios Savage (Thanks to Zeppy for helping)
+Fix: Dungeon/Trial Gear is now shown correctly
+Fix: Fixed an issue with potentially overriding gear sets (since 1.2.x.x)
+BiS: Added more BiS (AST, SCH, SGE)"""


### PR DESCRIPTION
Fix: Corrected loot for Anabaseios Savage (Thanks to Zeppy for helping)
Fix: Dungeon/Trial Gear is now shown correctly
Fix: Fixed an issue with potentially overriding gear sets (since 1.2.x.x)
BiS: Added more BiS (AST, SCH, SGE)