### PR TITLE
Tracky 1.3.4.9

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "18a7dad79cf2160894fb56819a836935ddd57942"
+commit = "81864d2ff1e27a64c63838ce938596f71f3a59b7"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Remove Korpokkur Kid from 4.0 boxes
- More records (50k, there is now a total of 800k)

Note for PAC:
Real diff = 2 lines