### PR TITLE
DeepDungeonDex 2.8.2

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "89874997292bdf8606283addc9d831f24fdbf181"
-changelog = "### 2.8.1 (2023-10-28)\n\n\n### Bug Fixes\n\n* change config saving to help stop config corruption (c7ccc68)\n* loading all fonts after plugin was loaded potentially crashing (d00ae2b)\n* windows sizes being wrong due to font scaling (aae6e6a)"
-version = "2.8.1"
+commit = "58a33ce0d16cf31afcf6e6b045bcc81c89a67f49"
+changelog = "### 2.8.2 (2023-11-10)\n\n\n### Bug Fixes\n\n* implement better font loading code to allow for all characters (beaf540)\n* recalculate mob notes if size has changed (ec122a1)\n* remove some config options that no longer affects display (8d83f5b)\n* transition MobData local storage to binary and safer save logic (89a0a1f)"
+version = "2.8.2"


### PR DESCRIPTION
### 2.8.2 (2023-11-10)


### Bug Fixes

* implement better font loading code to allow for all characters (beaf540)
* recalculate mob notes if size has changed (ec122a1)
* remove some config options that no longer affects display (8d83f5b)
* transition MobData local storage to binary and safer save logic (89a0a1f)