### PR TITLE
Pet Nicknames v1.4.8.1

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
 commit = "e6b97264a33d5ef705427cea59047bafa1bbe86b"
-owners = ["Glyceri",]
+owners = ["Glyceri"]
 	changelog = """
     [1.4.8.1]
     Fixed an issue where commands would still show in chat.
@@ -10,3 +10,4 @@ owners = ["Glyceri",]
     Chat messages that Pet Nicknames sets hidden now properly remain hidden.
     Pets on the Mappy Map will no longer show stuck when you are mounted.
     Pet Nicknames is now enabled in the Wolves' Den Pier, but as a result even more restricted in non-Wolves' Den Pier zones.
+"""

--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,8 +1,12 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "a86806f4940441dc4d04ae23ce468641c6217c76"
+commit = "e6b97264a33d5ef705427cea59047bafa1bbe86b"
 owners = ["Glyceri",]
 	changelog = """
-    + [1.4.7.1]
-    + Ready for nicknames!
-"""
+    [1.4.8.1]
+    Fixed an issue where commands would still show in chat.
+    [1.4.8.0]
+    The Mappy popup window is now reduced to a chat message.
+    Chat messages that Pet Nicknames sets hidden now properly remain hidden.
+    Pets on the Mappy Map will no longer show stuck when you are mounted.
+    Pet Nicknames is now enabled in the Wolves' Den Pier, but as a result even more restricted in non-Wolves' Den Pier zones.


### PR DESCRIPTION
    [1.4.8.1]
    Fixed an issue where commands would still show in chat.
    [1.4.8.0]
    The Mappy popup window is now reduced to a chat message.
    Chat messages that Pet Nicknames sets hidden now properly remain hidden.
    Pets on the Mappy Map will no longer show stuck when you are mounted.
    Pet Nicknames is now enabled in the Wolves' Den Pier, but as a result even more restricted in non-Wolves' Den Pier zones.