### PR TITLE
Simple Tweaks 1.9.6.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "84003865465f1ee516f7fc78c2840753660e6077"
+commit = "2ec9f7fcaa34f04b1c5a357cc8d5bfa417b0906b"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***New Tweaks***
- **`Equip Job Command`** - Adds a command to switch to a class or job's gearset. *(Lumina Sapphira)*

- **`Sticky Shout Chat`** - Prevents the game from automatically switching out of shout chat.


***Tweak Changes***
- **`Casting Text Visibility`** - Fixed tweak not working with a split primary target window

- **`Quick Sell Items at Vendors`** - Added option to allow quick selling items from player inventory while using a retainer.

- **`Target Castbar Countdown`**
  - Added option to change font size
  - Added option to adjust position
  - Fixed disable on primary and focus target