### PR TITLE
[Testing] Who's Talking 0.2.0.0

### DIFF
--- a/testing/live/WhosTalking/manifest.toml
+++ b/testing/live/WhosTalking/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/sersorrel/WhosTalking.git"
-commit = "7e2a30d6155dace594134996df4ae0f73550ff66"
+commit = "3f5f8a23dcd65b8e996d0f2da3cb65f040b2b6c8"
 owners = ["sersorrel"]
 project_path = "WhosTalking"
 changelog = """\
-- Fix poorly-sized voice activity indicators at certain UI scales
+- Add ability to manually set Discord usernames for characters (many thanks to Archon for implementing this!)
+
+  Head into the plugin settings and click "Advanced Individual Assignments" to set this up.
 """


### PR DESCRIPTION
new feature: 

![you can configure which Discord account corresponds to each XIV character now](https://cdn.discordapp.com/attachments/892131028188151808/1121816238591586314/248299567-7da26f4b-cedc-4732-ac0b-fd1bb35a4ad6.png)

I'll probably finally get around to moving this out of testing in a few weeks (gonna have limited availability til then)