### PR TITLE
[Testing] ItemIcons v0.3.1.0

### DIFF
--- a/testing/live/ItemIcons/manifest.toml
+++ b/testing/live/ItemIcons/manifest.toml
@@ -1,17 +1,5 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/ItemIcons.git"
-commit = "13da1ef64bd749612c015355b4d24cd3578816c9"
+commit = "7509f34aef03bb369d6350068d7346103ba33fa2"
 owners = [ "WorkingRobot" ]
 project_path = "ItemIcons"
-changelog = """Release 0.3.0.0
-New Changes:
- - New Materia (Text) icon type
- - Config window changes:
-   - Added the ability to globally disable a type of icon
-   - Added icon descriptions
-   - Added a list of used icons for every icon type
-   - Changed some names and other stuff around
-
-Fixed Bugs:
- - Glamour plate icons were in the wrong spot
-"""


### PR DESCRIPTION
New Features:
- Added support for Gathering window
- Added support for the Inspect window when you inspect a different player (included in the "Equipment" category)
- New Item Level "icon" shows the gear ilvl from a glance

Bug Fixes:
- Massive frames drop when an unobtained item was in view (i.e. orchestrion rolls)
- Premium saddlebag showed the icons of the free saddlebag