### PR TITLE
Wholist v1.4.1.0

### DIFF
--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "d2e2761ca23e0dc8a887d8c6c32d15b190a62bfd"
+commit = "a195dfff914d716091e87782378d6f531e44491f"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
## Fixes
- Local player showing up on the list when not intended to.
- A crash that could occur when attempting to obtain distance information about a player.