### PR TITLE
DeepDungeonTracker 1.0.0.7

### DIFF
--- a/stable/DeepDungeonTracker/manifest.toml
+++ b/stable/DeepDungeonTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/marconsou/deep-dungeon-tracker.git"
-commit = "5119f59c4f2001673e0463728540eaf44b479d92"
+commit = "851e8630888469b365a8611abb7ef242961267c8"
 owners = ["marconsou"]
 project_path = "DeepDungeonTracker"
 changelog = """

--- a/stable/DeepDungeonTracker/manifest.toml
+++ b/stable/DeepDungeonTracker/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/marconsou/deep-dungeon-tracker.git"
-commit = "9301b802cfa0fa35479eb2b9aae5c5c6f20ed2af"
+commit = "5119f59c4f2001673e0463728540eaf44b479d92"
 owners = ["marconsou"]
 project_path = "DeepDungeonTracker"
 changelog = """
-- Accurate Target HP % fix.
+- Added 3 to 8 room counts to the Statistics Window. (You can show or hide them individually on Configuration > Statistics tab)
 """

--- a/stable/DeepDungeonTracker/manifest.toml
+++ b/stable/DeepDungeonTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/marconsou/deep-dungeon-tracker.git"
-commit = "851e8630888469b365a8611abb7ef242961267c8"
+commit = "ad72bb5f8b6e8db250f1c64de044f4b3a39da022"
 owners = ["marconsou"]
 project_path = "DeepDungeonTracker"
 changelog = """


### PR DESCRIPTION
- Added 3 to 8 room counts to the Statistics Window. (You can show or hide them individually on Configuration > Statistics tab).