### PR TITLE
[Testing] Tracky Track 0.0.7.0

### DIFF
--- a/testing/live/TrackyTrack/manifest.toml
+++ b/testing/live/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "bbcbfb8a3f5d0984aeebd11e03d41ab5ed6e6baa"
+commit = "cb4902afc8e6a0bed3eccc56ffbafe67bfa3483d"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[UI]
- New tab added, Retainer
- Retainer tab also includes venture coffers
- Add config option to disable retainer tracking

[Tracking]
- Add retainer venture tracking

> Note:
> This is primarily targeted at quick ventures, and isn't well tested with other types of ventures, especially ones that return multiple items