### PR TITLE
Market Board 1.3.2

### DIFF
--- a/stable/MarketBoardPlugin/manifest.toml
+++ b/stable/MarketBoardPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/fmauNeko/MarketBoardPlugin.git"
-commit = "c9a5086f09b25fbc7b5a032164bf3edb0e3bad72"
+commit = "a62d3cc79937c2d71b87315676504866b689993c"
 owners = ["fmauNeko"]
 project_path = "MarketBoardPlugin"
-changelog = "- Update for 6.5 / API 9"
+changelog = "- Now the shopping list will stay open as long as it has item stored even if the main window is closed.\n- Added the option to show prices without the Gil Sale Tax"


### PR DESCRIPTION
- Now the shopping list will stay open as long as it has item stored even if the main window is closed.
- Added the option to show prices without the Gil Sale Tax