### PR TITLE
DeepDungeonDex 2.9.1

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "c045fa0efc70522363188059bf36047506cda451"
+commit = "8741fef0dcc9bd6117fa6017307534c5684159bb"
 changelog = "### 2.9.1 (2024-01-09)\n\n\n### Bug Fixes\n\n* sunset some unneeded fonts (df00156)\n* update untranslated locale data with Crowdin MT (fd14bc6)\n* use locale when type display does not exist (22e1dfa)"
 version = "2.9.1"

--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "fc8cb898f08156c90e43d32da35aa208e93cc393"
-changelog = "## 2.9.0 (2024-01-08)\n\n\n### Features\n\n* implement built data file lookup on http errors (65c2c07)\n* prepare for more types (3940e62)\n* retool internal storage to prepare for built data file (749c2ee)\n\n\n### Bug Fixes\n\n* change font push to always handle throws without leaking (34312a6)"
-version = "2.9.0"
+commit = "c045fa0efc70522363188059bf36047506cda451"
+changelog = "### 2.9.1 (2024-01-09)\n\n\n### Bug Fixes\n\n* sunset some unneeded fonts (df00156)\n* update untranslated locale data with Crowdin MT (fd14bc6)\n* use locale when type display does not exist (22e1dfa)"
+version = "2.9.1"


### PR DESCRIPTION
### 2.9.1 (2024-01-09)


### Bug Fixes

* sunset some unneeded fonts (df00156)
* update untranslated locale data with Crowdin MT (fd14bc6)
* use locale when type display does not exist (22e1dfa)

### Notes
Built with new CS from Canary does seem to work on Release