### PR TITLE
Honorific 1.4.0.0

### DIFF
--- a/stable/Honorific/manifest.toml
+++ b/stable/Honorific/manifest.toml
@@ -1,4 +1,4 @@
 [plugin]
 repository = "https://github.com/Caraxi/Honorific.git"
 owners = [ "Caraxi" ]
-commit = "86bddbf05fbe3db8cbbe8ce7e4a6820d064b7cb3"
+commit = "965d926c410b3848fa60de0783725707dafbf685"


### PR DESCRIPTION
- Adds ability to toggle titles by command
    - `/honorific title <toggle/disable/enable> <title>`
    - Titles can also be toggled by a unique ID if multiple titles share text, or if the title changes often. Right click the enable checkbox to copy the command with uinque id.
    
- Added a command guide to the settings window

- Added ability for random titles to be selected instead of only the first one.
    - Title changes automatically if the last random title is no longer meeting its conditions
    - Optional ability to pick a new title when changing area
    - `/honorific random` to force a new title to be selected.

- Limited the settings window size the be at most the size of the game window
    - Prevents people from somehow managing to set their window size to be a light year across
