### PR TITLE
Currency Tracker 1.3.3.8

### DIFF
--- a/stable/CurrencyTracker/manifest.toml
+++ b/stable/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "dbb8328adb1c77dccf522a7ad46f2f20cdadf349"
+commit = "d9276f2a32fb5217a9312c8e16db68418b4bcc55"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
 changelog = "- Fix an issue where the Rename Currency feature only partially renames data files.\n- Fix an issue involving a missing localization string.\n- Fix an issue where certain UI elements did not scale as anticipated.\n- Update Localization Files for English, Simplified Chinese, Traditional Chinese, and French."

--- a/stable/CurrencyTracker/manifest.toml
+++ b/stable/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "7198883d6d9470e9e50d65226272ed183a52a199"
+commit = "dbb8328adb1c77dccf522a7ad46f2f20cdadf349"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
 changelog = "- Fix an issue where the Rename Currency feature only partially renames data files.\n- Fix an issue involving a missing localization string.\n- Fix an issue where certain UI elements did not scale as anticipated.\n- Update Localization Files for English, Simplified Chinese, Traditional Chinese, and French."

--- a/stable/CurrencyTracker/manifest.toml
+++ b/stable/CurrencyTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "1854de88c4a05227fc2dfae270c8b266338a2308"
+commit = "7198883d6d9470e9e50d65226272ed183a52a199"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
-changelog = "- Fix an issue where Trade module will not work properly."
+changelog = "- Fix an issue where the Rename Currency feature only partially renames data files.\n- Fix an issue involving a missing localization string.\n- Fix an issue where certain UI elements did not scale as anticipated.\n- Update Localization Files for English, Simplified Chinese, Traditional Chinese, and French."


### PR DESCRIPTION
- Fix an issue where the Rename Currency feature only partially renames data files.
- Fix an issue involving a missing localization string.
- Fix an issue where certain UI elements did not scale as anticipated.
- Update Localization Files for English, Simplified Chinese, Traditional Chinese, and French.

Real diffs: 212 lines (2400 lines from only indentation adjustment, 41 lines from localization files update)