### PR TITLE
[Testing] rtyping 0.1.0.0

### DIFF
--- a/testing/live/rtyping/manifest.toml
+++ b/testing/live/rtyping/manifest.toml
@@ -1,8 +1,13 @@
 [plugin]
 repository = "https://github.com/apetih/rtyping.git"
-commit = "21942bdf922976c2c8c31131cb02299243e7500e"
+commit = "41218f912da1dac2d497ce5ea45807efd7e4b67a"
 owners = ["apetih"]
 project_path = "client/rtyping"
 changelog = """
-- Update for 6.5
+- Rewritten Websocket client to make future new feature(s) easier to implement.
+- Moved some items around in the configuration window.
+- Added server Connect/Disconnect button to configuration window.
+- Added window inside Trusted Characters list for adding party member characters to the list.
+- Changed Typing detection. It now requires active typing, and expires after a prolonged idle period.
+- Added somewhat of an IPC provider.
 """


### PR DESCRIPTION
Moved around a considerable amount of code. 

Changed Websocket Server/Client to use Socket.IO since it helped make my implementation cleaner and allows for easier addition or modification of features.
Moved most of the actual logic outside of the draw function.
Modified Typing detection to actually detect typing instead of just the blinking chat cursor, and made the typing status expire after a while of non-active typing, to make it _actually_ reflect typing status.
Lastly, added some IPC provider, unsure how used or useful it'll be, but it's there. If there's any issues or changes needed to make it work correctly or to work with specific cases, can let me know.

Since the server changed quite a bit, currently running a second server on a different port for this new version, hence the port change on the client, as to not disrupt the current version from working. Will turn off the older server instance if and when this update gets pushed, and will revert back to the original port at some later time.

If nothing breaks for a while, might finally push this to stable at some point in the future too.