### PR TITLE
[Testing] StopTheClip 0.0.0.1

### DIFF
--- a/testing/live/StopTheClip/manifest.toml
+++ b/testing/live/StopTheClip/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/ProjectMimer/StopTheClip.git"
+commit = "d9fa5cdba243314869ae9b30c789a9599a8ab084"
+owners = ["ProjectMimer"]
+project_path = "StopTheClip"
+changelog = ""


### PR DESCRIPTION
Do you want to take close up screenshots? Are you a melee and hate having the boss model disappear on you? Then this is the plugin for you, it overrides the near clip and stops models from hiding on camera collision. This plugin is based on XIVR code.