### PR TITLE
JustBackup v1.1.0.5

### DIFF
--- a/stable/JustBackup/manifest.toml
+++ b/stable/JustBackup/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/JustBackup.git"
 # The commit to check out and build from the repository.
-commit = "113f0d8dbba90291274da4a32c7d4b36de93370e"
+commit = "582fde8ab8dad0f3bf13cbbf4a14bf5cc2a7dcbf"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"

--- a/stable/JustBackup/manifest.toml
+++ b/stable/JustBackup/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/JustBackup.git"
 # The commit to check out and build from the repository.
-commit = "1cec5fb3c7d46bc2a988dc64b190066ffc4bd7ae"
+commit = "113f0d8dbba90291274da4a32c7d4b36de93370e"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"


### PR DESCRIPTION
Changes vs current Testing version:
- Removed restriction on how long backup cooldown may be

Changes vs Latest Release version:
- Slightly reworked gui
- Fixed temp files not always getting deleted
- Added an option to redefine temp path for files
- Now default amount of CPU threads will be 1/4 of all available rather than 1
- Added an option to restrict maximum amount of threads plugin can use
- Added an option to throttle copying, reducing disk load during backup
- Added an option to enable short backup cooldown limited by 60 minutes. After a successful backups, no backups will be created within specified amount of time, useful when you restart the game very often. You can still do the backup manually with `/justbackup` command.