### PR TITLE
NoTankYou v6.0.0.6

### DIFF
--- a/stable/NoTankYou/manifest.toml
+++ b/stable/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "afcc0af8abf3b5a49bf84d3554ba8f76378d8db1"
+commit = "70d4834a326ce412daa66cfac57ba58cb92c3083"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
Fixes warnings showing during Nier Alliance Raid when transformed (And possibly other areas when you are transformed)