### PR TITLE
CrossUp v1.0.0.1

### DIFF
--- a/stable/CrossUp/manifest.toml
+++ b/stable/CrossUp/manifest.toml
@@ -1,14 +1,9 @@
 [plugin]
 repository = "https://github.com/ItsBexy/CrossUp.git"
-commit = "8eb196dd82333cf3460d3cc9d165bcf5eb72fb02"
+commit = "9ba9a43fafe7c8154a3bdd62f5b1fa356b68be54"
 owners = [
     "ItsBexy",
 ]
 changelog = """
-With the plugin appearing to have survived Patch 6.4 very comfortably, I'm ready to push the latest build to Stable. Hooray!
-
-For the non-testing world, here's a recap! CrossUp is a plugin for controller users, providing more options to customize how the game's Cross Hotbar looks and feels to use.
-- Various visual customizations, including colour schemes and layout modifications
-- Allows the Expanded Hold Controls (accessed with L→R and R→L inputs) to be displayed as separate elements onscreen, rather than sharing space with the main bar
-- Enables extra bars to automatically switch sets alongside the main bar
+Fixed a bug wherein some of the controls for positioning the Expanded Hold bars were faulty (whoops!)
 """


### PR DESCRIPTION
Fixed a bug wherein some of the controls for positioning the Expanded Hold bars were faulty (whoops!)