### PR TITLE
SubmarineTracker 1.7.7.7

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "56ef6ca4a53b87d4a7d170f19d7da55aa386073c"
+commit = "72985f7aadc9de818b1baa8aa06d7ed44afc716e"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "053067cf56be26cd596225fbca416d859f036eb1"
+commit = "e1f2aa4c2dbd41a028a0cc6565de575032d90014"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "90ddef74c16eca2f57025321a9c9a4bc99716222"
+commit = "56ef6ca4a53b87d4a7d170f19d7da55aa386073c"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "e1f2aa4c2dbd41a028a0cc6565de575032d90014"
+commit = "ab8f6e2a5a907d3bb2ffbcfb7129c85a5be75b2b"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "72985f7aadc9de818b1baa8aa06d7ed44afc716e"
+commit = "053067cf56be26cd596225fbca416d859f036eb1"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[Builder > Leveling]
- Include avg bonus exp option
- Maybe fix "Ignore Unlocks" not working
- Add support for custom duration
- Cleanup the UI
- Pick the lowest duration for same exp routes

[Loot]
- Adjust favor wording
- Add FC name to all submarines
- Improved performance of voyage history
  - Seeing an entry with date 01/01/0001 is normal, gets fixed the next time this submarine returns

[Config]
- Show the menu gear icon in the lower bar

[Tracker]
- Fix date showing incorrectly for date option

[Menu]
- Added button for discord thread, github issues, and ko-fi tips

[Discord & Spreadsheet]
- Switched from submarine builder to overseas casuals discord as recommendation
- Replaced all old spreadsheet mentions with the new improved spreadsheet

[Internal]
- Rework loot tracking, making it more robust against patch downtime