### PR TITLE
[Testing] MacroMate 1.0.9.0

### DIFF
--- a/testing/live/MacroMate/manifest.toml
+++ b/testing/live/MacroMate/manifest.toml
@@ -1,6 +1,11 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "8540d3b14a2243131cbaead16431bb185e2fa44d"
+commit = "bed2fd1378983a3796c5b89057f542a66a4ba924"
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.6.1"
+version = "1.0.9.0"
+changelog = """
+- Auto-translate support (copy/paste only)
+
+This is a fairly significant change under the hood so please report any bugs while this is under testing
+"""


### PR DESCRIPTION
- Auto-translate support (copy/paste only)

This is a fairly significant change under the hood so please report any bugs while this is under testing. 

(My plan is to leave this version in testing for a week or so and then publish it to stable, since under the hood we moved from `string` to `SeString` and I want to see it work cleanly on other machines)