### PR TITLE
[Testing] AutoTimer (v1.0.0.1)

### DIFF
--- a/testing/live/AutoTimer/manifest.toml
+++ b/testing/live/AutoTimer/manifest.toml
@@ -1,6 +1,8 @@
 [plugin]
 repository = "https://github.com/s5bug/AutoTimer.git"
-commit = "53dc51164b655d84321a11806d08ce4b3d00c18a"
+commit = "aa03d1dd6d0b7f02396c72db0f2b0b0410d7c7bc"
 owners = ["s5bug"]
 project_path = "AutoTimer"
-changelog = "Initial release"
+changelog = '''
+- Fix issue in which non-English versions would throw errors due to the plugin improperly matching locale-dependent strings against static strings
+- Add more information about Ninja's bar background'''


### PR DESCRIPTION
Adds hint text to the bar background selector in the configuration window clarifying how it should be interpreted on Ninja, as well as fixes a bug where the base GCD of a class was uncalculatable due to searching for `"Spell"`/`"Weaponskill"` in all game languages instead of using the locale-independent spreadsheet row ID.