### PR TITLE
NeatNoter 2.5.2.0

### DIFF
--- a/stable/NeatNoter/manifest.toml
+++ b/stable/NeatNoter/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/NeatNoter.git"
 owners = [ "kalilistic" ]
 project_path = "src/NeatNoter"
-commit = "5dcf850126244df6cbb697f16b6ef35b530452fc"
+commit = "c0c87899c61e3b9de7ece82d9efcdbc3e578425c"


### PR DESCRIPTION
- Update deprecation warning to be more clear that the plugin is up for adoption if another developer is interested. If you are interested then stop by the plugin dev channel.
- Fix bug with exporting data with game characters.
- Upgrade to net8.