### PR TITLE
DeepDungeonDex 2.9.2

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "8741fef0dcc9bd6117fa6017307534c5684159bb"
-changelog = "### 2.9.1 (2024-01-09)\n\n\n### Bug Fixes\n\n* sunset some unneeded fonts (df00156)\n* update untranslated locale data with Crowdin MT (fd14bc6)\n* use locale when type display does not exist (22e1dfa)"
-version = "2.9.1"
+commit = "631ad812909a90d335e99b899c221b40fc489e21"
+changelog = "### 2.9.2 (2024-01-10)\n\n\n### Bug Fixes\n\n* change content type to local flag enum (5f2e180)\n* data loading to only load local once if first attempt fails (d1e2e82)\n* finalize unknown content display (b1eebe2)"
+version = "2.9.2"


### PR DESCRIPTION
### 2.9.2 (2024-01-10)


### Bug Fixes

* change content type to local flag enum (5f2e180)
* data loading to only load local once if first attempt fails (d1e2e82)
* finalize unknown content display (b1eebe2)