### PR TITLE
SubmarineTracker 1.7.2.6

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "87a7992e269a494ea18a8e7c9cc07f99993a7f0b"
+commit = "7a2c85c9bd1aee07a74c5944f82514a7325b743f"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Hash loot dumps

> Note:
> I'm looking for loot data, especially for cryPTO routes, if you wish to contribute and help my efforts
> /sloot -> Export Tab -> Pick an output path -> Export
> Just send the created dump over discord (@ infi) or use the linked discord thread in the "About" Tab 