### PR TITLE
XIVDupeFinder to 1.0.1.0 (stable)

### DIFF
--- a/stable/XIVDupeFinder/manifest.toml
+++ b/stable/XIVDupeFinder/manifest.toml
@@ -1,7 +1,13 @@
 [plugin]
 repository = "https://github.com/CallumCarmicheal/XIVDupeFinder.git"
-commit = "91e260eb2bdf72a8cb3a9960e3fcd44ff768d846"
+commit = "7c3653270265c4280dd5cc8e31de8d94650152f5"
 owners = ["CallumCarmicheal"]
 project_path = "XIVDupeFinder"
-changelog = """# XIVDupeFinder v1.0.0 Patch Notes
+changelog = """# XIVDupeFinder 1.0.1
+- Fixed hooks to stop plugin running when disabled / closed.
+- Fixed issue with highlighting always clearing when not enabled
+- Minor optimizations and code refactoring
+- Moving from Testing to Stable
+
+# XIVDupeFinder v1.0.0 Patch Notes
 Fixed ghosted items"""


### PR DESCRIPTION
Updating to latest commit, 1.0.1.0. Changing to stable (because I put it in the wrong folder, whoops).

- Fixed hooks to stop plugin running when disabled / closed.
- Fixed issue with highlighting always clearing when not enabled
- Minor optimizations and code refactoring
- Moving from Testing to Stable