### PR TITLE
BetterShadows 1.3.0.0

### DIFF
--- a/stable/BetterShadows/manifest.toml
+++ b/stable/BetterShadows/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Drahsid/BetterShadows.git"
-commit = "4bdc9f3e87b55afd6cbb4d3d45ceb80620251abc"
+commit = "5b448cdcc28a049a289d19cd594b8be2288ab150"
 owners = ["Drahsid"]
 project_path = "BetterShadows"
 changelog = """
-- Updated for 6.5
-- Updated for API9
+- You can now adjust the shadowmap resolution to be anything from 64p to 16384p (Default is 4096p on High)
+- Added a 'Recover Default Preset' button
+- Added an option to open the Config window when entering GPose
 """
 

--- a/stable/BetterShadows/manifest.toml
+++ b/stable/BetterShadows/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/BetterShadows.git"
-commit = "5dc2859f07b6573aac89ccfb1c0a48a51ad4de30"
+commit = "46c81782c5804aad267c8b5d9211ee55cab32eab"
 owners = ["Drahsid"]
 project_path = "BetterShadows"
 changelog = """

--- a/stable/BetterShadows/manifest.toml
+++ b/stable/BetterShadows/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/BetterShadows.git"
-commit = "5b448cdcc28a049a289d19cd594b8be2288ab150"
+commit = "5dc2859f07b6573aac89ccfb1c0a48a51ad4de30"
 owners = ["Drahsid"]
 project_path = "BetterShadows"
 changelog = """


### PR DESCRIPTION
Just an update from some stuff I stumbled upon, and some features that have been requested.
You can now adjust the shadowmap resolution to be anything from 64p to 16384p (Default is 4096p on High).
I added a 'Recover Default Preset' button; and an option to open the Config window when entering GPose.