### PR TITLE
DeepDungeonDex 2.9.4

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
-owners = [ "wolfcomp" ]
+owners = ["wolfcomp"]
 project_path = "DeepDungeonDex"
-commit = "76c4b32a693085d3326b16b9e2a6723eb59aaa5b"
-changelog = "### 2.9.3 (2024-01-12)\n\n\n### Bug Fixes\n\n* block some content that shouldn't have displays added at a later time (7a47aae)"
-version = "2.9.3"
+commit = "135c4aa203baffc9d2b4ba9f2e60061a9a18ec7f"
+changelog = ""
+version = "2.9.4"

--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -3,5 +3,5 @@ repository = "https://github.com/wolfcomp/DeepDungeonDex.git"
 owners = ["wolfcomp"]
 project_path = "DeepDungeonDex"
 commit = "135c4aa203baffc9d2b4ba9f2e60061a9a18ec7f"
-changelog = ""
+changelog = "### 2.9.4 (2024-01-17)\n\nRollback of window changes until development is finished. As per PAC request."
 version = "2.9.4"


### PR DESCRIPTION
### 2.9.4 (2024-01-17)

Rollback of window changes until development is finished. As per PAC request.