### PR TITLE
PetRenamer 0.2.1

### DIFF
--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,12 +1,12 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "926fd51ff22bc444524bb936b5da127fa98ea64c"
+commit = "0cec7efbe8e9ff02e17a2aeb089bc32a16d5026c"
 owners = [
 	"Glyceri",
 ]
 project_path = "PetRenamer"
 changelog = """
-+ Rewrite Pet Renamer Plugin
-+ Clear all Names option
-+ Disable Name Display option
++ Added support for subcommands (AKA: if a command is called /petname you can add multiple extra commands that will call the same code. For example: /minionname)
++ (AFAIK) Renamed all instances of pet to minion.
++ Added a little info spot that informs users to look away or resummon the pet to apply the name changes.
 """

--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "0cec7efbe8e9ff02e17a2aeb089bc32a16d5026c"
+commit = "be44543af6417d7bbc6ecaa89a79ab69c07d5882"
 owners = [
 	"Glyceri",
 ]
@@ -9,4 +9,5 @@ changelog = """
 + Added support for subcommands (AKA: if a command is called /petname you can add multiple extra commands that will call the same code. For example: /minionname)
 + (AFAIK) Renamed all instances of pet to minion.
 + Added a little info spot that informs users to look away or resummon the pet to apply the name changes.
++ Updated version number........................
 """


### PR DESCRIPTION
Update to the PetRenamer plugin.
My discord handle btw is: @glyceri formerly known as Glyceri#9461

Changelog:
 - Added support for subcommands (AKA: if a command is called /petname you can add multiple extra commands that will call the same code. For example: /minionname)
 - (AFAIK) Renamed all instances of pet to minion.
 - Added a little info spot that informs users to look away or resummon their pet to apply the name changes.
