### PR TITLE
Update Chat 2 to 1.18.10

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = 'https://git.anna.lgbt/anna/ChatTwo.git'
-commit = '5094e70e7e7d6c6e92acde3ac2e35baa6ad41469'
+commit = '1ab389256b65de58f995a86229af194ea5527d2e'
 owners = [ 'lojewalo' ]
 changelog = """\
-- API 9
+- Fix issue with Dalamud custom link payloads
 """


### PR DESCRIPTION
Fix custom payload links and use new PluginLog service