### PR TITLE
Allagan Tools v1.5.0.10

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "783945fa8e19ccd76d758c5c5b5eaa118d505a33"
+commit = "130eb2a68d2ffa4460ad6b8c6e021d29accdbca5"
 owners = [
     "Critical-Impact",
 ]
@@ -10,4 +10,5 @@ changelog = """\
 Add an ingredient search filter(this will calculate the ingredients required to craft the items selected in the filters configuration and only show those ingredients)
 Filters now have a reset button to quickly clear their settings
 Multiple choice filters can now be searched from the setting interface + you can add all the items in the drop down list with a button
+Added 6.4 submarine drops and unlocks (thanks Infi <3)
 """

--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,11 +1,13 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "1a469a63b48f68b917520922355ebfcc2de39a17"
+commit = "783945fa8e19ccd76d758c5c5b5eaa118d505a33"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.5.0.9"
+version = "1.5.0.10"
 changelog = """\
-Adjust ItemCount IPC to use int instead of uint
+Add an ingredient search filter(this will calculate the ingredients required to craft the items selected in the filters configuration and only show those ingredients)
+Filters now have a reset button to quickly clear their settings
+Multiple choice filters can now be searched from the setting interface + you can add all the items in the drop down list with a button
 """


### PR DESCRIPTION
Add an ingredient search filter(this will calculate the ingredients required to craft the selected items and only show those). 
Filters now have a reset button to quickly clear their settings
Multiple choice filters can now be searched from the setting interface + you can add all the items in the drop down list with a button
Increased the character limit for filter configuration imports