### PR TITLE
EngageTimer v2.3.2.0

### DIFF
--- a/stable/EngageTimer/manifest.toml
+++ b/stable/EngageTimer/manifest.toml
@@ -1,14 +1,8 @@
 [plugin]
 repository = "https://github.com/xorus/EngageTimer.git"
-commit = "6b0d046010e59da231d15520ebd2d716fb9c3406"
+commit = "318c59cda44e758d58a62763be34d3cdc829ba25"
 owners = ["xorus"]
 changelog = """\
-- You can set alarms to play a game sound effect, change stopwatch color or display text at specified combat durations
-- Big code rewrite and a bit of optimization
-- Fix save errors when spinning color sliders like a maniac in configuration
-- Reorganized configuration file to preserve my sanity
-- "Hide original addon" now uses AddonLifecycle events instead of searching for the original countdown every frame
-- Reduce CountdownHook CPU usage by fixing a stupid event spam mistake
-- Optimize countdown display code
-- Fix the "first-draw" workaround that draws the countdown window once on plugin activation to prevent a freeze caused by ImGUI initializing the window does not occur when starting a countdown
+- Add an option to draw the custom 0-5 numbers without hiding the original countdown
+- Make animation match vanilla a bit better
 """


### PR DESCRIPTION
- Add an option to draw the custom 0-5 numbers without hiding the original countdown
- Make animation match vanilla a bit better