### PR TITLE
Tick Tracker 1.4.1.0

### DIFF
--- a/stable/TickTracker/manifest.toml
+++ b/stable/TickTracker/manifest.toml
@@ -1,10 +1,9 @@
 [plugin]
 repository = "https://github.com/Kurochi51/TickTracker.git"
-commit = "a1cb14b1b68759ca2827d1e3a94d63bce7ba3c57"
+commit = "b361daa9fd4157b162992dc1af808bb083616f5a"
 owners = ["Kurochi51"]
 project_path = "TickTracker"
 changelog = """
-- Fix a bug that wouldn't take into account the LockBar checkbox state when showing or hiding the HP and MP bar.
-- Remove obsolete PluginEnabled option.
-- Reorganized the Settings window.
+- Added an alternative tick indicator that uses the native ui.
+- NET8 update
 """


### PR DESCRIPTION
nofranz
Moved native update from testing to stable since no one has reported an issue since, also changed to net8 stuff.
This is the diff since the last testing PR [diff +260 -224](https://github.com/Kurochi51/TickTracker/compare/41686616cb549fec763bf4a202babe056136ef54..main)