### PR TITLE
Tracky 1.4.0.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "81864d2ff1e27a64c63838ce938596f71f3a59b7"
+commit = "df45cbd890f77625d625f45629024a385b587c6c"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fragments are being tracked correctly now
- Old Fragment history is getting wiped on update
- Bulk Desynthesis detection works better
- New detection method for bunny chests, this should make them ping independent 
- Coffers (Material, Venture ....) have improved performance and detection
- Triple Triad Card Packs get tracked now

Note: 
If you notice any issues, especially with the new bunny chest method, please post a message in the Discord thread