### PR TITLE
DelvCD release 0.4.0.1

### DIFF
--- a/testing/live/DelvCD/manifest.toml
+++ b/testing/live/DelvCD/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvCD.git"
-commit = "02261ec37be9c9eae1515624aceb4ceb24d2b811"
+commit = "c08534cc9fcf1ed7bca649852c29c7d61da51824"
 owners = ["Tischel"]
 project_path = "DelvCD"


### PR DESCRIPTION
- Fixed Summoner's Garuda related conditions not working properly.