### PR TITLE
[Testing] Currency Tracker 1.2.1.1

### DIFF
--- a/testing/live/CurrencyTracker/manifest.toml
+++ b/testing/live/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "2542ddba77bb67e9f2b7108c519da1ed04da0d30"
+commit = "85994e1afbedfcbccbf948af740e3673f443897d"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
 changelog = "- Please refer to my GitHub Changelog page."


### PR DESCRIPTION
- UI Adjustments:
  - Adjusted the display of the currency order adjustment button and the hide/restore currency button.
  - Rearranged the position of the "Records Per Page" input component, which is now displayed by clicking the current page number.
  - Reordered the display sequence of some buttons in the "Record Options" section.
- Fixed an issue in the "Merge Records" interface where selecting "One-Way Merge" after entering 0 as the threshold value but still displayed the error message "Please enter a threshold value."
- (English Only) Adjusted some text.