### PR TITLE
DeepDungeonDex 2.9.2

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "9c97be350615046c801b03d34f367aca62058f71"
+commit = "a0e7e2182fcd85ac65dc34dd10d33e5a336806bb"
 changelog = "### 2.9.2 (2024-01-10)\n\n\n### Bug Fixes\n\n* change content type to local flag enum (5f2e180)\n* config window not respecting language on boot (f5e3c21)\n* data loading to only load local once if first attempt fails (d1e2e82)\n* finalize unknown content display (b1eebe2)\n* fixing edge cases with word wrapping (7f55750)\n* force language to be loaded after all other data (7d728e7)\n* mob notes not working after 2.9.0 restructuring (b598f2e)"
 version = "2.9.2"

--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "a0e7e2182fcd85ac65dc34dd10d33e5a336806bb"
+commit = "19345a3b319441740301248aa15dd8d22b4d58ad"
 changelog = "### 2.9.2 (2024-01-10)\n\n\n### Bug Fixes\n\n* change content type to local flag enum (5f2e180)\n* config window not respecting language on boot (f5e3c21)\n* data loading to only load local once if first attempt fails (d1e2e82)\n* finalize unknown content display (b1eebe2)\n* fixing edge cases with word wrapping (7f55750)\n* force language to be loaded after all other data (7d728e7)\n* mob notes not working after 2.9.0 restructuring (b598f2e)"
 version = "2.9.2"

--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "8741fef0dcc9bd6117fa6017307534c5684159bb"
-changelog = "### 2.9.1 (2024-01-09)\n\n\n### Bug Fixes\n\n* sunset some unneeded fonts (df00156)\n* update untranslated locale data with Crowdin MT (fd14bc6)\n* use locale when type display does not exist (22e1dfa)"
-version = "2.9.1"
+commit = "9c97be350615046c801b03d34f367aca62058f71"
+changelog = "### 2.9.2 (2024-01-10)\n\n\n### Bug Fixes\n\n* change content type to local flag enum (5f2e180)\n* config window not respecting language on boot (f5e3c21)\n* data loading to only load local once if first attempt fails (d1e2e82)\n* finalize unknown content display (b1eebe2)\n* fixing edge cases with word wrapping (7f55750)\n* force language to be loaded after all other data (7d728e7)\n* mob notes not working after 2.9.0 restructuring (b598f2e)"
+version = "2.9.2"


### PR DESCRIPTION
### 2.9.2 (2024-01-10)


### Bug Fixes

* change content type to local flag enum (5f2e180)
* config window not respecting language on boot (f5e3c21)
* data loading to only load local once if first attempt fails (d1e2e82)
* finalize unknown content display (b1eebe2)
* fixing edge cases with word wrapping (7f55750)
* force language to be loaded after all other data (7d728e7)
* mob notes not working after 2.9.0 restructuring (b598f2e)