### PR TITLE
Update Nameplate Debuffs to 1.0.3.0

### DIFF
--- a/stable/NamePlateDebuffs/manifest.toml
+++ b/stable/NamePlateDebuffs/manifest.toml
@@ -1,12 +1,13 @@
 [plugin]
-repository = "https://github.com/abashby/NamePlateDebuffs.git"
-commit = "ac54d7278a4605f1bdb089e568e71568ce2da776"
+repository = "https://github.com/sourpuh/NamePlateDebuffs.git"
+commit = "cfbc973fb48fd4c31b373fc9a12ce9e00b35413c"
 owners = [
     "aers",
     "JHerig",
     "abashby",
+    "sourpuh",
 ]
 project_path = "NamePlateDebuffs"
 changelog = """
-- Update for 6.4
+- Update for 6.51
 """

--- a/stable/NamePlateDebuffs/manifest.toml
+++ b/stable/NamePlateDebuffs/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/sourpuh/NamePlateDebuffs.git"
-commit = "cfbc973fb48fd4c31b373fc9a12ce9e00b35413c"
+commit = "52c22f9937a77bd053b667943c04e49a90d5a97e"
 owners = [
     "aers",
     "JHerig",


### PR DESCRIPTION
- Update Nameplate Debuffs to 1.0.3.0 to support patch 6.51
- Changed config window to use Dalamud Windowing API