### PR TITLE
VFXEditor v1.8.0.5

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "8442922d662bb699a72f54c309270a7061d90068"
+commit = "013ffe24401100fe760e1e89436aecda47c5192b"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Added model cube and reset button
- Hopefully fixed occasional crashes when saving workspace
- Refactored model preview rendering
- Fixed issue with VFX emitters not rotating properly in preview
- Added texture import cog menu
- Fixed sub-windows not being hidden when window is collapsed
- Allow previewing of custom sound paths
- Fixed issues when replacing 5551 textures (like icons) in TexTools mods
- UI tweaks
- Added option to split VFX "Spawn" button in Selection dialog into _"Self"_ and _"Ground"_