### PR TITLE
Currency Tracker 1.3.1.5

### DIFF
--- a/stable/CurrencyTracker/manifest.toml
+++ b/stable/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "a778aa9ee10d76eb20c10c38dea0184cc75dfaeb"
+commit = "78678e81f4d292203552882dac04e040a39351d7"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
-changelog = "- All UI elements now can adapt to scaling\n-Now you can update the localization files in-plugin from the cloud.\n- New feature: Interval Alert - You can set unlimited customizable intervals for currencies' Change/Amount to inform you."
+changelog = "Fix a null reference issue"


### PR DESCRIPTION
Fix a null reference issue

Real diffs: 69 lines (265 lines from ChineseTraditional localization ``.resx`` file)