### PR TITLE
[TESTING] XIVDeck 0.3.14

### DIFF
--- a/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/testing/live/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "d4a8470c9f23d5f5f50975ddf3a12f6bba8cd5c4"
+commit = "d1e264b14374401703546898cfdb01223b4b8011"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
For a release that should be dedicated to pi, XIVDeck has decided to lose some weight and become quite a bit leaner. Kinda need to do that if you want to start running on phones...

- XIVDeck now properly supports Stream Deck SDK version 6.1, which brings some minor code improvements.
- A bunch of performance improvements to keep XIVDeck feeling snappy.
  - A minor optimization to hotbar monitoring means XIVDeck wastes less of each frame, every frame.
  - Removed an unnecessary cache that just made on-login and other events take slightly longer.
  - Update volume management to listen for events instead of checking every frame for volume changes.
- Update the German and French translations (thank you Alice and Khayle!).
- Adds some useful logging messages on plugin startup to help diagnose certain issues.
- Other miscellaneous fixes.

For those of you who are interested in XIVDeck (or otherwise bringing your hotbars out of the game), but don't want to buy a Stream Deck, I have some cool news. Elgato released a new version of [Stream Deck Mobile for iOS](https://apps.apple.com/us/app/elgato-stream-deck-mobile/id1440014184), which now gives you six virtual buttons free, forever. Android is allegedly going to get this update soon. Possibly. I promise I was not paid to make this statement.

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.14).