### PR TITLE
TargetLines 1.5.1

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,10 +1,13 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "cbf010dd4d1f479d6b67a260e14c7ac252ceef2f"
+commit = "afa643a240e655d376577960a47a1d8a12373555"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
-- Visually improved situations where a line segment would intersect the camera with fancy lines
-- Visually improved the target line effect when viewing in first person
+- UI occlusion now checks for line intersections, so there should no longer be segments appearing if it's rect overlaped a UI element, but did not intersect it under certain circumstances
+- Fixed a bug which would cause the end cap to have the wrong opacity when 'Fade to End' is enabled
+- Adjusted the rendering of the end caps so they appear uniform
+- Fixed issue where the first/third person transition for lines which target or source the player would appear disjointed
+- Minor optimizations in the broad phase of UI occlusion
 """
 


### PR DESCRIPTION
Pretty much as detailed in the changelog.
Most changed code will be the ABGR class becoming a RGBA struct. I was testing some stuff that required it to be unmanaged, but that stuff didn't make it in.
Besides this, the UI occlusion now checks for line intersections, which fixes issues where a line segment would overlap a piece of the UI, but all of its' points lie outside.
Additionally, there are some minor bugfixes relating to the first/third person changes from the last update, and the rendering of the start/end caps.