### PR TITLE
[Testing] Allagan Tools v1.6.0.3

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,17 +1,25 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "4410e12f70f6d228d486b646cf2cf916514beb17"
+commit = "e94d2bedecb7af53db9d3225067e5d20d9611ad5"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.6.0.2"
+version = "1.6.0.3"
 changelog = """\
-**Allagan Tools: v1.6.0.2**
-Added 'Buy' button that teleports you to the nearest vendor of an item + a dropdown of locations
-Added Teleporter integration for vendors
-Fixed a bug where HQ required for all items was not respected
-Added timed node countdowns to the 'Gather' column.
-The total required amount should now list the correct value
-The missing ingredients popup should now list the correct values 
+**Allagan Tools: v1.6.0.3**
+Added in craft list zone system(you can specify preferred zones and also override the zone on each item)
+The HQ Required, Retrieve from Retainer and Source Preferences can be switched by left clicking/right clicking their icons
+Group headers in craft lists can have their text colour changed
+Tooltip category whitelist/blacklist added
+Ignore escape key setting added for most windows
+Added missing vendors
+Ventures and Exploration ventures were split as exploration ventures are random and might not be preferred
+Items from housing vendors are not duplicated and will indicate they are available only from placable vendors
+Active Craft List functionality added(when a craft list is active, crafts count towards it) + auto switch craft list setting added. IPC calls added for activating/deactivating craft lists
+Duplicate "Open in Crafting Log" fixed
+Fixed an issue where zeroing an item in a craft list would zero all items
+Fixes in the way tooltips are displayed when HQ items are involved
+If a craft generates extra materials due to yield, we'll try to take less from external sources
+Had a lot of help from KiwiKahawai testing and on the dev side, big thanks to them :)
 """


### PR DESCRIPTION
**Allagan Tools: v1.6.0.3**
**New Features:**
- Added in a zone system for craft lists(you can specify preferred zones and also override the zone on each item)
- The HQ Required, Retrieve from Retainer and Source Preferences can be switched by left clicking/right clicking their icons
- Group headers in craft lists can have their text colour changed
- Tooltip category whitelist/blacklist added
- Ignore escape key setting added for most windows
- Ventures and Exploration ventures are now two seperate preferences as the random nature of exploration ventures is not all too useful 
- Items from housing vendors will be listed as housing vendors, they've also been deduplicated
- Active Craft List functionality added(when a craft list is active, crafts count towards it) + auto switch craft list setting added. IPC calls added for activating/deactivating craft lists
- If a craft generates extra materials due to yield, we'll try to take less from external sources

**Fixes:**
- Duplicate "Open in Crafting Log" fixed
- Fixed an issue where zeroing an item in a craft list would zero all items
- Fixes in the way tooltips are displayed when HQ items are involved
- Added missing vendors
- Fixes to retrieval recommendations and item counting when the item is marked as HQ required
- Had a lot of help from KiwiKahawai testing and on the dev side, many thanks to them