### PR TITLE
SubmarineTracker 1.7.7.0

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "38add178b97f54bb25e085660d61a6734dbfa923"
+commit = "913cddc092df7f8b755a650fa4a5eff207f215fc"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "2f57a299165a8ec40ee5398c7e2ce18fbbf05777"
+commit = "274a7a5ca234ebb92fd0eafa369cfcee12d694b0"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "913cddc092df7f8b755a650fa4a5eff207f215fc"
+commit = "999607421dd12acaf3b22d0cf819469ad72fb42c"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "4439bbd39199c19f28d18efef23cdc60fcf39cad"
+commit = "742113cd9e7c12c9c8b92d5d3eb631cbdad154b7"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "274a7a5ca234ebb92fd0eafa369cfcee12d694b0"
+commit = "38add178b97f54bb25e085660d61a6734dbfa923"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "742113cd9e7c12c9c8b92d5d3eb631cbdad154b7"
+commit = "90ddef74c16eca2f57025321a9c9a4bc99716222"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "999607421dd12acaf3b22d0cf819469ad72fb42c"
+commit = "4439bbd39199c19f28d18efef23cdc60fcf39cad"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[Config]
- New Tab: Upload
- Option to auto include next main sector

[Builder > Best EXP]
- Custom duration support
- Fixed a bug that prevented automatic recalculation

[Route Overlay]
- Custom duration support
- Option to auto include next main sector
- Enabled automatic recalculation

[Unlock Overlay]
- Only show secondary branches

[Webhook]
- Use a timestamp for returned submarines

[Calculations]
- Removed unnecessary calculations, increased performance

**New [Upload]**
- Upload new loot entries
- Implemented a first time upload of existing loot data
  - The upload won't happen until the user received the notification + extra time

Note for PAC:
<https://canary.discord.com/channels/581875019861328007/653504487352303619/1154149570897510450>
Shipping my own newtonsoft dll because supabase requires it and it is clashing with the dalamud internal version if i try to use it