### PR TITLE
[Testing] Pet Nicknames v1.4.8.0

### DIFF
--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "931e4a49ebbed6117e2aa8f8f88402a113700a17"
+commit = "eb47d409e49b98844e150c8cb50391c1c50dbb6f"
 owners = ["Glyceri",]
 	changelog = """
-    + [1.4.7.0]
-    + There is now a new Pet News window.
-    + You can now hide buttons in the Toolbar.
-    + Certain default images have been changed.
+    [1.4.8.0]
+    The Mappy popup window is now reduced to a chat message.
+    Chat messages that Pet Nicknames sets hidden now properly remain hidden.
+    Pets on the Mappy Map will no longer show stuck when you are mounted.
+    Pet Nicknames is now enabled in the Wolves' Den Pier, but as a result even more restricted in non-Wolves' Den Pier zones.
 """


### PR DESCRIPTION
[1.4.8.0]
    + There is now a new Pet News window.	    The Mappy popup window is now reduced to a chat message.
    + You can now hide buttons in the Toolbar.	    Chat messages that Pet Nicknames sets hidden now properly remain hidden.
    + Certain default images have been changed.	    Pets on the Mappy Map will no longer show stuck when you are mounted.
    Pet Nicknames is now enabled in the Wolves' Den Pier, but as a result even more restricted in non-Wolves' Den Pier zones.