### PR TITLE
SubmarineTracker 1.8.2.6

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "d458ec8cc93ac42cf229cb6adeaf0304032aacaa"
+commit = "6f2777eb91d3fd94a8e30d0991f080854c6303f0"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fixed an issue which had submarines with same name not be selectable in builder
- Submarine selection in builder follows naming convention now