### PR TITLE
XIVLogger 1.0.5.0

### DIFF
--- a/stable/XIVLogger/manifest.toml
+++ b/stable/XIVLogger/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/XIVLogger.git"
-commit = "cc698793b52f6ca313fbd1fa5a06fec27526cda2"
+commit = "723e641cd457b6fd1071ecab7faf585e3d00b1a4"
 owners = [
   "cadaeix",
   "Infiziert90"


### PR DESCRIPTION
- Swap from old UI to Windows
- Fix autosave not working after login/world travel
- Autosave filename are now set on login, preventing weirdness from saving configs
- Autosave minute selection is now stepping 1 each time instead of 64
- Redo the login/logout logic, which should prevent more weirdness
- Added about tab, if there is any issues visit it for the discord thread link

Note:
The autosave fix affects the existing behaviour of "static" filenames, this wasn't intended and was causing a lot of problems.
With this update autosave files are unique to your login/logout, sorry if someone relied on the old behaviour.

