### PR TITLE
VFXEditor v1.8.1.6

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "4f9c6da09b72786af7192eb7fe5cc50f12943812"
+commit = "a047daf460e58452566086c08e88012d80d82f11"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Fixed issue with file browser
- Fixed issue with copy/pasting graph nodes
- `.glb` files can be imported as well
- Added some sit poses `.pap` paths