### PR TITLE
DelvCD release 0.5.2.0

### DIFF
--- a/testing/live/DelvCD/manifest.toml
+++ b/testing/live/DelvCD/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvCD.git"
-commit = "87f20c3a729bb0b0b4f155fcdcd841b5ae9ff94b"
+commit = "6ce241ad98ed9c4661b2ffb82ce64b083eb61481"
 owners = ["Tischel"]
 project_path = "DelvCD"


### PR DESCRIPTION
- Added Source Type for Status Triggers:
  * This allows to make triggers that only work on enemies or allies.

- Added option to configure HP, MP, CP and GP triggers with percentages instead of raw values.

- Fixed Monk's Master Gauge Chakra not working correctly:
  * Opo-opo and Raptor chakras were inverted.

- Fixed the Conditions tab sometimes not rendering properly.