### PR TITLE
[Testing] Pet Nicknames v1.4.3.3

### DIFF
--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "f3e4221da301447a27702cf5de4d0128dfb310de"
+commit = "933412fb5d3d9ed24c68446638d543f42f8ef6c6"
 owners = ["Glyceri",]
 	changelog = """
     + [1.4.3.3]

--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "933412fb5d3d9ed24c68446638d543f42f8ef6c6"
+commit = "a3eba10c310f6241223db67c9088d79e88160114"
 owners = ["Glyceri",]
 	changelog = """
     + [1.4.3.3]

--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "a3eba10c310f6241223db67c9088d79e88160114"
+commit = "02c56f4f3ab9e0459370607e5f1e57c22bd533dc"
 owners = ["Glyceri",]
 	changelog = """
     + [1.4.3.3]
     + Fixed an issue where people with a dash '-' in their name could not use the plugin properly.
     + A warning will now be displayed when you enter a PVP area and the plugin disables itself.
+    + Fixed an IPC issue.
 """

--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,11 +1,9 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "f11a1122529902849bdb334e8c920d5a50fa826c"
+commit = "f3e4221da301447a27702cf5de4d0128dfb310de"
 owners = ["Glyceri",]
 	changelog = """
-    + [1.4.3.2]
-    + Proper IPC Endpoints
-    + Removed dependancy on ... for nameplate redraws
-    + Complete rewrite of the petlist
-    + Added a Ko-fi Button
+    + [1.4.3.3]
+    + Fixed an issue where people with a dash '-' in their name could not use the plugin properly.
+    + A warning will now be displayed when you enter a PVP area and the plugin disables itself.
 """


### PR DESCRIPTION
    + Fixed an issue where people with a dash '-' in their name could not use the plugin properly.
    + A warning will now be displayed when you enter a PVP area and the plugin disables itself.