### PR TITLE
Tracky Track 1.3.0.4

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "dc415b499c442f5bb09e64a6e7801aa8adc2c7b3"
+commit = "d5d41063922dc8105ac9efac5f9eda2f57d96f82"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Also track discarded lockbox/logogram/.... items
- Increase timer for eureka bunny chests, this should help with high ping not being tracked