### PR TITLE
XIVLogger 1.0.6.0

### DIFF
--- a/stable/XIVLogger/manifest.toml
+++ b/stable/XIVLogger/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/XIVLogger.git"
-commit = "a35e8d6224d9edd6fb39312852abfb68c9cf36c0"
+commit = "4bf27983b80222a4a6f0d027b87816a272af2bca"
 owners = [
   "cadaeix",
   "Infiziert90"


### PR DESCRIPTION
- Added "Other /random" as chat type
- New option to save messages no matter the chat type [default: false]
- New option to generate sortable filenames [default: false]