### PR TITLE
ChatTwo 1.24.2

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "638d462732c59ffa7f18f12f08dbd58699533124"
+commit = "b7c6c1da5ac130abbf7c36288a7f4d7fd4c20328"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Fixes TextChunks with null content from crashing chat log
- Prevents TextChunks with null content from being written, they will now be replaced with ""
- Fixes messages being rendered on the same line as the previous message
- Fixes messages being clipped off at the start in modern view 
- Fix emotes not working in ExtraChat channels