### PR TITLE
ChatTwo 1.23.2

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "91129d5bb36df48a6b44801fa676f6fd346b1bc9"
+commit = "b9e3920ff3699cde091e416ea7eb839ce9523f80"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Fix event items not working with vanilla tooltips [thanks `@nebel`]