### PR TITLE
GatherBuddy 3.3.0.0

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "0a5a32069aa28d4d944a84d5708a2ea93fa8e669"
+commit = "6442bcdb05a1630aac82de221cc2b11b5b81305e"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Update for 6.5 and API 9
- Add preliminary 6.5 fish data.