### PR TITLE
Browsingway 1.6.0.0 (.net 8)

### DIFF
--- a/stable/Browsingway/manifest.toml
+++ b/stable/Browsingway/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Styr1x/Browsingway.git"
-commit = "68fd115247cece23711aba63df709282f8afcdd0"
+commit = "45b2380ff73264ac5aa655448db95cb528e45858"
 owners = ["Styr1x"]
 project_path = "Browsingway"
 changelog = """\
-- Chromium 121.0.6167.184 (fix for various CVEs)
-- Fullscreen mode by Una (experimental, unsupported)
-- Minor UI fixes
+- Chromium 122.0.6261.112
+- Option to hide overlays out of combat (by electr0sheep)
+- .net 8 support
+- IPC refactoring
 """


### PR DESCRIPTION
- Chromium 122.0.6261.112
- Option to hide overlays out of combat (by electr0sheep)
- .net 8 support
- IPC refactoring