### PR TITLE
XIVDeck 0.3.17

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "cca5a774ab3a739cc5e2f89b4e42171be1a805b0"
+commit = "99279ec293a49cd6ce5afee22065a1bfedf0690e"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Features don't really matter, right? Right?

- Use the shiny new notification system to inform users that it's time to update the Stream Deck Plugin.
- Finally update to .NET 8
- Update some internal dependencies

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.17).