### PR TITLE
PriceInsight 2.7.0.0

### DIFF
--- a/stable/PriceInsight/manifest.toml
+++ b/stable/PriceInsight/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-priceinsight.git"
-commit = "d0366deff8edd3941ea327e2c309c427ef3ef3cd"
+commit = "b60cebfd92cda4f550e91b487888a5b42df55790"
 owners = ["Kouzukii"]
 project_path = ""
 changelog = """
-Fixed tooltip text having randomized character spacing
+- Fixed items displaying the time of the posting of a price rather than the time it was last checked.
+- Add an option to force connect via ipv4 to universalis. Should help people experiencing issues with VPN connections.
 """


### PR DESCRIPTION
- Fixed items displaying the time of the posting of a price rather than the time it was last checked.
- Add an option to force connect via ipv4 to universalis. Should help people experiencing issues with VPN connections.