### PR TITLE
Coordinate Importer v1.1.0.0

### DIFF
--- a/testing/live/CoordImporter/manifest.toml
+++ b/testing/live/CoordImporter/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/zw3lf/ffxiv-coord-importer.git"
-commit = "c69cd53ca294ffc69aaae6132af995960eaf60bc"
-owners = ["zw3lf"]
+commit = "a7be703d9621ec24ad63038a5b3dfdea47bb1612"
+owners = ["zw3lf", "dit-zy"]
 project_path = "CoordImporter"
-changelog = "Fix Lumina problematically caching Placenames when building the map dictionary"
+changelog = "Implement export to HuntHelper train feature (thank you dit-zy!) and refactor code"


### PR DESCRIPTION
This is a pretty significant rewrite of the code, as well as an additional feature.

The feature is being able to send the imported coordinates to HuntHelper via IPC; most of this logic is contained within `Managers/HuntHelperManager.cs`.

The rewrite of the code mostly lifts out business logic from `Plugin.cs` and redistributes it into more semantically isolated locations. E.g. All the parser logic now exists within the `CoordImporter.Parsers` namespace. A slightly more functional style of programming has been employed for a lot of the data transformation and retrieval, and this has meant we  pulled in the CSharpFunctionalExtensions package. Finally, because I'm lazy, I have tried using (what appears to be) the typical Dependency Injection framework for C# instead of manually wiring up all the constructor dependencies.

The biggest reason for the restructuring was to allow the parsers be unit-testable; which is where the bulk of the changes in the diff appear. There is a new solution `CoordinateImporter.Tests` which, at the moment, contains some straightforward regression tests to ensure that the regexes work correctly. Dit-zy and I are going to be writing some more tests, as well as probably refactoring some of the harnesses as we get better at c#, but this portion of the project is intended to be ignored by the Dalamud build process (I'll likely set up some CI job to run the tests via GHA; I just haven't gotten around to that yet).

Finally, I've added dit-zy as an owner to this project as they have been doing a huge amount of work on improving the original code I wrote, and they have a lot more free time than I do to be able to improve this project.