### PR TITLE
ChillFrames v2.0.0.0

### DIFF
--- a/stable/ChillFrames/manifest.toml
+++ b/stable/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "4531f354ebe4b54aaa0c0ecd2cc7e75d40abd178"
+commit = "3c50ce5583ec98d315d1f6454601ac8a74c2e95f"
 owners = ["MidoriKami"]
 project_path = "ChillFrames"


### PR DESCRIPTION
You can now set a "idle" framerate limit, and a "active" framerate limit.

Lets say you wanna idle in limsa but not use a ton of CPU/GPU power, set the idle limit to 30fps and boom, savings.
Then your queue pops for Good King Mog (Ultimate), and you don't want your framerate to be a gazillion fps, set the active framerate limit to 60fps (or whatever your displays refresh rate is)

This update will nuke your configs, sorry, tech debt, I made mistakes in the past, and have to pay for them now.

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/9083275/eb303755-f455-4a8f-b74d-213f3a4d3e31)
