### PR TITLE
[Testing] Allagan Tools v1.7.0.0

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,18 +1,32 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "baefeee3d269d1b5bf5c1ea7a1e9f478a544ad96"
+commit = "dabc3e9c74f896fda2cfce5c13db6ee25dded377"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.6.0.4"
+version = "1.7.0.0"
 changelog = """\
-**Allagan Tools: v1.6.0.4**
-- Have finished crafts count correctly towards completion based on their flags
-- Add the ability to choose "Empty" as a source
-- Fix an issue where setting an item to 0 while Hide Completed is active would remove all the items
-- The craft table now has a moveable splitter with a saved position + the original collapse functionality
-- Copying a configuration into the default craft list now works
-- Stopped items that can't be bought from gil vendors from being considered as buyable(even if they have a buy from vendor price)
-- Unless there are other bugs this will be the final release before this is pushed to live
+**Allagan Tools 1.7.0.0 - Reworked**
+- With this version comes an entirely reworked internal structure, which should give a much more reliable base for any new features I decide to add. To go along with the new internals are:
+
+**New Features:**
+- All columns can now be renamed and some can be configured, multiple copies of the same column can be added
+- The market integration now supports multiple worlds, associated columns and craft lists can be configured to pick which worlds are applicable to you
+- The more information window has a market tab listing the current prices
+- Configuration wizard for when you first install the plugin and if you choose when new features come out
+- Buy/craft/gather button columns added
+- Favourites column added
+- Add to craft list context menu added
+- The plugin can be opened when not logged in
+- A icon can be added to the main dalamud menu for easy access
+
+
+**Changes:**
+- Filters are now called Lists so there are Item Lists and Craft Lists
+- Settings menus reworked
+- Support .net 8(finally)
+
+**Removed:**
+- Some of the older Inventory Tools specific slash commands
 """

--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "dabc3e9c74f896fda2cfce5c13db6ee25dded377"
+commit = "3cd089f43d2ebba89f11d82b552b0637a67d606a"
 owners = [
     "Critical-Impact",
 ]


### PR DESCRIPTION
**Allagan Tools 1.7.0.0 - Reworked**
- With this version comes an entirely reworked internal structure, which should give a much more reliable base for any new features I decide to add. To go along with the new internals are:

**New Features**
- All columns can now be renamed and some can be configured, multiple copies of the same column can be added
- The market integration now supports multiple worlds, associated columns and craft lists can be configured to pick which worlds are applicable to you
- The more information window has a market tab listing the current prices
- Configuration wizard for when you first install the plugin and if you choose when new features come out
- Buy/craft/gather button columns added
- Favourites column added
- Add to craft list context menu added
- The plugin can be opened when not logged in
- A icon can be added to the main dalamud menu for easy access


**Changes**
- Filters are now called Lists so there are Item Lists and Craft Lists
- Settings menus reworked
- Support .net 8(finally)

**Removed**
- Some of the older Inventory Tools specific slash commands