### PR TITLE
OfDungeonsDeep v1.0.0.2

### DIFF
--- a/stable/OfDungeonsDeep/manifest.toml
+++ b/stable/OfDungeonsDeep/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NotNite/OfDungeonsDeep.git"
-commit = "7f5fd04c8ea48b1992ad572e5e044bc986697745"
+commit = "7478715b2a419814eb25e5b42b033136b7817eb3"
 owners = ["NotNite", "MidoriKami"]
 project_path = "OfDungeonsDeep"


### PR DESCRIPTION
Disable ESC key from trying to close TargetDataWindow.

It's an overlay, it's not meant to be able to be closed. If you want it to not show, turn it off in the settings.