### PR TITLE
[Testing] Update FCNameColor to 4.0.0.0

### DIFF
--- a/testing/live/FCNameColor/manifest.toml
+++ b/testing/live/FCNameColor/manifest.toml
@@ -1,8 +1,14 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "6d57f2206b9d0090f6222ff9da2993fdb544bd74"
+commit = "64195a25f28d2217c7325f06e75fe7a95a2b2176"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
-- Update for 6.4
+- Update for 6.5
+- Reworked configuration to reduce config size
+- Add ignore friends option
+- Add ability to change the group for the player's own FC
+- Allowed for additional FC list to scale for longer lists
+- Wrote migration from old config to new config
+- Switched over to new method of doing the nameplates, this should alleviate issues with name abbreviation settings
 """

--- a/testing/live/FCNameColor/manifest.toml
+++ b/testing/live/FCNameColor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "64195a25f28d2217c7325f06e75fe7a95a2b2176"
+commit = "315f8b929b38e38c769ec4d31645accf3cea0c08"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """


### PR DESCRIPTION
- Update for 6.5
- Reworked configuration to reduce config size
- Add ignore friends option
- Add ability to change the group for the player's own FC
- Allowed for additional FC list to scale for longer lists
- Wrote migration from old config to new config
- Switched over to new method of doing the nameplates, this should alleviate issues with name abbreviation settings