### PR TITLE
ChatTwo 1.23.3

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "b9e3920ff3699cde091e416ea7eb839ce9523f80"
+commit = "5b30e54f65a9a6e2102423c8a5599e46ededb9a7"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Tabs with disabled input ignore all keybind and input events
  - Only exception is pressing the Enter-Key while chat2 is hidden
- Error messages won't be saved to the DB anymore
  - Like Battle Messages they are not important and also can be heavily spammed by the game
  - This will also fix the issue of Chat2 freezing in battle, because of people macro spamming <-<
- Internal performance improvements for read and write will lead to less freezes and better performance [thanks `@dean`]