### PR TITLE
[stable] ChatTranslated v1.4.1.0

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "a901469a41758bfd027aaf0510dbd3c728e51fa8"
+commit = "fab0e48578e46381c17f7fe73ab8b32bd03863da"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
-changelog = "New icon. Attempt to fix a bug where connection fails with VPN."
+changelog = "various bug fixes. added option to disable plugin in duty. added Better Translation option for OpenAI API mode."
 [plugin.secrets]
 chatfunction_key = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAeezmQlBzptEr4kFDPVxfwQlrkFIrQEv+gW9T6hXI\nSRkwhyoasqyUkEmHw5JPl/Mo+QLnfVPZ2U1SBdiQyTgbMnNQsrETk8ey+xcg\naap2G4lj0lkBTYS2qV6OCPwFo73Pzv09g5yCiPjAs6h/unUb3sBMIuDMsSM+\nyfxY2Et8tqMPzXB2vXVGnHQIHqC7EuKRxOjJOiBpIVFAmp7dFEQOBJv4s8G0\nFlYaiMawxA==\n=Ii28\n-----END PGP MESSAGE-----\n"


### PR DESCRIPTION
New config option:
Enable in duty (default off)
Better translation: Can choose to use GPT-4-turbo and more detailed prompt in OpenAi API mode

Bug fixes:
Fixed config window size.
Fixed a bug where server names are included in the sender field of translated message.
Fixed a bug where message will not appear in main window if filtered.