### PR TITLE
ChatTwo 1.25.1

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "c9383e5411022e1bcda256d8d317a30bae4de3ea"
+commit = "23122e924bb814fc1846b4752bdf68da843a60da"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Input Preview now supports <item> and <flag>
- Share code between inside and top/bottom, so they behave the same now