### PR TITLE
DeepDungeonDex 2.8.1

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "2372b2e0e84f1c779b98ac3bf718af01f5906c70"
-changelog = "## 2.8.0 (2023-10-03)\n\n\n### Features\n\n* api 9 update (cf32904)"
-version = "2.8.0"
+commit = "89874997292bdf8606283addc9d831f24fdbf181"
+changelog = "### 2.8.1 (2023-10-28)\n\n\n### Bug Fixes\n\n* change config saving to help stop config corruption (c7ccc68)\n* loading all fonts after plugin was loaded potentially crashing (d00ae2b)\n* windows sizes being wrong due to font scaling (aae6e6a)"
+version = "2.8.1"


### PR DESCRIPTION
### 2.8.1 (2023-10-28)


### Bug Fixes

* change config saving to help stop config corruption (c7ccc68)
* loading all fonts after plugin was loaded potentially crashing (d00ae2b)
* windows sizes being wrong due to font scaling (aae6e6a)