### PR TITLE
[Testing] Who's Talking 0.6.1.0

### DIFF
--- a/testing/live/WhosTalking/manifest.toml
+++ b/testing/live/WhosTalking/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/sersorrel/WhosTalking.git"
-commit = "ae8f485797a29992f153f57059ebc53a9d838a5b"
+commit = "901317182224055d3c2f0978c4265c6dc52b06e2"
 owners = ["sersorrel"]
 project_path = "WhosTalking"
 changelog = """\
-Added DelvUI support! (requires DelvUI 2.0.0.0)
+Added a setting to disable the voice activity indicators on the vanilla party list.
+This is probably quite useful for DelvUI users.
 """


### PR DESCRIPTION
apparently it's impossible to reliably figure out such things as "whether the party list is currently visible". thanks, square enix!

in light of this, here's an update to add a setting that just disables the voice activity indicators on the vanilla party list.