### PR TITLE
VFXEditor v1.8.0.1

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "7eff7b6c8404c02ed2a38c952e592b1692aa1009"
+commit = "fb9f0b03d0b6a3cb7899ac8fc9bb36032e9f6117"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- API9 + 6.5
- Added missing/new `.avfx` fields
- Fixed `.avfx` verification bug
- Added "Import missing textures" dialog
- Added async workspace loading
- Added recent workspaces menu item
- Added Actions tab to `.scd` selector
- Added `.shpk` editor (still WIP)
- Fixed bug with `.pap` motion preview looping
- Properly support `.gltf` meshes with multiple primitives
- Added `.eid` skeleton view
- Added vfx and sound preview next to path input (such as in `C012`)
- Fixed issue with previewing non type-0 `.pap` files
- Refactoring and UI tweaks