### PR TITLE
Himbeertoni Raid Tool 1.3.1.1

### DIFF
--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,5 +2,12 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "7c5366acf615a71171c896e79c70186f6d6e5bd8"
-changelog = "Fix: Merge infos for multiple database entries for one character"
+commit = "c3a8fc9673ec0014e71ea7966cd1a5b73ae7dff2"
+changelog = """
+General: Only cap applicable stats on items
+General: Fixed stat claculations due to unintentionally capping stats lower than intended
+Loot Session: \\%DPS gain now properly takes SKS/SPS into account
+Loot Session: Removed manually curated DPS for players
+Edit Gear: Properly handle local and etro.gg sets (Etro sets cannot be edited and need to be converted to local to edit)
+Edit Gear: Slightly reworked Ui
+Edit Gear: You can now edit the names of sets"""

--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "c3a8fc9673ec0014e71ea7966cd1a5b73ae7dff2"
+commit = "c7192c2896e29869b669c9b950f8800fc1c9baf5"
 changelog = """
 General: Only cap applicable stats on items
 General: Fixed stat claculations due to unintentionally capping stats lower than intended


### PR DESCRIPTION
General: Only cap applicable stats on items
General: Fixed stat claculations due to unintentionally capping stats lower than intended
Loot Session: %DPS gain now properly takes SKS/SPS into account
Loot Session: Removed manually curated DPS for players
Edit Gear: Properly handle local and etro.gg sets (Etro sets cannot be edited and need to be converted to local to edit)
Edit Gear: Slightly reworked Ui
Edit Gear: You can now edit the names of sets