### PR TITLE
[Testing] ChatTwo 1.20.1

### DIFF
--- a/testing/live/ChatTwo/manifest.toml
+++ b/testing/live/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "4369a9ae7943401ced781305a9599e3f85dbdf00"
+commit = "8446cb3c1f63895fc7a25dc3cfada78a9239d2b3"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Full support for role colors and icons
  - Just like vanilla chat, this only works if your party members are in the same area
- Fix Command Helper not closing
- Fix Command Helper window appearing if it shouldn't
- Allow freely resizing all chat log windows 
- New copy methods [thanks @deansheather]
  - "Copy" will copy everything to your clipboard
  - "Copy content" only copies the message content
- Clickable URLs [thanks @deansheather]
  - Only some well known tlds (com, net, org ....) will work without www / https
  - **DO NOT CLICK URLs YOU DON'T TRUST**
- Working tells in Eureka/Bozja
  - Same behaviour as vanilla chat, the moment your input loses focus it will reset to the previous input channel
- Tooltips with content added by PriceInsight aren't cut-off anymore
- Added configurable height offset for tooltips

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/22648449/3d5b7bd5-6c17-46ea-8db3-e298b9daceae)