### PR TITLE
[Testing] Craftimizer 1.9.5.0

### DIFF
--- a/testing/live/Craftimizer/manifest.toml
+++ b/testing/live/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/craftimizer.git"
-commit = "0de5697428c5d524c33f55644c717e1374c5ed3e"
+commit = "a5033463ec4b9eccb39aab4daa6c2f5a259025f9"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"

--- a/testing/live/Craftimizer/manifest.toml
+++ b/testing/live/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/craftimizer.git"
-commit = "5f33779409d65efbf7389037f2d0bd4e0247c421"
+commit = "0de5697428c5d524c33f55644c717e1374c5ed3e"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"

--- a/testing/live/Craftimizer/manifest.toml
+++ b/testing/live/Craftimizer/manifest.toml
@@ -1,17 +1,5 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/craftimizer.git"
-commit = "80a758e24bc11a1b429dcbc9219963a6d04b41ae"
+commit = "5f33779409d65efbf7389037f2d0bd4e0247c421"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"
-changelog = """
-Big solver generation fixes! *It now tries super duper hard to get to 100% HQ!*
-
-New features:
-- Recipes without a need for quality will prioritize only step count
-- Minor UI tweaks
-
-Fixed bugs:
-- Solver gives a subpar macro when 100% HQ is clearly possible
-- Small off-by-1 errors with progress/quality calculations
-- Normal stepwise algorithm never finishes
-"""


### PR DESCRIPTION
## Big QoL Update!

New & Improved Synthesis Helper:
- Get live suggestions of what actions to use in the middle of a craft!
- Works great on expert crafts (or wherever a macro doesn't work well)
- Can be automatically disabled whenever a macro is running (so your computer doesn't do redundant work)

New Features:
- View your macro's reliability from a glance: hover over a progress bar in the macro editor to see your macro's reliability with a violin plot! You can configure how many trials to run in the settings.
- Progress bar when generating macros: a progress bar is displayed on the bottom of the macro editor when generating a macro.
- Condition randomness (reintroduced): click the dice icon to toggle it
- Drag and move around actions in the macro editor and move in new actions directly to where you want them!
Reorder your macros in the macro list
- Added a nice little clickable settings button in the title bar of the macro editor & macro list windows :)
- Changed the order of actions in the macro list to be consistent with the crafting log window
- Big optimizations (~20% speedup!) with slightly better macro generation

Bug Fixes:
- Icon buttons were slightly off center
- Outdated configs weren't adopting new additions and caused a variety of issues
- A macro's actions' images in the macro editor were drawn inconsistently to the ones in the sidebar
- Macro list would render improperly if opened from the /craftmacros command without opening the crafting log

No more features will be added until 2.0, think of this as release candidate 2. Only minor bug fixes will occur now!