### PR TITLE
ChatTwo 1.21.0

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "882099affe6fde5621b3c3de44730e6297e6f3cf"
+commit = "5f7199773a4b5d4029005c9d117f8839e7274a0a"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**New**
- Full support for role colors and icons
    - Just as vanilla chat, this only works if your party members are in the same area
- New option to hide chat2 during loading screens [default false]
- Added configurable height offset for tooltips [default 10px]
- Allow Users to Override the Popout and ChatLogWindow Styles [default false, thanks @spide-r]
- Allow tab input channel to be set to ExtraChat [thanks @deansheather]
- Hide unused ECLS indices from chat selector menu [thanks @deansheather]
- Added database details section to settings  [thanks @deansheather]
- Clickable URLs [thanks @deansheather]
    - Only some well known tlds (com, net, org ....) work without www / https
    - **DO NOT CLICK URLs YOU DON'T TRUST**

**Adjustments**
- Use hi-res textures for all icons in chat
- Switch to dalamud window system for all UI
- Replaced some old functions with newer ones which should help stability and future-proofing
- Expanded the About tab with more infos and links to get help
- ScreenshotMode also hides tell target name now [thanks @deansheather]
- Copy methods [thanks @deansheather]
    - "Copy" will copy everything to your clipboard
    - "Copy content" only copies the message content

**Fixes**
- Tells in Eureka and Bozja
    - Same behaviour as vanilla chat, unfocus input and it resets to the previous input channel
- ESC key not working
- Double messages on login
- Tooltips with content added by PriceInsight being cut-off
- ChatAlerts not letting tell messages pass
- Autocomplete menu crashing for languages with special letters like é and â (looking at you french <-<)
- Autocomplete menu not working in quick tell reply [thanks @deansheather]
- Quick tell reply getting reset on chat unfocus [thanks @deansheather]
- Double-up player names in screenshot mode [thanks @deansheather]

**Experimental**
- Keybinds are checked every framework update now, fixes temp channel keybinds not working
    - If you notice FPS drops, lags or other issues, please inform me (@infi)


![preview](https://github.com/Infiziert90/ChatTwo/raw/main/ChatTwo%2Fimages%2FchatWindow.png)


From testing to stable, real diff:
https://github.com/Infiziert90/ChatTwo/compare/1a2b313598324a7095fda41069ecd17c1240548f..5f7199773a4b5d4029005c9d117f8839e7274a0a