### PR TITLE
[Testing] Allagan Tools 1.7.0.1

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,32 +1,23 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "3cd089f43d2ebba89f11d82b552b0637a67d606a"
+commit = "7e106ffc0d72111d40535449168af58eff5c5efa"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.7.0.0"
+version = "1.7.0.1"
 changelog = """\
-**Allagan Tools 1.7.0.0 - Reworked**
-- With this version comes an entirely reworked internal structure, which should give a much more reliable base for any new features I decide to add. To go along with the new internals are:
+**Allagan Tools 1.7.0.1**
+- Thanks for all the bug reports, as this is a rework they are to be expected, hopefully I've gotten the most obvious ones
 
-**New Features:**
-- All columns can now be renamed and some can be configured, multiple copies of the same column can be added
-- The market integration now supports multiple worlds, associated columns and craft lists can be configured to pick which worlds are applicable to you
-- The more information window has a market tab listing the current prices
-- Configuration wizard for when you first install the plugin and if you choose when new features come out
-- Buy/craft/gather button columns added
-- Favourites column added
-- Add to craft list context menu added
-- The plugin can be opened when not logged in
-- A icon can be added to the main dalamud menu for easy access
+**Fixes:**
+- Lists would sometimes not update on login
+- Changing tab would not refresh the highlighting if it was active
+- Opening a single list with /openlist now works
+- Hotkeys for windows will toggle instead of just opening
+- Highlighting should mostly work now
+- The filter bar in lists were sharing a common object that cached what the user had typed meaning whatever you typed in one column filter would show up in all other columns of that type, this has been fixed
+- Boolean columns now use a dropdown instead of a checkbox
+- The filters window was not being removed from the open windows list making it come up on plugin load
 
-
-**Changes:**
-- Filters are now called Lists so there are Item Lists and Craft Lists
-- Settings menus reworked
-- Support .net 8(finally)
-
-**Removed:**
-- Some of the older Inventory Tools specific slash commands
 """


### PR DESCRIPTION
**Allagan Tools 1.7.0.1**
- Thanks for all the bug reports, as this is a rework they are to be expected, hopefully I've gotten the most obvious ones

**Fixes:**
- Lists would sometimes not update on login
- Changing tab would not refresh the highlighting if it was active
- Opening a single list with /openlist now works
- Hotkeys for windows will toggle instead of just opening
- Highlighting should mostly work now
- The filter bar in lists were sharing a common object that cached what the user had typed meaning whatever you typed in one column filter would show up in all other columns of that type, this has been fixed
- Boolean columns now use a dropdown instead of a checkbox
- The filters window was not being removed from the open windows list making it come up on plugin load
