### PR TITLE
SubmarineTracker 1.7.4.1

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "4712f47632a5b02a728f4da556bb43e8d34da53c"
+commit = "a5f521804591a3d27c2b5071f4f48d7ea731995c"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[Builder -> Leveling]
- Added option to ignore shark part behaviour
- Added option to ignore unmodded part behaviour

> Both options are completely unsupported behaviour and have special requirements, they got added after being requested