### PR TITLE
Update Sound Filter to 1.4.11

### DIFF
--- a/stable/SoundFilter/manifest.toml
+++ b/stable/SoundFilter/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = 'https://git.anna.lgbt/ascclemens/SoundFilter.git'
-commit = '24be9d517f7715c9828cdc5e798a96a12abd7dd7'
+commit = '35157e152e09afa44da626ec4813729bc871048f'
 owners = [ 'ascclemens' ]
-changelog = 'API 8'
+changelog = 'Fix the sound log staying open when not closed properly'


### PR DESCRIPTION
If you close the sound log via the X button instead of unchecking the checkbox, it saves properly now. You're welcome.