### PR TITLE
BatteryGauge 1.1.0

### DIFF
--- a/stable/BatteryGauge/manifest.toml
+++ b/stable/BatteryGauge/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVBatteryGauge.git"
-commit = "5361d42f04e1ab5de23198da13bb1b6a5cd52e9a"
+commit = "79d652029ac17473e52e12d605e0b48c6bd32c99"
 owners = ["KazWolfe"]
 project_path = "BatteryGauge"


### PR DESCRIPTION
This plugin wasn't supposed to *need* updates! It was meant to be a simple and easy to use demo that I could ignore! Anyways, new features are cool.

- Update to support Dalamud API 9.
- Add a tooltip to the Server Info Bar entry for *all the infos*.

Thank you to Kurochi for doing the actual work!