### PR TITLE
Teleporter 2.0.2.3

### DIFF
--- a/stable/TeleporterPlugin/manifest.toml
+++ b/stable/TeleporterPlugin/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/pohky/TeleporterPlugin.git"
-commit = "1e99de1c94d3394be6c88478e0cb27e83c44124b"
+commit = "f9f3b40e75fe00e6a424ab756990ca93b86acd41"
 owners = ["pohky"]
 project_path = "TeleporterPlugin"


### PR DESCRIPTION
- fix error message caused by trying to unregister the command before registering it (not an actual error, just a log message)