### PR TITLE
SubmarineTracker 1.7.4.6

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "a2837b7f69caa4b727e7024090ac2a4106400f94"
+commit = "b17485a3e532512ffde76261200804fa6a6d6628"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "b17485a3e532512ffde76261200804fa6a6d6628"
+commit = "f6900328d748021ebf24a4af4d11ba2c6a28a3db"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[Helpy > Storage]
- Prevent accidental chat spam if AllaganTools isn't installed

[Config > Notify]
- Added option to disable return chat notifications 
- Support discord webhook for dispatched and returned submarines
    - Click the help button to open the discord webhook guide
    
> Functionality Note: 
> Return only works with your game running when the submarine returns
> Dispatch has a timestamp included, so discord will show you the exact time until the submarine returns
