### PR TITLE
[Testing] PlayerTrack

### DIFF
--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "447f4f3739dbecb8918783240e2db61aa30a5b13"
+commit = "b44ec2958f2a5b0195e5d479f75223a734059b26"


### PR DESCRIPTION
- Fix the issue where the window would keep getting bigger on non-default global scales.
- Move backups to %appdata%\XIVLauncher\playerTrackBackups to avoid them being deleted with config data.
- Fix the issue where notes weren't saving.
- Add the ability to show warnings in the migration window.
- Attempt to migrate older or unrecognized versions of litedb instead of failing immediately.
- Warn and skip if can't clean up old backups instead of failing immediately.
- Warn and skip up to 10 players if run into errors instead of failing immediately.
- Fix back-end ci issue with toml.