### PR TITLE
ChatTwo 1.23.1

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "86485373a428cf37ea3fbd9c5b3423999bc8501e"
+commit = "91129d5bb36df48a6b44801fa676f6fd346b1bc9"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "8e006f8ab56799cbaecf0b57b3667011728b5b64"
+commit = "86485373a428cf37ea3fbd9c5b3423999bc8501e"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Allow tabs to have disabled input
- Disable native tooltips for event item, it will default to chat2 tooltips for these
- Fix hitch that occurred on first message sent [thanks `@dean`]
- Auto translate should now include all possible options, including Races, Clans and Companion Actions [thanks `@dean`]

- Update german localization

Note: 
Sorry PAC, crowdin decided to ruin my loc files