### PR TITLE
ChatTwo 1.24.0

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "32ccf721124ef44ec23392b2db6f02367d1d1899"
+commit = "638d462732c59ffa7f18f12f08dbd58699533124"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "50cb486cdad64b660dc3feb1d93d371e9d586f08"
+commit = "e7e4c0e2212d3ef07cac73bc9949cd8f567d0fed"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "e7e4c0e2212d3ef07cac73bc9949cd8f567d0fed"
+commit = "32ccf721124ef44ec23392b2db6f02367d1d1899"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**New**
- Emote support [**Enabled by default**]
  - Uses BetterTTV for all its emotes, Twitch won't be supported because of Auth requirements
  - You can block specific emotes in the config
  - Currently has 1157 emotes available
  - Just try "catJAM" in your cat~

- Option to hide chat2 while in combat [disabled by default]
- Option to keep input focus at all times [enabled by default]


**Fixes and Updates**
- More loc updates
- Maybe no more jittering/flickering ? [thanks `@dean`]
- Improved message processing speeds [thanks `@dean`]
- Prevent messages from going out of order in some cases [thanks `@dean`]

