### PR TITLE
TrackyTrack 1.3.0.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "aef8194b1d9c8f17b35df5bfdabc84b9c0aee43b"
+commit = "721dca6c9d3fe4446208634011d77e9474c6ef10"
 owners = [
     "Infiziert90",
 ]

--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "8387e1ccab90c9bdedff7666072396a480f2bfbb"
+commit = "a9a9bd35f42edbaeab5f0fab9a903ec237155ad8"
 owners = [
     "Infiziert90",
 ]

--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "a9a9bd35f42edbaeab5f0fab9a903ec237155ad8"
+commit = "aef8194b1d9c8f17b35df5bfdabc84b9c0aee43b"
 owners = [
     "Infiziert90",
 ]

--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "721dca6c9d3fe4446208634011d77e9474c6ef10"
+commit = "42803c818747bb98cf389a6759bd9ea9f52a016f"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
[New]
- Eureka/Bozja Lockbox tracking
  - This is also regarded as upload worthy data, you can opt-out at any time

[Important]
- This update resets the island sanctuary gacha history
  - A bug filled the list with fake amounts, so a reset was the only solution

