### PR TITLE
TidyChat v.1.2.9 - Compatibility fix by Glyceri

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "da2635c073b45c313897d4ca26c95c0b2e0e9440"
+commit = "863ea736db86548fc37820d5593423f6de122d5a"
 owners = [
     "NadyaNayme",
 ]


### PR DESCRIPTION
This moves TidyChat to work on ChatMessageHandled instead of ChatMessage to avoid conflicts with Pet Nicknames & Chat Emote Color and potentially other plugins that also hook ChatMessage and set isHandled. The issue was identified and fixed by Glyceri after reports of incompatibility with their Pet Nicknames plugin. 

Thank you Glyceri for the contribution! 