### PR TITLE
TextToTalk v1.28.7

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "098809014f667952d3f735f70545e6529e3f08f3"
+commit = "a7491a6424ee6e02de76b0fde55d9b02c2f76d21"
 project_path = "src"
 owners = ["karashiiro"]
 changelog = """\
-- Fixes config window closing in rare cases when selecting the NPC voices tab
+- Fixes NPC names being unable to be changed in the NPC voices tab of the config window
+- Adds global toggles for disabling NPC/player voice presets
 """


### PR DESCRIPTION
- Fixes NPC names being unable to be changed in the NPC voices tab of the config window
- Adds global toggles for disabling NPC/player voice presets