### PR TITLE
Honorific 1.3.1.0

### DIFF
--- a/stable/Honorific/manifest.toml
+++ b/stable/Honorific/manifest.toml
@@ -1,4 +1,4 @@
 [plugin]
 repository = "https://github.com/Caraxi/Honorific.git"
 owners = [ "Caraxi" ]
-commit = "2a65d2a9d635842a6c786f1d090f5a69488e3995"
+commit = "86bddbf05fbe3db8cbbe8ce7e4a6820d064b7cb3"


### PR DESCRIPTION
Added a command to apply titles

A title set by command will override all other configured titles until it is cleared.

Examples:
`/honorific force set New Title` - Set title to suffix of "New Title" with no colour or glow.
`/honorific force set New Title | prefix` - Set title to prefix of "New Title" with no colour or glow.
`/honorific force set New Title | #ff0000` - Set title to suffix of "New Title" in red with no glow.
`/honorific force set New Title | prefix | #ff0000 | #00ffff` - Set title to prefix of "New Title" in red with an aqua glow.
`/honorific force clear` - Clears title set by command. 
