### PR TITLE
PlayerTrack v3.2.9.0

### DIFF
--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "c8994565f50cf9cbf9ab4d22c6301a2389dbe15c"
+commit = "109a3ce3eb4579dda768a6a28e98a1296409121e"


### PR DESCRIPTION
PlayerTrack can now sync with your socials: Friends List, Blacklist, Free Company, and Linkshells. All lists will refresh when you open their respective screen. In addition, the Friends and Blacklist will update when you login.

The following settings can be set per character/list.
- Add players from social lists.
- Create a dynamic category where players are automatically added/removed.
- Assign a default category to assign one of your existing categories to the player.

This release also includes API optimizations and is the same that's in testing today.