### PR TITLE
[Testing] Update FCNameColor to 4.0.0.1

### DIFF
--- a/testing/live/FCNameColor/manifest.toml
+++ b/testing/live/FCNameColor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "315f8b929b38e38c769ec4d31645accf3cea0c08"
+commit = "9df61370a508fe6b3010aca932d5d2c4cb0c3bb4"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
@@ -11,4 +11,7 @@ changelog = """
 - Allowed for additional FC list to scale for longer lists
 - Wrote migration from old config to new config
 - Switched over to new method of doing the nameplates, this should alleviate issues with name abbreviation settings
+- Add additional logic for ensuring a group always exists
+  This should alleviate some of the crashing issues.
+- Made it so that opening the config with /fcnc or through the plugin installer toggles the config on and off
 """


### PR DESCRIPTION
- Add additional logic for ensuring a group always exists This should alleviate some of the crashing issues.
- Made it so that opening the config with /fcnc or through the plugin installer toggles the config on and off

Please contact `cfg` on Discord if you run into more crash issues.