### PR TITLE
VFXEditor v1.7.9.1

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "7eff7b6c8404c02ed2a38c952e592b1692aa1009"
+commit = "8a4d972807b764826085a28fec4f8e4e15a8fc77"
 owners = [
     "0ceal0t",
 ]

--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "8a4d972807b764826085a28fec4f8e4e15a8fc77"
+commit = "578d66432d7a6dec5227223da80d7e16bbd10471"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- API9 prep
- Added _Actions_ tab to `.scd` selector
- Added `.shpk` editor (still WIP)
- Fixed bug with `.pap` motion preview looping
- Properly support `.gltf` meshes with multiple primitives
- Added `.eid` skeleton view
- Added vfx and sound preview next to path input (such as in `C012`)
- Fixed issue with previewing non type-0 `.pap` files
- Refactoring and UI tweaks