### PR TITLE
MacroMate 1.0.7.1

### DIFF
--- a/stable/MacroMate/manifest.toml
+++ b/stable/MacroMate/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "d6cac094e6aad4b3f312c423854ad31473becf1a"
+commit = "58905fb69cb69ae0621dfd3d375ed2b7a1eec19d"
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.7.0"
+version = "1.0.7.1"
 changelog = """
-- Added Import/Export
+- Added Import/Export (compressed)
 """


### PR DESCRIPTION
Make Import/Export compressed.

Codes from yesterdays version are way too long. This makes them a lot shorter but does render any codes from yesterday obsolete.