### PR TITLE
PlayerTrack V3.1.0

### DIFF
--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -2,9 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "78a305d04d2e55d239e81ee7bf42c1141ecfe4f9"
-[plugin]
-repository = "https://github.com/kalilistic/PlayerTrack.git"
-owners = [ "kalilistic" ]
-project_path = "PlayerTrack.Plugin"
 commit = "15296c52d61b3f5c7ecf193d8233484ab5811df2"

--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -3,3 +3,8 @@ repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
 commit = "78a305d04d2e55d239e81ee7bf42c1141ecfe4f9"
+[plugin]
+repository = "https://github.com/kalilistic/PlayerTrack.git"
+owners = [ "kalilistic" ]
+project_path = "PlayerTrack.Plugin"
+commit = "15296c52d61b3f5c7ecf193d8233484ab5811df2"


### PR DESCRIPTION
- Update for Patch 6.5 / Dalamud API 9
- Change to keep config window closed by default (toggle)
- Change the design of the category settings window
- Add extra check to avoid some migration errors (hopefully)
- Fix migration to carry over Visibility Type (i.e. Void/White List)
- Fix frame drops and selection issues with the color picker
- Fix certain dalamud styles causing icons to cut off on the list

Note: Just this past weekend, I released a major update with nameplates and other backend changes. If you're concerned about bugs or nervous about restoring a backup, it's probably best to wait. This update will be in the main version soon. Read the previous change log for the full details.