### PR TITLE
NoTankYou v6.0.0.5

### DIFF
--- a/stable/NoTankYou/manifest.toml
+++ b/stable/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "621bf3a308b81d7279abf94d768ec8178f83f78f"
+commit = "c14c64c89d233851062131a9850452a6c65ac4c5"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"

--- a/stable/NoTankYou/manifest.toml
+++ b/stable/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "c7faa6e0c86114af63a77fcd7a21386fff5dfbcc"
+commit = "621bf3a308b81d7279abf94d768ec8178f83f78f"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"

--- a/stable/NoTankYou/manifest.toml
+++ b/stable/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "c14c64c89d233851062131a9850452a6c65ac4c5"
+commit = "afcc0af8abf3b5a49bf84d3554ba8f76378d8db1"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
Potentially fix pet related warnings with multiple Summoners or Scholars are in the party

Improved blacklist feature

Commands have changed, use `/notankyou help` or `/nty help` to see all available commands.

Added new command `/notankyou [modulename] suppress`

Sometimes you will come across players that will simply refuse to do their role-specific actions, while a warning for a player that won't do their job is showing, use `/notankyou [modulename] suppress` and that player will no longer generate any more warnings for that module.

Suppression is reset when you change zones. (Moving from one area to another within a duty is not a zone change)
