### PR TITLE
DeepDungeonTracker 1.0.0.3

### DIFF
--- a/stable/DeepDungeonTracker/manifest.toml
+++ b/stable/DeepDungeonTracker/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/marconsou/deep-dungeon-tracker.git"
-commit = "5b87e17b534c61e805706d28266f17deb713ba74"
+commit = "9680b66cd5a783d26398379c841d854019cc16c1"
 owners = ["marconsou"]
 project_path = "DeepDungeonTracker"
 changelog = """
+- Added [Score Window Kills] for HoH. Check General tab >>> Information section for more info.
 - The option [Improved Magicite Kills Detection] is enabled by default (always enabled for now).
 - The time for checking the [Time Bonus] was increased by 1 second. (from 30:01 to 30:02).
 - Small tweaks.


### PR DESCRIPTION
- Added [Score Window Kills] for HoH. Check General tab > Information section for more info.