### PR TITLE
Submarine Tracker 1.7.5.0

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "b0250c5fd61c73ac7beb9f169930056b11cf7b41"
+commit = "de2e1130d3a5a1a148bcc1157ca57ff1b6f18326"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "de2e1130d3a5a1a148bcc1157ca57ff1b6f18326"
+commit = "871cfdc19ac6045142a95af7c85f16a69ddb3ee1"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[Config > Builder]
- New option: Maximize Duration [True]
- New option: Show Route Overlay [True]
- New option: Highest Level [Rank 90]

[Builder]
- Maximize duration is now a persistent option
- Fixed a bug that set repair after voyages as value -1

**NEW** [Route Overlay]
- Only works with "Auto Select Current Submarine" enabled
- Shows best exp routes in an overlay that is attached to the Voyage Selection interface
- Works the same as Best EXP tab in builder

[Fix]
- Actually refresh the loot cache if sync is requested
- Refresh loot cache if another client had loot updates