### PR TITLE
Submarine Tracker 1.7.2.4

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,10 +1,7 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "cc2755d0e7f9470f42943e4271b579ccbda27f15"
+commit = "68a0a271b4fc70d986b97fb4a115fac64c927971"
 owners = [
     "Infiziert90",
 ]
 project_path = "SubmarineTracker"
-changelog = """
-+ Disable option to unminimize overlay on startup
-"""


### PR DESCRIPTION
#### [Config > Overlay]
+ All options default to false
+ New option: Always open on return
+ New option: Sort by lowest return time
+ New option: Only show returned subs
+ New option: Lock window size
+ New option: Lock window position

#### [Loot > Analyse]
+ Fixed bug in analyse that excluded the last submarine of each FC
+ Added button to rebuild the cache
  + This is required if legacy inclusion was disable/enable or submarines have returned
