### PR TITLE
1.22.1

### DIFF
--- a/testing/live/ChatTwo/manifest.toml
+++ b/testing/live/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "b4cb73dd0aa0f33d22ad5ede6bc8af7b47793b19"
+commit = "3d281626413ef28b52f5d2bc5c901a4881b08cd7"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Stop popout tabs from freezing
- Prevent tabs from triggering errors when reordered
- Use ImRaii everywhere, this should help with stability
- Fix a height issues that lead to chat rapidly flicker in popout and main window
  - Unsure if this fixed the issue of chat flickering in general
  - If it still happens to you, please send feedback
- Disabled ESC key closing for the migration window
- Scale icons with the general font size
  - The icon buttons left and right of the input box align now
- Fix settings not applying correctly