### PR TITLE
[Testing] Currency Tracker 1.1.1.3

### DIFF
--- a/testing/live/CurrencyTracker/manifest.toml
+++ b/testing/live/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "1256b4a9caa9b014035b5d20ca7333426d3fa51a"
+commit = "640b9bd524ab33f712bf71b7fdb91a87683af193"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
-changelog = "- Add a command /ct to open the main interface of the plugin.\n- Modified the way the data is displayed in the main interface of the plugin, so that filters can now be applied properly."
+changelog = "- Fix bugs that might cause game crashes.\n- Add a new command to open the main interface of the plugin with specific currency shown."


### PR DESCRIPTION
Changelog:
- Fix bugs that might cause game crashes.
- Add a new command to open the main interface of the plugin with specific currency shown.

I sincerely apologize for any game crashes might caused by the plugin.
While I must confirm that since its first release, the plugin has been running on my client for nearly a month without any instances of game crashes.
But Based on the feedback issue provided and the self-check of the code, I have completed a round of fixes. The plugin has also undergone a six-hour test with the interface open on my client, during which no game crashes were encountered.