### PR TITLE
VFXEditor v1.8.0.4

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "03fe387b535edda55a85bf46ab51adae62d379bb"
+commit = "8442922d662bb699a72f54c309270a7061d90068"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Fix bug with replaced texture preview not displaying properly
- Add `.shpk` material parameter view
- Fix overlay being broken
- Fix multi-monitor support
- Support adding and removing `.sklb` mappings
- Force lowercase paths for sound paths in `avfx` emitter and `C063`
- Misc clean up