### PR TITLE
ChatTwo 1.21.3

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "7d1ab8b98eeed855ab28e74600bf326909755f68"
+commit = "2d69af3f5cd1c8431ec82756c94e031d29a73c65"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**New Stable Update v1.21.3**

**New**
- Option to limit drawn messages [default 10k, thanks @haroldiedema]
  - Performance increase is more notable with lower limits
  - Use a limit that you are comfy with, nobody needs 10k messages (original behaviour) drawn at all times~

**Fix**
- Set channel whenever tabs user switches chat tab, this fixes weird behaviour with macros 
- Use same hide state for chat log and popouts
- Correctly dispose chat2 if it explodes while loading