### PR TITLE
TPie release 1.7.1.0

### DIFF
--- a/stable/TPie/manifest.toml
+++ b/stable/TPie/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/TPie.git"
-commit = "434fdde846f9506bbdbfb745f70d504098c7ee54"
+commit = "8cd8ac74879248c3bc5ff4aabc920e478e90a8f1"
 owners = ["Tischel"]
 project_path = "TPie"
-changelog = "- Added support for Patch 6.3 and Dalamud Api8."
+changelog = "- Added support for the Wotsit plugin:\n    + You can search for rings with by name to go directly to its settings.\n    + Only rings with a name will work.\n\n- Added a Quick Settings shortcut:\n    + Double right-clicking while a ring is opened will open the settings windows for that ring:\n    + This can be disabled in the general settings.\n\n- Improved interactions when editing ring items:\n    + Selecting a different ring item when the edit window is opened will refresh the window with the newly selected item."


### PR DESCRIPTION
- Added support for the Wotsit plugin:
    + You can search for rings with by name to go directly to its settings.
    + Only rings with a name will work.

- Added a Quick Settings shortcut:
    + Double right-clicking while a ring is opened will open the settings windows for that ring:
    + This can be disabled in the general settings.

- Improved interactions when editing ring items:
    + Selecting a different ring item when the edit window is opened will refresh the window with the newly selected item.