### PR TITLE
TextToTalk v1.28.9

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "0f68a13c36ee95ee3fed997785bcc16ab5128e7c"
+commit = "7a54207f0f093c2d73d3067c7dc0e506288e9925"
 project_path = "src"
 owners = ["karashiiro"]
 changelog = """\
-- Fixes voice preset deletions not always being saved
+- Fixes being unable to add lexicons to the Azure voice backend
+- Fixes being unable to save changes to existing chat type presets
+- Small internal refactor which might fix some other minor bugs in voice playback
 """


### PR DESCRIPTION
- Fixes being unable to add lexicons to the Azure voice backend
- Fixes being unable to save changes to existing chat type presets
- Small internal refactor which might fix some other minor bugs in voice playback