### PR TITLE
Mappy v1.0.1.3

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "007a156bba314a61cfdd2e0a9bf31f158b800352"
+commit = "e824eb769b97c9bcee2d80388970e18f1500e812"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Add `Icon Control` tab

This new tab lets you disable *any* icon that Mappy has shown you.
Disable icons responsibly.