### PR TITLE
DeathRecap 1.10.3.0

### DIFF
--- a/stable/DeathRecap/manifest.toml
+++ b/stable/DeathRecap/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-deathrecap.git"
-commit = "fc2fee682945e5b28544548b49b137448fb28993"
+commit = "303394e6707b9fc1159c1b73daab1277d9c57b18"
 owners = ["Kouzukii"]
 project_path = ""
 changelog = """
-Add BLU Bad Breath, Conked from Magic Hammer, and Candy Cane (new in 6.45) to the list of captures status effects. (Thanks xiashtra)
+Now uses the "System Message" chat type as default to avoid spamming all chat windows.
+Also fixed some chat types missing a space between player name and "has".
 """


### PR DESCRIPTION
Now uses the "System Message" chat type as default to avoid spamming all chat windows.
Also fixed some chat types missing a space between player name and "has".