### PR TITLE
Allagan Tools v1.6.1.0

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,13 +1,25 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "4005a950471307708c963b12d8bb89ece6bcfa4e"
+commit = "dfc05227bf34a41d0f97468f2cbde9af3d891a73"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.5.0.11"
+version = "1.6.1.0"
 changelog = """\
-Add search filter to acqusition icons column
-Remove unrequired logging
-Update lumina supplemental(Thanks to Emma for the mob spawn data)
+This is the live release of the crafting update for Allagan Tools which brings it closer to being a full replacement of some of the existing external tools. The update includes the following changes: 
+
+- Improved handling of items with sources other than crafting. Sourcing can be configured via a priority system and then overridden per item
+- There are now options to group the items in the craft list
+  - Precrafts: Class, Depth, Together
+  - Everything Else: Zone, Together
+  - Crystals/Currency: Seperate/Together
+- NQ/HQ can be configured per item
+- Retainer Retrieval can be configured per item
+- Any item can be added to a craft list(completion tracking for non-craft items will come later)
+- Teleporation and zoning for vendors has been greatly improved
+- There has been a lot of changes under the hood to accommodate these changes so any issues please head to the #plugin-help-forum
+A inventory history module has also been added, it's still very new and is opt in, the plugin will prompt you when you open the new "History" filter if you wish to turn it on.
+
+Also massive thanks to KiwiKahawai for helping me test this thing and helping me reign in my constant feature creep :slight_smile:
 """


### PR DESCRIPTION
This is the live release of the crafting update for Allagan Tools which brings it closer to being a full replacement of some of the existing external tools. The update includes the following changes: 

- Improved handling of items with sources other than crafting. Sourcing can be configured via a priority system and then overridden per item
- There are now options to group the items in the craft list
  - Precrafts: Class, Depth, Together
  - Everything Else: Zone, Together
  - Crystals/Currency: Seperate/Together
- NQ/HQ can be configured per item
- Retainer Retrieval can be configured per item
- Any item can be added to a craft list(completion tracking for non-craft items will come later)
- Teleporation and zoning for vendors has been greatly improved
- There has been a lot of changes under the hood to accommodate these changes so any issues please head to the #plugin-help-forum
A inventory history module has also been added, it's still very new and is opt in, the plugin will prompt you when you open the new "History" filter if you wish to turn it on.

Also massive thanks to KiwiKahawai for helping me test this thing and helping me reign in my constant feature creep :slight_smile: