### PR TITLE
Map Party Assist v2.1.1.0

### DIFF
--- a/stable/MapPartyAssist/manifest.toml
+++ b/stable/MapPartyAssist/manifest.toml
@@ -1,11 +1,10 @@
 [plugin]
 repository = "https://github.com/wrath16/MapPartyAssist.git"
-commit = "02c3280f604be09b5f713d9bad51628b5d68e1ff"
+commit = "25ccbc0e75e01b134ba5e83d8e46e9c38b622a48"
 owners = ["wrath16"]
 project_path = "MapPartyAssist"
 changelog = """
-- Added loot tracking.
-- Added price checking using Universalis.
-- Major UI overhaul.
-- Performance improvements.
+- Fix for handled chat messages stopping plugin from functioning.
+- Fix for special map names not being recognized.
+- Minor UI changes.
 """


### PR DESCRIPTION
- Fix for plugin not working if chat messages are being handled by another plugin.
- Some other minor changes.