### PR TITLE
[Testing] Collector's Anxiety 0.0.6

### DIFF
--- a/testing/live/CollectorsAnxiety/manifest.toml
+++ b/testing/live/CollectorsAnxiety/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/CollectorsAnxiety.git"
-commit = "c03458e0ce7db540e869ac10dd6cce083101f2fd"
+commit = "f87902390c2a1bc211cba6475b3f0ee3bc459e37"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
If you were to really stop to think about what you can collect in this game, there are a lot more than just minions, mounts, fashion accessories, and so on. There's a whole world of things! Like duties! Map locations! And, if Savage PF is to be believed, vuln stacks!

Why *shouldn't* Collector's Anxiety help you with some of these? It should, so now you can track how many duties you still need to unlock!

I am not responsible for the pain this will inflict when you realize you will never get a 100% unlock of the Duty category because Ultimates are gated behind clearing Savage.