### PR TITLE
Distance 1.1.1.0

### DIFF
--- a/stable/Distance/manifest.toml
+++ b/stable/Distance/manifest.toml
@@ -1,10 +1,23 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/Distance.git"
-commit = "8ee1642d06e0fb92e12d2af2e5b18081409e8cc3"
+commit = "6f1d0c10640d4d9760d399fe9a2a914c73f8dea1"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "Distance"
 changelog = '''
-- Updated for API 9.  Thank you Felys!
+- Added distance-based fading to text widgets and nameplate distances
+- Added offsets by object type to nameplate distances.
+- Minor config UI improvements.
+
+Also contains the following differences that were previously only in the testing branch:
+- Added a custom arcs feature to match custom widgets.
+- Rewrote config UI.
+- Added job filters to all distance displays.
+- Added a filter for in and out of instance.
+- Applied other filter types to displays that did not have them.
+- Improved nameplate node setup to more closely match the base game.
+- Fixed a bug that caused nameplate text nodes to not be properly cleaned up during plugin unload.
+- Improved logging.
+- Significant code cleanup and reorganization.
 '''


### PR DESCRIPTION
If you were *not* on the testing branch, this release includes all of the following:

- Added a custom arcs feature to match custom widgets. By default, there are no custom arcs enabled. If you want to use this feature, go to the custom arcs tab in plugin settings, and click the '+' button to add one. The default arc added this way is set up to show max melee range on the targeted enemy, but you can add and configure these for pretty much whatever you want (other players, yourself, etc., filtered by job, target type, and more, and colorable/fadeable based on distance).
- Brand new config UI. The number of options was getting unwieldy in the old UI.
- Added job filters to all distance displays. You can limit widgets, nameplates, and arcs to only show for certain jobs. By default, these are set to all battle jobs.
- Added filters for in and out of instance.
- Added existing filter kinds to distance readout types that did not already have them.
- Improved nameplate distance text styling to more closely match the rest of the nameplate. They still do not match the skinny font used on the "new"-style nameplates, but that is in the works.
- Fixed a bug that caused nameplate text nodes to not be properly cleaned up during plugin unload.
- Updated logging.
- Significant code cleanup and reorganization.

If you *were* using the previous testing release (1.1.0.0), this update only includes:

- Added distance-based fading to text widgets and nameplate distances.
- Added configurable offsets by object type (players, BNpcs, others) to nameplate distances.
- Minor config UI improvements.

**IMPORTANT:** If you encounter any problems, please open an issue on the plugin's GitHub repo. I will not see any other feedback.