### PR TITLE
PlayerTrack v3.2.8.0

### DIFF
--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "c8994565f50cf9cbf9ab4d22c6301a2389dbe15c"
+commit = "bd5714fa6b18013b597971968106843cc74ed615"


### PR DESCRIPTION
PlayerTrack can now sync with your socials: Friends List, Blacklist, Free Company, and Linkshells. All lists will refresh when you open their respective screen. In addition, the Friends and Blacklist will update when you login.

The following settings can be set per character/list.
- Add players from social lists.
- Create a dynamic category where players are automatically added/removed.
- Assign a default category to assign one of your existing categories to the player.

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/35899782/cec86d25-ef1c-45c0-9093-bf413ed2aae6)
