### PR TITLE
TextToTalk v1.28.3

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -9,5 +9,5 @@ Changes since 1.28.2
 
 Changes since 1.24.2
 - Adds support for ElevenLabs TTS
-- Adds Cortana voices to the "Don't see all of your voices?" button
+- Adds Cortana voices to the \"Don't see all of your voices?\" button
 """

--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,8 +1,13 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "c7d6315b8454797f7b5f1c78599cd92dd4440930"
+commit = "86bf94064a7cb4e1a69722acc6449b62a6f98f7c"
 project_path = "src"
 owners = ["karashiiro"]
 changelog = """\
-- Fixes errors while upgrading config versions
+Changes since 1.28.2
+- Improves logging during config migrations for easier debugging in the future
+
+Changes since 1.24.2
+- Adds support for ElevenLabs TTS
+- Adds Cortana voices to the "Don't see all of your voices?" button
 """


### PR DESCRIPTION
This update finally merges the testing version of the plugin back to the stable version of the plugin. I'll be paying closer attention to the debug channel this update as there have been past issues with config updates between 1.24 and 1.25 that may still show up in some cases. Please send your plugin config if this occurs so I can quickly patch any remaining instances of the issue.

Changes since 1.28.2
- Improves logging during config migrations for easier debugging in the future

Changes since 1.24.2.6
- Adds support for ElevenLabs TTS
- Adds Cortana voices to the "Don't see all of your voices?" button