### PR TITLE
Tick Tracker 1.4.0.0

### DIFF
--- a/testing/live/TickTracker/manifest.toml
+++ b/testing/live/TickTracker/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Kurochi51/TickTracker.git"
-commit = "c4a004a4e2053e837e9f58890b397a3e251a828a"
+commit = "b39c9578bb488746902566076277d0ce9125ad7f"
 owners = ["Kurochi51"]
 project_path = "TickTracker"
 changelog = """
-- Added additional indicators to the bar for paused regen and double speed regen.
+- Added an alternative tick indicator that uses the native ui
 """


### PR DESCRIPTION
nofranz

I've been sitting on this for a few weeks, I didn't notice anything out of order, but it's kinda difficult to test these things when you know how they're supposed to work. 

The new native ui part attaches to the frame of the hp and mp/gp bar, and will grow alongside the length of said bar. The color isn't uniform, so some parts will look darker, this is because of the underlying texture used for the image node. 

There's also some penumbra ipc to disable the native settings if `Material UI` is detected, that's because the textures that MUI comes with lack the specific part I need, and I rely on client-loaded textures.