### PR TITLE
[Testing] HUDManager 2.5.18.0

### DIFF
--- a/testing/live/HUDManager/manifest.toml
+++ b/testing/live/HUDManager/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/zacharied/FFXIV-Plugin-HudManager.git"
-commit = "6150a364099186424ca14ce5ebd862e143652f6b"
+commit = "907fc99b4dc18c09ee661bcb700221556133215e"
 owners = ["zacharied", "nebel"]
 project_path = "HUDManager"


### PR DESCRIPTION
Features

- Improve "add element" popup to highlight (and disable) elements already added
  to the layout, and add the ability to search for elements.
- Show job abbreviation after all job gauge names, hopefully making them
  easier to find.
- Save the slider speed setting to the configuration file, allowing it to
  persist after game restarts and plugin reloads.

Fixes

- Fixed an issue where the configuration UI and real swap state sometimes
  became desynced when editing an inactive layout and exiting the config UI or
  swapping config UI tabs.

Other

- Fixed and/or brought back the ability to set a fixed hotbar cycling number
  for Hotbar 1. This used to work, but broke when the fix for retaining the
  hotbar cycling state during swaps was added. So it's quite likely nobody even
  uses this feature. But anyway, it's now back as a new toggleable feature
  "Overwrite cycling state" in Hotbar 1's "Hotbar number" section. The "Hotbar
  number" section has also been removed entirely for all other hotbars except
  Hotbar 1, as it never worked for them in the first place.
- Changed swap logic to modify visibility for job gauge elements only when your
  job actually changes, and other minor performance improvements.
