### PR TITLE
Snooper 1.2.1.1

### DIFF
--- a/stable/Snooper/manifest.toml
+++ b/stable/Snooper/manifest.toml
@@ -1,20 +1,10 @@
 [plugin]
 repository = "https://github.com/Maia-Everett/dalamud-snooper.git"
-commit = "6fb2273f9d4fa665dc83f8e9e446fda747493f0f"
+commit = "bdd2eccde81985019508604851b0229c5df4f19f"
 owners = ["Maia-Everett"]
 project_path = "Snooper"
-version = "1.2.0.0"
+version = "1.2.1.0"
 changelog = """
-Changelog from 1.1.0.0 (testing) to 1.2.0.0:
-* New feature: Chat logs are loaded from disk and persist between plugin and game restarts.
-* New feature: It is now possible to choose between local time and server time for timestamps. Default is now server time. On disk, logs are always written in server time.
-* Outgoing tells are now properly displayed in both the sender log and the receiver log.
-
-Changelog from 1.0.0.0 (stable) to 1.1.0.0:
-* New feature: Chat logs are now saved to My Documents/Snooper Logs by default (can be disabled or changed). (#8, #17)
-* New feature: Chat logs can now be copied to clipboard from Snooper windows. (#17)
-* The "+" button for the main window has been moved to the bottom toolbar to save space.
-* The bottom toolbar for the main window now includes a button to open plugin settings.
-* Fixed a bug where your own party messages were not displayed in Snooper windows including you. (#5)
-* Fixed a bug with settings not saving (#7).
+* Snooper will no longer play a sound when you send a tell. This was never intended. (#18)
+* If saving logs to disk is disabled, Snooper will no longer load already existing logs from disk.
 """

--- a/stable/Snooper/manifest.toml
+++ b/stable/Snooper/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Maia-Everett/dalamud-snooper.git"
-commit = "bdd2eccde81985019508604851b0229c5df4f19f"
+commit = "a0fa7be17b3e9645818b5f06ad42adc98d3c4d5d"
 owners = ["Maia-Everett"]
 project_path = "Snooper"
-version = "1.2.1.0"
+version = "1.2.1.1"
 changelog = """
 * Snooper will no longer play a sound when you send a tell. This was never intended. (#18)
 * If saving logs to disk is disabled, Snooper will no longer load already existing logs from disk.
+* Reduced plugin log spam, fixing an issue where exception stack traces were logged for normal operation.
 """


### PR DESCRIPTION
* Snooper will no longer play a sound when you send a tell. This was never intended. ([#18](https://github.com/Maia-Everett/dalamud-snooper/issues/18))
* If saving logs to disk is disabled, Snooper will no longer load already existing logs from disk.
* Reduced plugin log spam, fixing an issue where exception stack traces were logged for normal operation.