### PR TITLE
RoleplayProfiles 1.1.0.0

### DIFF
--- a/stable/RoleplayProfiles/manifest.toml
+++ b/stable/RoleplayProfiles/manifest.toml
@@ -1,6 +1,9 @@
 [plugin]
-repository = "https://github.com/Maia-Everett/dalamud-roleplay-profiles.git"
-commit = "94b7cdfd0b5478f87c3b0bd489660e6766275193"
+repository = "https://codeberg.org/Linneris/dalamud-roleplay-profiles.git"
+commit = "5cfc4bc3abf0a32bc28aee6f04016045287383cb"
 owners = ["Maia-Everett"]
 project_path = "RoleplayProfiles"
-changelog = """RPP now supports creating character profiles for the North America region (via crystalarchives.org) in addition to Europe (via chaosarchives.org). User accounts are shared for both sites."""
+changelog = """
+* The plugin no longer asks for the user password to log in. Instead, it opens an in-browser authorization page.
+* Characters from all regions are now supported thanks to the cross-region character profiles website, Central Archives (https://centralarchives.org).
+"""


### PR DESCRIPTION
* The plugin no longer asks for the user password to log in. Instead, it opens an in-browser authorization page.
* Characters from all regions are now supported thanks to the cross-region character profiles website, Central Archives (https://centralarchives.org).

Screenshots:

![image](https://github.com/goatcorp/DalamudPluginsD17/assets/10684/931318f0-7214-4170-b210-0f6da68d2aa5)
![image](https://github.com/goatcorp/DalamudPluginsD17/assets/10684/0de0ca57-466b-40fa-a5d3-386358df4850)

