### PR TITLE
Update PositionalGuide (stable)

### DIFF
--- a/stable/PositionalGuide/manifest.toml
+++ b/stable/PositionalGuide/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/PrincessRTFM/PositionalAssistant.git"
 owners = [ "PrincessRTFM",]
 project_path = ""
-commit = "017977e4a253e736b24a97e0afc9ee8d15cb94ee"
-changelog = ""
+commit = "7401f69e187c0e94365c2b337d937754f4c5d4e5"
+changelog = "Fixed an issue where the command help section could be cut off at the bottom by limiting the maximum window size and making it scrollable."


### PR DESCRIPTION
Fixed an issue where the command help section could be cut off at the bottom by limiting the maximum window size and making it scrollable.