### PR TITLE
TrackyTrack 1.2.0.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "4fb86e3cfa86b3ce50750e04d2c4ea07b895ac8f"
+commit = "8387e1ccab90c9bdedff7666072396a480f2bfbb"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[Fixes]
- Fix a bug that would lead to sanctuary box contents being stored as grand company box

[Upload]
- Implement upload for coffer data
  - A warning will be send whenever the user logs in
  - After the warning a 1 hour period is given for the user to opt out of any upload
  - (Exact same system that submarine tracker uses)