### PR TITLE
[Testing] Who's Talking 0.6.5.0

### DIFF
--- a/testing/live/WhosTalking/manifest.toml
+++ b/testing/live/WhosTalking/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/sersorrel/WhosTalking.git"
-commit = "98d6d6935d10bcf2e0eb63aef9dbea2bce7ef65a"
+commit = "4dd9a31ebc38b84e9614c1a16d94af221584d8af"
 owners = ["sersorrel"]
 project_path = "WhosTalking"
 changelog = """\
-- Added an easier way to configure individual assignments
-- Fixed a bug causing the overlay to show up even if the party list was hidden via HUD Layout
-- Fixed a crash that could occur if the Discord API sent an invalid response
+- Added ability to configure colours of voice activity indicators (find this in the plugin settings)
+- Bugfix for individual assignments in cross-world parties
+
+Thank you to the two contributors who did all the actual work for this release!
 """


### PR DESCRIPTION
- Added ability to configure colours of voice activity indicators
  ![image](https://github.com/goatcorp/DalamudPluginsD17/assets/9433472/a5da4bba-2aec-4647-b797-cf0a5e483eb9)
- Bugfix for individual assignments in cross-world parties

Thank you @PYRiTEmonark and @zeroeightysix for these two PRs!