### PR TITLE
XIVDeck 0.3.16

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "b7774a11a7aa6a0b975839c65e8036b170dc4774"
+commit = "cca5a774ab3a739cc5e2f89b4e42171be1a805b0"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
With the light of a new adventure growing on the horizon, it's worth taking a look back at the path we walked to get to what we once thought was the end. Let us set the stage for the next journey, bravely venturing forth into API version 9.

* Update the plugin to support FFXIV Patch 6.5 and Dalamud version 9.
* Switch around some action execution logic to be more reliable, especially for non-EN clients.
* Fix a bug with HQ icons not loading properly in some cases.
* Add some help text for the Classes button explaining how it works.

Because this patch does target Dalamud 9.0 and Patch 6.5, there may be a couple rough edges in some lesser-used features. I have tested what I could, but please don't hesitate to [reach out in Discord](https://discord.com/channels/581875019861328007/1019648519226806323) if you see something not working right!

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.16).
