### PR TITLE
Simple Tweaks 1.9.4.2

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "3e11d374be5e58ac5d2e769ec922f895fc847b0a"
+commit = "ec747689a0c230fab8550f75a71e392a7210936f"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
nofranz

Fixed `Fast Item Search` not working due to accidentally removed hooks.