### PR TITLE
ActionTimeline release 1.3.0.1

### DIFF
--- a/stable/ActionTimeline/manifest.toml
+++ b/stable/ActionTimeline/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/ActionTimeline.git"
-commit = "5280394852b052dd4a3d896aa12cf11c0d4ad02d"
+commit = "9c3df56537445f62a6bd3bd205f195eea739ea61"
 owners = ["Tischel"]
 project_path = "ActionTimeline"
-changelog = "- Added support for patch 6.5 and Dalamud API 9."
+changelog = "- Fixed Samurai's Kaeshi: Namikiri not showing correctly on the timeline.\n- Fixed several Ninja actions not showing correctly on the timeline."


### PR DESCRIPTION
- Fixed Samurai's Kaeshi: Namikiri not showing correctly on the timeline.
- Fixed several Ninja actions not showing correctly on the timeline.