### PR TITLE
VFXEditor v1.7.8.4

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "d36c8da808f9bb3c87bb24cb580c51770daf7411"
+commit = "1555f423b214eb139a78949bdb2e30fb4775e844"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Fix `.sklb` parsing
- Fix `.pap` import bug
- Add option to only export animated bones in `.pap` gLTF export
- Display unanimated bones in different color in `.pap` motion preview
- Fix issue when zooming too far into models
- Info on where to find loaded `.pap` files
- `.sklb` overlay
- Slight rework of "loaded files" tab
- UI tweaks
- Misc cleanup