### PR TITLE
Hunty 1.3.0.1

### DIFF
--- a/stable/Hunty/manifest.toml
+++ b/stable/Hunty/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/Hunty.git"
-commit = "f80c84b5cc942f78da1d2b01d6d702cf389bfa2e"
+commit = "6345c6830a62470b6750842372aa1ecca223c698"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Rewrite the monster name localization

PAC Note: 
95% of line changes is adding monster ID for all 500+ hunting log tasks 