### PR TITLE
[Testing] ChatTwo 1.20.3

### DIFF
--- a/testing/live/ChatTwo/manifest.toml
+++ b/testing/live/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "9feb70d26234443051fe8d2f5eea775aacfd85de"
+commit = "f52bc2a41b21a1eb9433be8a9ac6f69e32005f60"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
### New
- New option to hide chat2 during loading screens [default false]
- Allow Users to Override the Popout and ChatLogWindow Styles [default false, thanks @spide-r]
- Allow tab input channel to be set to ExtraChat [thanks @deansheather]
- Hide unused ECLS indices from chat selector menu [thanks @deansheather]
- Added database details section to settings  [thanks @deansheather]

### Adjustments
- Use hi-res textures for all icons in chat
- Replaced some old functions with newer ones which should help stability and future-proofing
- ScreenshotMode also hides tell target name now [thanks @deansheather]

### Fixes
- Fix ESC key not working
- Fix autocomplete menu crashing for languages with special letters like é and â (looking at you french <-<)
- Fix autocomplete menu not working in quick tell reply [thanks @deansheather]
- Fix quick tell reply getting reset on chat unfocus [thanks @deansheather]
- Fix double-up player names in screenshot mode [thanks @deansheather]

### Experimental
- Keybinds are checked every framework update now, fixes temp channel keybinds not working
  - If you notice FPS drops, lags or other issues, please inform the author
