### PR TITLE
Update manifest repo urls for CollectableCalculator/TitleRoulette

### DIFF
--- a/stable/CollectableCalculator/manifest.toml
+++ b/stable/CollectableCalculator/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/mabako/CollectableCalculator.git"
-commit = "f45d1984626d58cca0105fd3bd12f227bc495d71"
+commit = "f207da229a2e6a75f729a03f98e93f8d69ac51ff"
 owners = ["carvelli", "mabako"]
 project_path = "CollectableCalculator"

--- a/stable/TitleRoulette/manifest.toml
+++ b/stable/TitleRoulette/manifest.toml
@@ -1,4 +1,4 @@
 [plugin]
 repository = "https://github.com/mabako/TitleRoulette.git"
-commit = "51b70927a0674d6f64c154e98f611910fce6c393"
+commit = "4878d96b14bb418b4e6d422119011c11af676f31"
 owners = ["carvelli", "mabako"]


### PR DESCRIPTION
- Update repo urls in the manifest to point to the current GitHub repo locations