### PR TITLE
Mappy v1.0.4.2

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "e39f34c9fc47b54f3982c716932ecd6751c7af0b"
+commit = "beaace936bf8930554b848f0a3ae789b18870c9a"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Use alternative system for QuestLinkMarkers, they will now only show if you are in the same map as the marker.