### PR TITLE
ChatTwo 1.25.0

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "26e993be675f28e609df6799e54ef09aab875d9a"
+commit = "c9383e5411022e1bcda256d8d317a30bae4de3ea"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**New**
- A preview of what will actually appear in chat, with emotes, autotranslate and text
  - Defaults to Inside!!!
  - Possible positions: Inside-, Below- or Above the chat log
  - If you want to disable this: /chat2 -> Miscellaneous -> Input Preview -> None

**Fixes**
- Emote names will now be displayed if the loading failed
- Emotes use 3x resolution now, this makes them just sharper overall
- Emotes will now appear on the next line, if the available space isn't enough
- Avoid message parsing errors in logs [thanks `@dean`]
- More stability updates to prevent crashes
