### PR TITLE
[Testing] HotbarHelper v0.0.2.2

### DIFF
--- a/testing/live/HotbarHelper/manifest.toml
+++ b/testing/live/HotbarHelper/manifest.toml
@@ -1,16 +1,12 @@
 [plugin]
 repository = "https://github.com/kiwikahawai/HotbarHelper.git"
-commit = "d2cb8f51725b39827a74f276655a944cdd469133"
+commit = "40d67ede1c0fef1caf56fb184fd6e6f21fc15490"
 owners = [
     "kiwikahawai",
 ]
 project_path = "HotbarHelper"
-version = "0.0.2.1"
+version = "0.0.2.2"
 changelog = """\
-**HotbarHelper (initial release)**
-- Searches your hotbars as you use them for missing actions and useful actions like Limit Break
-- Particularly useful if you've lost your hotbars or regularly switch between platforms and find actions are missing
-- Ability to ignore actions you may have in macros (such as Raise)
-
-DoH and DoL classes will be supported in a future release.
+- Reduce spam on levelling up when no action is needed.
+- Internal changes for recent Dalamud features.
 """


### PR DESCRIPTION
Quick update to reduce the amount of spam on levelling up (saves the 'validation complete' messages basically.

Also: Remove a spurious/mostly useless button (okay, it did switch to the config tab, but... users could just click the tab anyway right?) in the plugin window, and switch to `ITextureProvider`.

No rush for this, it's only spammy if power levelling, and I made a note in plugin-testing that I was aware of this.