### PR TITLE
VFXEditor v1.7.8.1

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "a94057c572049e2f64f9b859013584e9f92153e2"
+commit = "40a27c163933388e8ebfb4693a30cd6d4688f122"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Rework `.pap` editor to use game's havok functions rather than shipping with `animassist_custom.exe`
- Added `.pap` gLTF import and export
- Added `.sklb` gLTF import and export
- Adjust `.sklb` gLTF export
- Fixed `.sklb` parsing issues
- Bone rotation now displayed as angles rather than quaternion
- Fixed issue with `/vfxedit` command not opening window
- Added UI for skeleton mappings
- UI tweaks