### PR TITLE
Target Lines 1.4.0.0

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,11 +1,12 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "5c4e038244cc6d9543f809d8c8cac30019f37f8f"
+commit = "2fcd8776915f63e2a2ee088b7e1208ce7e5f3daf"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
-- Updated for 6.5
-- Updated for API9
-- Minor fixes
+- New and improved configuration UI
+- Added option for Dynamic Sample Count when using Fancy Lines
+- Added option for UI collision when using Fancy Lines
+- Some incomplete work on a implementation of lines which do not use ImGui
 """
 

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "2fcd8776915f63e2a2ee088b7e1208ce7e5f3daf"
+commit = "182aae3481af7db7d79f28a5624bda15c340e0c9"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """


### PR DESCRIPTION
This is just an update which brings some improvements that I've finished working on/been hoarding.
The most likely thing that users will see is that I Revised the configuration UI, it is now more organized.
Besides that, I implemented a system which will occlude segments of the lines which they would intersect part of the UI. Because it is not cheap to AABB test potentially hundreds of rects (I know there is some insane person who would set the sample count to 500 then complain the plugin takes 20ms to process), I also added an option which dynamically adjusts the sample count of the lines based on how long the line is. 
Besides this, the only change that users may see is that I am now also checking the center point of the line when doing occlusion culling with the world.

There are some more changes related to my unhinged effort to draw the lines manually myself. Currently, the only way for a user to access this is to toggle a "Debug DX Lines" option in the debug tab, then restart the plugin. This just draws an opaque white line at hardcoded coordinates. Whenever I get this working, it should look and perform better; though at the time this is just something that I've left in.