### PR TITLE
[Testing] CoordImporter v1.1.0.4

### DIFF
--- a/testing/live/CoordImporter/manifest.toml
+++ b/testing/live/CoordImporter/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/zw3lf/ffxiv-coord-importer.git"
-commit = "2c8964cd773d7f1f24e522dbcb10584e7529bfd8"
+commit = "ba8f3bbd60f37746a7b4eb01a332b4779b80c1f0"
 owners = ["zw3lf", "dit-zy"]
 project_path = "CoordImporter"
-changelog = "Bug fix: Get Li'l Murderer working with HuntHelper train importer"
+changelog = "Bug fix: Prevent name collisions causing the wrong mobs to be imported to hunt helper"


### PR DESCRIPTION
Minor change to only index hunt marks, to prevent duplicate mob names causing the wrong mob to be imported.