### PR TITLE
Mappy v1.0.1.2

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "1a70b3565725238b2830b0220585d352bebf4f2e"
+commit = "007a156bba314a61cfdd2e0a9bf31f158b800352"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Added another search mode "Region Search", default to on, so if you prefer the text search bar turn the Region Search option off.

Split `Follow and Center on player when opening map` into two options `Follow Player when opening map` and `Center on Player when opening map.