### PR TITLE
Team Fortress Fantasy 1.1.5.0

### DIFF
--- a/stable/Tf2Hud/manifest.toml
+++ b/stable/Tf2Hud/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-hud-plugin.git"
-commit = "bb4cf2ba388d77e747462663bbbc0c9d1982b77f"
+commit = "3b5b0c64f6963e9c999502f56fc8d9c6fc13eee1"
 owners = ["Berna-L"]
 project_path = "Tf2Hud"
 changelog = """
-[Win Panel]
-- Fix scores table overflowing when there's too much data. (Thanks HuiEtyud for another bug report!)
+[General]
+Add failsafe if Dalamud thinks a Windows user is under Linux.
+
+(Thanks to AlexFlipnote for the report!)
 """

--- a/stable/Tf2Hud/manifest.toml
+++ b/stable/Tf2Hud/manifest.toml
@@ -1,11 +1,12 @@
 [plugin]
 repository = "https://github.com/Berna-L/ffxiv-tf2-hud-plugin.git"
-commit = "3b5b0c64f6963e9c999502f56fc8d9c6fc13eee1"
+commit = "c28f1181443d57fc6374d81b7ad8369a8d01cbcd"
 owners = ["Berna-L"]
 project_path = "Tf2Hud"
 changelog = """
 [General]
-Add failsafe if Dalamud thinks a Windows user is under Linux.
+- Add failsafe if Dalamud thinks a Windows user is under Linux.
+- Add chat message if the TF2 installation folder could not be autodetected.
 
 (Thanks to AlexFlipnote for the report!)
 """


### PR DESCRIPTION
**[General]**
Add failsafe if Dalamud thinks a Windows user is under Linux.
Add chat message if the TF2 folder could not be autodetected.

(Thanks to AlexFlipnote for the report!)