### PR TITLE
[Testing] ScoutHelper v1.0.0.0

### DIFF
--- a/testing/live/ScoutHelper/manifest.toml
+++ b/testing/live/ScoutHelper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
-repository = "https://github.com/im-scared/scout-helper.git"
-commit = "5c747cc08711a10ad7a22e7c35f1abf894bafbb4"
+repository = "https://github.com/dit-zy/scout-helper.git"
+commit = "69e8b21fa8881f7d7f1c6531ae39027681de3934"
 owners = ["dit-zy", "zw3lf"]
 project_path = "ScoutHelper"
-changelog = "non-functional rewrite of dependency handling"
+changelog = "add support for siren hunts! :D"


### PR DESCRIPTION
this change is kind of big >_<. a bunch of changes are to the unit tests `ScoutHelperTests`. but this change adds support for a whole new scout tracker website, sirenhunts.com, so there is quite a bit added to support that. notably, though, siren doesn't need any web calls -- it's all string manipulation to generate the links with appropriate url parameters.