### PR TITLE
[Testing] HUDManager 2.5.17.1

### DIFF
--- a/testing/live/HUDManager/manifest.toml
+++ b/testing/live/HUDManager/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/zacharied/FFXIV-Plugin-HudManager.git"
-commit = "a85881b406d802e5baf8425cf17e7d49898c2f62"
+commit = "6150a364099186424ca14ce5ebd862e143652f6b"
 owners = ["zacharied", "nebel"]
 project_path = "HUDManager"


### PR DESCRIPTION
**Fixes**
- Fixed a bug which prevented checking the "layer" checkbox before a swap condition was saved at least once.
- Fixed a bug which caused edited swap conditions to be saved even if the edit was discarded by hitting "X".
- Fixed a bug which prevented job gauge visibility from being applied properly.
