### PR TITLE
ChatTwo 1.19.3

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "5ceb327f3ad4f322ea9f76878dfcbfc5bcc1ecb1"
+commit = "40fd726519756470d4c487f33a353b5ec3532d75"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "40fd726519756470d4c487f33a353b5ec3532d75"
+commit = "882099affe6fde5621b3c3de44730e6297e6f3cf"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Add "Adventurer Plate" option to the context menu of players (same requirements as vanilla chat)
- Automatically move the item tooltip to not be covered by chat2
  - This only applies if the option "Next to Cursor" is selected by the user
- New crowdin URL