### PR TITLE
Pet Nicknames v1.4.2.2

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,8 +1,14 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "d4cba4f3d24519fcc1f4e59f161bc4bf547d5e07"
+commit = "9419ee8b70ed4b4bbd374b8f2847bdf9c44de7d6"
 owners = ["Glyceri",]
 	changelog = """
-    + [1.4.0.2]
-    + Fixed Map Pet Tooltips not working. (By completely removing the feature and reimplementing it later down the line when it actually fully functions and works).
+    + [1.4.2.2]
+    + Custom names will show up on Esteem again.
+    + [1.4.2.1]
+    + Fixed a bug where Legacy Compatibily would only trigger once.
+    + [1.4.2.0]
+    + Every different Battle Pet model can now be assigned a name. No more naming per Job.
+    + You can no longer see names on models that are Human. Sorry to those that enjoyed this feature, but it is problematic :(
+    + Save File Version Updated from Version 7 to Version 8.
 """


### PR DESCRIPTION
 Exact same push as is currently active on Testing. It's the same commit SHA.

    + [1.4.2.2]
    + Custom names will show up on Esteem again.
    + [1.4.2.1]
    + Fixed a bug where Legacy Compatibily would only trigger once.
    + [1.4.2.0]
    + Every different Battle Pet model can now be assigned a name. No more naming per Job.
    + You can no longer see names on models that are Human. Sorry to those that enjoyed this feature, but it is problematic :(
    + Save File Version Updated from Version 7 to Version 8.
