### PR TITLE
[Testing] Craftimizer 1.9.0.2

### DIFF
--- a/testing/live/Craftimizer/manifest.toml
+++ b/testing/live/Craftimizer/manifest.toml
@@ -1,11 +1,17 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/craftimizer.git"
-commit = "39e95305af9808bf9b667d1c8e81ac0e888f8f7f"
+commit = "60a939e023f312dbd5af9c6751b60c0a737e739d"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"
-changelog = """Release 1.9.0.1
+changelog = """Release 1.9.0.2
+Quite minor, nothing too new.
 
-- API 9
-- Huge sweeping UI changes
-- Some features have been disabled in order to get this update out in a (relatively) timely manner.
+New Features:
+- Warning when Macro Chain isn't installed/enabled
+- Added an option to create a shorter macro even if it might not have a notification sound (on by default)
+
+Fixed Bugs:
+- Esc key breaks crafting log window
+- Copying from clipboard to game macros
+- Macro Chain setting does nothing
 """


### PR DESCRIPTION
Small bug fixes and a few macro related updates.

New Features:
- Warning when Macro Chain isn't installed/enabled
- Added an option to create a shorter macro even if it might not have a notification sound (on by default)

Fixed Bugs:
- Esc key breaks crafting log window
- Copying from clipboard to game macros
- Macro Chain setting does nothing