### PR TITLE
Resizable HUD 1.2.1.0

### DIFF
--- a/stable/ResizableHUD/manifest.toml
+++ b/stable/ResizableHUD/manifest.toml
@@ -1,9 +1,8 @@
 [plugin]
 repository = "https://github.com/Drahsid/ResizableHUD.git"
-commit = "01d0da4d1450ab9059c4a67b025a906a1968aa13"
+commit = "ff6fc8e7ca349fa342a845f9bb6598197689de90"
 owners = ["Drahsid"]
 project_path = "ResizableHUD"
 changelog = """
-- Updated for 6.5
-- Updated for API9
+- Fixed issue causing addon inspector to not render
 """

--- a/stable/ResizableHUD/manifest.toml
+++ b/stable/ResizableHUD/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/ResizableHUD.git"
-commit = "ff6fc8e7ca349fa342a845f9bb6598197689de90"
+commit = "cec39d4644df075c5ae4e6929272f8ed53f34352"
 owners = ["Drahsid"]
 project_path = "ResizableHUD"
 changelog = """


### PR DESCRIPTION
I fixed an issue which was causing my addon inspector/editor to stop working. The old method I used was pointing into bogus memory after a recent Dalamud update.