### PR TITLE
Currency Tracker 1.3.4.3

### DIFF
--- a/stable/CurrencyTracker/manifest.toml
+++ b/stable/CurrencyTracker/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/AtmoOmen/CurrencyTracker.git"
-commit = "2633c2191124c39c124f4d903041cd2040485ac1"
+commit = "f9d9d20892debc1e2857787e4e3816ebd2817ed7"
 owners = ["AtmoOmen"]
 project_path = "CurrencyTracker"
 changelog = """
-- Fix an DateTime parsing issue.
+- Fixed a file save failure error that occurred when a specific item name contained characters that could not be used as a file name.
 """


### PR DESCRIPTION
- Fixed a file save failure error that occurred when a specific item name contained characters that could not be used as a file name