### PR TITLE
[Testing] TooltipNotes 1.3.0.0

### DIFF
--- a/testing/live/TooltipNotes/manifest.toml
+++ b/testing/live/TooltipNotes/manifest.toml
@@ -1,13 +1,14 @@
 [plugin]
 repository = "https://github.com/Lerofni/TooltipNotes.git"
-commit = "c02c2e08fce3d064b0810ab52de06aafba388326"
+commit = "5efa759adddecd26f46bde5f7bd7cd1acf210f56"
 owners = ["Lerofni"]
 project_path = "TooltipNotes"
 changelog = """
-1.2.0.0
+1.3.0.0
 
-Hello Everyone,
-TooltipNotes is back for patch 6.5 and its better than ever!
-What changed?
-it may not look like much but behind the scenes a lot has changed which means now those who couldnt use TooltipNotes before due to FPS drops and it just straight up not working should niw be able to use it wihtout worries I hope
+New Toggle for Quality Specific Notes:
+    Been tired of your NQ and HQ notes being differen? Fret not! now there is a toggle in the config which will prioritize NQ notes over HQ notes on HQ items
+Some behind the scenes changes:
+    Note and Label data has been migrated, due to that there might be some things not working right, if something is found that doesnt work please contact me.
+    Should some of your notes not be there anymore after the update, dont worry there should be a backup, we can restore your notes
 """


### PR DESCRIPTION
1.3.0.0

New Toggle for Quality Specific Notes:
    Been tired of your NQ and HQ notes being differen? Fret not! now there is a toggle in the config which will prioritize NQ notes over HQ notes on HQ items
Some behind the scenes changes:
    Note and Label data has been migrated, due to that there might be some things not working right, if something is found that doesnt work please contact me.
    Should some of your notes not be there anymore after the update, dont worry there should be a backup, we can restore your notes