### PR TITLE
[API9] TargetLines 1.3.1.0

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,14 +1,11 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "f135a3b9d8ffb526af9dd65451b936e28a9536db"
+commit = "bb267f59c18f69ce97b884752854d4629deec258"
 owners = ["Drahsid"]
 project_path = ""
-changelog = """1.2.7
-- Improved the rendering of fancy lines, now they should look less looney when they clip the camera
-- Improved visibility logic
-- Improved logic relating to intangible game objects (ghost lines should no longer appear)
-- Set default sample count for fancy lines to an odd number (should give the line a middle point with the default config)
-- Made visibility check on Game Objects less aggresive
-- Introduced a regression, where the sample count for lines is only applied when the line is constructed
+changelog = """
+- Updated for 6.5
+- Updated for API9
+- Minor fixes
 """
 

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "bb267f59c18f69ce97b884752854d4629deec258"
+commit = "e9424055b8afd9555502f4539461cb022c78eaab"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "e9424055b8afd9555502f4539461cb022c78eaab"
+commit = "5c4e038244cc6d9543f809d8c8cac30019f37f8f"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/Drahsid/TargetLines.git"
 commit = "bb267f59c18f69ce97b884752854d4629deec258"
 owners = ["Drahsid"]
-project_path = ""
+project_path = "TargetLines"
 changelog = """
 - Updated for 6.5
 - Updated for API9


### PR DESCRIPTION
Pretty much another API9 update. Changed some minor behavior which should make occlusion more consistent, and besides that, possible optimizations in TargetLine.