### PR TITLE
[Testing] Umbra 1.0.6.17

### DIFF
--- a/testing/live/Umbra/manifest.toml
+++ b/testing/live/Umbra/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "a4e566552914041a0da67890c0b78bc3da067f05"
+commit = "0d4288fced8eb2d0c481eaab271b9b8efeefecaa"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """

--- a/testing/live/Umbra/manifest.toml
+++ b/testing/live/Umbra/manifest.toml
@@ -1,14 +1,13 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "e4bc833f9ba5ea9aa81803c8afbccc05fe51caaf"
+commit = "a4e566552914041a0da67890c0b78bc3da067f05"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
- - Add visibility options for combat & duties
- - Add (optional) auto-hide functionality
- - Add (optional) shadow aestehtics to the toolbar
- - Add right-click option to the Online Status widget to open the Social Window
- - Add mentor statuses to the Online Status widget menu
- - Updated the Stacked Clock widget to respect all clock-related settings
- - Add options to toggle default label and icon for the currencies widget
+- Added an option to auto-close the gearset switcher when changing gearsets
+- Fixed thousands separator for clients that use NNBSP in the Currency Widget
+- Fixed the overflow container shadow effect not scaling with custom UI scale
+- Fixed & Added localization for Volume, World Marker, and Gearset widgets
+- Fixed the clock widgets showing the wrong prefix icon if the language in Umbra has been overridden.
+- Fixed the district name in the location widget to be faster and match in-game names.
 """


### PR DESCRIPTION
- Added an option to auto-close the gearset switcher when changing gearsets
- Fixed thousands separator for clients that use NNBSP in the Currency Widget
- Fixed the overflow container shadow effect not scaling with custom UI scale
- Fixed & Added localization for Volume, World Marker, and Gearset widgets
- Fixed the clock widgets showing the wrong prefix icon if the language in Umbra has been overridden.
- Fixed the district name in the location widget to be faster and match in-game names.