### PR TITLE
SubmarineTracker 1.8.1.3

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "5317dde6d1c67234a89e7a1c51ba4146afa84e4d"
+commit = "0a230683d44c0aa52a5d5c8e40378b996352b71f"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Add 1, 3, 5 days for date limit selection
- Add an option to automatically close the overlay, and hold closed