### PR TITLE
Allagan Tools v1.6.1.3

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,14 +1,15 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "6ac6e22857a110cc15ff401bd7a988a7ffc1a2b3"
+commit = "a6f7b6de88c89cd3ceb0f261749e893f67157f84"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.6.1.2"
+version = "1.6.1.3"
 changelog = """\
-- Company Craft phases should now show/switch correctly
-- Add reduction data for 6.45 + previously missing reduction items
-- Fix a crash that could occur on plugin unload
-- Added a HQ Item count IPC method(thanks Taurenkey)
+- The acquisition icon column will display in a slightly nicer order(at least until it's configurable)
+- Fixed the way in which shop locations are grouped (KiwiKahawai)
+- Fixes to marked items as properly returned (rather than still used) (KiwiKahawai)
+- Solves issues with items not appearing in filters if HQ required is set (KiwiKahawai)
+- Minor changes to CriticalCommonLib to help support other plugins using it
 """


### PR DESCRIPTION
- The acqusition icon column will display in a slightly nicer order(at least until it's configurable)
- Fixed the way in which shop locations are grouped (KiwiKahawai)
- Fixes to marked items as properly returned (rather than still used) (KiwiKahawai)
- Solves issues with items not appearing in filters if HQ required is set (KiwiKahawai)
- Minor changes to CriticalCommonLib