### PR TITLE
DelvUI release 2.0.2.1

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "e4593e376d02c145c19dad0f180b8212226abd06"
+commit = "2bf92bb3c5bfe49e30b47743f55613e1a7d88dea"
 owners = ["Tischel"]
 project_path = "DelvUI"

--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "2bf92bb3c5bfe49e30b47743f55613e1a7d88dea"
+commit = "1ab34b062bbff61aa592b4fc57a435a7c95a359f"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Invulnerability and Raise trackers now use a numeric label:
  * This means the amount of decimals shown can be now configured.

- Added "Change Labels Colors When Active" setting to Party Cooldowns Bars / Icons.
- Added "Show Effect Duration" and "Show Remaining Cooldown" to Party Cooldowns Time Labels.
- Fixed `-short` Text Tags not using the correct regional formatting.