### PR TITLE
MemoryMarker v1.1.0.0

### DIFF
--- a/stable/MemoryMarker/manifest.toml
+++ b/stable/MemoryMarker/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/MemoryMarker.git"
-commit = "03027a8228b2d9c5b29ba077dd922411a9bc166c"
+commit = "a08908dfb8bddcf27ef1cf094d1e0642d4de5b9c"
 owners = ["MidoriKami"]
 project_path = "MemoryMarker"


### PR DESCRIPTION
Update for Patch 6.5 / Dalamud API9

Rebuilt logic, much simpler, more efficient, more reliable.
No longer clears waymarks when leaving a zone.
Labels will only show if you are in the correct zone for the markers.