### PR TITLE
[Testing] Pet Nicknames v1.4.6.3

### DIFF
--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "63ba62a8c1905f57b832b2d48ed96d1373103e9a"
+commit = "5a49f58e360d2ddef7f62a70614509acd5add044"
 owners = ["Glyceri",]
 	changelog = """
-    + [1.4.6.1]
-    + Names should now display properly in German.
+    + [1.4.6.3]
+    + Fixed an issue where summoner would overwrite Pet Mirage settings at any given oppertunity.
+    + The chat should now be less greedy in renaming pet names.
 """

--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "5a49f58e360d2ddef7f62a70614509acd5add044"
+commit = "84c3b69507bc9be7610f66321634ea6b3ce7bd77"
 owners = ["Glyceri",]
 	changelog = """
     + [1.4.6.3]
     + Fixed an issue where summoner would overwrite Pet Mirage settings at any given oppertunity.
     + The chat should now be less greedy in renaming pet names.
+    + The context menu config setting works again.
 """


### PR DESCRIPTION
    + [1.4.6.3]
    + Fixed an issue where summoner would overwrite Pet Mirage settings at any given oppertunity.
    + The chat should now be less greedy in renaming pet names.