### PR TITLE
Allagan Tools v1.5.0.7

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,11 +1,13 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "cc4d2c5e9fcfec4ef89f60c62e99c6bfe8596ffb"
+commit = "690cc35d842f4dd7d6a648158ebc9e27cf647738"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.5.0.6"
+version = "1.5.0.7"
 changelog = """\
-Actually fix the housing crash, much appreciated to Laissabelle for helping me track it down
+Tetris has returned! Turn it on in the 'Fun' section within Settings -> General
+The add item search field now accepts advanced filters (||,&&,!, etc)
+Added an extra ~800 mob drops, the data should be far more complete and include drops from the latest expansion
 """


### PR DESCRIPTION
Tetris has returned! Turn it on in the 'Fun' section within Settings -> General
The add item search field now accepts advanced filters (||,&&,!, etc)
Added an extra ~800 mob drops, the data should be far more complete and include drops from the latest expansion