### PR TITLE
Transfer CurrencyAlert

### DIFF
--- a/stable/CurrencyAlert/manifest.toml
+++ b/stable/CurrencyAlert/manifest.toml
@@ -1,21 +1,5 @@
 [plugin]
-repository = "https://github.com/Lharz/xiv-currency-alert.git"
-commit = "1f5c326dfbc56b9e63ab588706c258fc4a1e6276"
-owners = ["Lharz"]
+repository = "https://github.com/MidoriKami/CurrencyAlert"
+commit = "f51155212736fb421fc7c74c3246d36cd0f42c1c"
+owners = ["MidoriKami", "Lharz"]
 project_path = "CurrencyAlert"
-changelog = """
-=== 0.5.0.1
-- FR, DE and JP translations
-=== 0.5.0.0
-Version provided by MidoriKami
-- Configuration remade and much more clean now
-- More configuration options (such as minimal display, window lock, etc)
-- Dynamic currency display, so further game updates shouldn't need a plugin update
-- Base code for translations (soon...)
-=== 0.4.0.0
-- Added new Tomestones of Causality
-- Added icons for currencies
-- Added an option to lock the alert window
-- Revamped the configuration UI a bit
-- Revamped the user configurations code internally, which unfortunately resulted in an inevitable configuration reset
-"""

--- a/stable/CurrencyAlert/manifest.toml
+++ b/stable/CurrencyAlert/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
-repository = "https://github.com/MidoriKami/CurrencyAlert"
+repository = "https://github.com/MidoriKami/CurrencyAlert.git"
 commit = "f51155212736fb421fc7c74c3246d36cd0f42c1c"
 owners = ["MidoriKami", "Lharz"]
 project_path = "CurrencyAlert"


### PR DESCRIPTION
nofranz

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/9083275/2629fd0d-43fd-4597-a5a3-e5ff750857eb)

There are no code changes from the currently available release. I will rework this plugin before patch 6.5 releases.

This PR just version bumps and transfers the code to my new repo.
