### PR TITLE
DelvCD release 0.5.0.0

### DIFF
--- a/testing/live/DelvCD/manifest.toml
+++ b/testing/live/DelvCD/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvCD.git"
-commit = "c08534cc9fcf1ed7bca649852c29c7d61da51824"
+commit = "c753a6698edf86be945011879bc85d7e52825241"
 owners = ["Tischel"]
 project_path = "DelvCD"


### PR DESCRIPTION
- Added support for patch 6.5 and Dalamud API 9.
- Added new trigger condition for Red Mage's Job Gauge that compares White and Black Mana.