### PR TITLE
GoodFriend v3.0.2.0

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/GoodFriend.git"
-commit = "b0cdeef0989302a4eb910e402bb866a2dbb590d5"
+commit = "b96edfb21267a6132eedeb9dcfa3c9967995aeb5"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
Buckle up, folks, because today's update is a real doozy. It appears that our resident coding genius – and by genius, I mean someone who's seemingly mastered the art of forgetting – managed to pull off a stunt that'll go down in the annals of programming history. They actually, and I can't stress this enough, forgot to add the code for saving the announcements module configuration file. Now, I've heard of cutting corners, but this is like building a race car with square wheels!

But hold your applause, because we're not stopping at mere forgetfulness. No, sir! We've put on our education hats and taught our developer a lesson they won't soon forget. Thanks to some tough love and maybe a few raised voices, we've managed to coerce them into fixing their egregious mistake. I'm delighted – or maybe just relieved – to announce that the plugin update hitting the *Aperture Science Dalamud Plugin Installer* rectifies this colossal blunder. Your announcement configuration? Oh, it'll be saved correctly now, like it should've been from the get-go.

So there you have it ladies, gents, AI overlords and anyone else in-between. The developer's momentary lapse in coding judgment has led to a triumph of problem-solving that would make even Sir Isaac Newton raise an impressed eyebrow. Our software not only saves your configurations now but does it with a flair that's simply unparalleled. Remember, the only way from here is up, and we've taken that elevator to new coding heights. Cave Johnson signing off.