### PR TITLE
[Testing] JustBackup 1.1.0.4

### DIFF
--- a/testing/live/JustBackup/manifest.toml
+++ b/testing/live/JustBackup/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/JustBackup.git"
 # The commit to check out and build from the repository.
-commit = "122910a16f8b88228e80634641eff37eec310db6"
+commit = "ff7c21cb92293f5f254270f45f6cf4e8ebe86748"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"


### PR DESCRIPTION
- Slightly reworked gui
- Fixed temp files not always getting deleted
- Added an option to redefine temp path for files
- Now default amount of CPU threads will be 1/4 of all available rather than 1
- Added an option to restrict maximum amount of threads plugin can use
- Added an option to throttle copying, reducing disk load during backup
- Added an option to enable short backup cooldown limited by 60 minutes. After a successful backups, no backups will be created within specified amount of time, useful when you restart the game very often. You can still do the backup manually with `/justbackup` command.