### PR TITLE
CollectableCalculator 1.2

### DIFF
--- a/stable/CollectableCalculator/manifest.toml
+++ b/stable/CollectableCalculator/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/mabako/CollectableCalculator.git"
-commit = "101fbcc86c1c9baa9d4d1d704d05bcf6a1357a36"
+commit = "f45d1984626d58cca0105fd3bd12f227bc495d71"
 owners = ["carvelli", "mabako"]
 project_path = "CollectableCalculator"


### PR DESCRIPTION
Adds optional settings to include the total number of items/scrips you would have AFTER turning in all items in your inventory. Mostly useful for the relics where your inventory might be too small to all required collectables at once.

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/125113/593bab22-09de-4363-a57f-901eda7aa2ab)
