### PR TITLE
Himbeertoni Raid Tool 1.3.2.0

### DIFF
--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,5 +2,11 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "635dafb28ad3311401629c816808e8b65fdf6b25"
-changelog = "General: Fix a crash when using wine"
+commit = "804a48afd56bce1d350458777a8b8de597c7d96d"
+changelog = """
+Loot session: Added rule "Can use now" (Tome Upgrades)
+Loot session: Added rule "Can buy" (requires you to track the books correctly)
+Gear: You can now delete gear sets
+Database: Remove unused entries (old gear sets and characters)
+Etro.gg: Import crafted items as HQ again  (broken since 1.2.x)
+General: Fix extremly rare crash on startup"""


### PR DESCRIPTION
Loot session: Added rule "Can use now" (Tome Upgrades)
Loot session: Added rule "Can buy" (requires you to track the books correctly)
Gear: You can now delete gear sets
Database: Remove unused entries (old gear sets and characters)
Etro.gg: Import crafted items as HQ again  (broken since 1.2.x)
General: Fix extremly rare crash on startup