### PR TITLE
DelvUI release 2.1.3.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "904a24fdf97da6b0b241de407d1e6e859e61bfc9"
+commit = "3f43d781764aa22ed775b8ad36f2f5e74f7e31f8"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added "Always show while target exists" visibility setting.
- Fixed the default castbar, job gauges and pull timer sometimes being off screen when DelvUI is unloaded.
- Fixed the chat getting spammed with hotbar commands during dialogues.