### PR TITLE
Mappy v1.0.1.5

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "352e26107f707e2679eb0ede2d0035b3b73218e1"
+commit = "14b5e1a9205dd15b07363a4d3d62d0133a803118"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Fixes Island Sanctuary Icons showing on other maps
Add "View Map: [parent]" context menu entry for sub-areas
Fixes Icon Control showing icons with different sizes
Fixes Little Circles showing when quest icons are hidden
Add Directional Markers to Quest marks