### PR TITLE
ChatTwo 1.21.2

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "30ccf8e416abd74ea28710338a64ca97484f0994"
+commit = "7d1ab8b98eeed855ab28e74600bf326909755f68"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Disable window open/closing sounds for all of chat2

Note:
There is a known bug that chat2 might crash while a Game Master (GM) writes in chat.
To finish your GM conversation, please start your game without plugins, `right-click login -> without dalamud`
if you happen to crash please inform me over discord `@infi` or use the buttons in the about tab