### PR TITLE
SubmarineTracker 1.7.0.0

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,14 +1,29 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "4cbd3a4e49861d8593987c05070b718a9a6daa9f"
+commit = "d124bb48e981b8e9b0ab1b957e01c75fe07f09e4"
 owners = [
     "Infiziert90",
 ]
 project_path = "SubmarineTracker"
 changelog = """
-[Loot]
-+ Added export functionality, exporting all the valid loot data into a csv for excel/spreadsheet
+[Builder]
++ Leveling Tab has been added (thanks @ WildWolf for all the improvements)
+> Allows for a simple, customisable leveling calculator to show progress towards target Rank 
++ Added new maximize option, for more information see the "(i)" icon in the menu
++ Wide variety of small UI improvements
++ All calculations now factor in guaranteed bonus experience
 
-[Misc]
-+ Added all breakpoints for the new sectors
+[Tracker]
++ The All Tab has been reworked, allowing space to show more FCs at once
++ Yellow color will now be added to the name of the submarine that will require repair on voyage return
++ A tooltip will show more information when hovering over any submarine
++ The detailed view of submarines including more specific information, such as number of voyages until repairs, etc
+
+[Loot]
++ The voyage tab has been reworked, condensing information to allow more to be shown at once
++ Exclude Legacy now also effects the voyage history
++ Voyage history has been reversed, the latest voyage will now always display at the top of the list
+
+Info:
+I'm looking for loot data samples, if you wish to contribute and help my efforts, please use the export function (Exluce Date Yes) in the addon and send the created dump file into the linked discord thread (Config > About Tab).
 """


### PR DESCRIPTION
[Builder]
+ Leveling Tab has been added (thanks @ WildWolf for all the improvements)
> Allows for a simple, customisable leveling calculator to show progress towards target Rank 
+ Added new maximize option, for more information see the "(i)" icon in the menu
+ Wide variety of small UI improvements
+ All calculations now factor in guaranteed bonus experience

[Tracker]
+ The All Tab has been reworked, allowing space to show more FCs at once
+ Yellow color will now be added to the name of the submarine that will require repair on voyage return
+ A tooltip will show more information when hovering over any submarine
+ The detailed view of submarines including more specific information, such as number of voyages until repairs, etc

[Loot]
+ Added export functionality, exporting all the valid loot data into a csv for excel/spreadsheet
+ The voyage tab has been reworked, condensing information to allow more to be shown at once
+ Exclude Legacy now also effects the voyage history
+ Voyage history has been reversed, the latest voyage will now always display at the top of the list



Info:
I'm looking for loot data samples, if you wish to contribute and help my efforts, please use the export function (Exluce Date Yes) in the addon and send the created dump file into the linked discord thread (Config > About Tab).