### PR TITLE
[Testing] Mappy v1.0.0.1

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "1f84898458fa812b6bb8963029a0ca3ee4fa8964"
+commit = "9fdb469cbbf6181c32aa835241528232097d6df7"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Improved tooltips, they now have icons and look really cool
Improved plugin defaults, each module now has a reasonable default layer

Added option to display tooltips for misc map markers, ie, "Shop", "Repair", "Trader"
Added more tooltips for special icons

Treasure icons now no longer have a planar distance limit, instead they have a height limit, you can't see treasure more than 20y above or below you on the map.

**It is recommended to right click the plugin in the installer and click "Reset plugin configuration and reload"**
If you find think some of the defaults are a bad idea, let me know at the github issue tracker: <https://github.com/MidoriKami/Mappy/issues>

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/9083275/298b0026-6459-4939-8c01-1a6d728f06fd)
