### PR TITLE
[Testing] Mappy v1.0.0.4

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "ff9f13464a11a2a6bd6de6e08365fbc7ce8e1ec1"
+commit = "f65f1555660f44b009c30807a71ce568c48ecca3"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "31690da01e5c32fda26b4216a9e944c255e70674"
+commit = "ff9f13464a11a2a6bd6de6e08365fbc7ce8e1ec1"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Add basic Island Sanctuary Support.
(Gathering areas are not supported, use ReSanctuary Plugin to display specific locations on the map)

Add Center on Open Option, Re-centers map on player when opening the map, off by default

Add Zoom on Hover option, on by default

Add more Fade Map options

No longer shows self as a party member

This will be the last testing release, the next release will be to public stable

Add marker to the map when using `/mappy map goto ## ##`

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/9083275/d5b89a77-fa65-4754-b33f-e2d679869ddc)
