### PR TITLE
Mappy v2.0.0.0

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "d796b1f5fbfad1862176251f92391040baefa1fb"
+commit = "f40d4251bbcd547dbc6a77951388b25e72006cb5"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "58da1c57f435c25c9936dabeb86cee541abf43de"
+commit = "4f0bcc2a5064082e25ce64257e03294ad7377312"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "6714360c6186732a2061e2bf4c3a9a475304542c"
+commit = "58da1c57f435c25c9936dabeb86cee541abf43de"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "f40d4251bbcd547dbc6a77951388b25e72006cb5"
+commit = "ab107877c4ad49ef8d73b8e54e0fba0b83747ead"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "ab107877c4ad49ef8d73b8e54e0fba0b83747ead"
+commit = "6714360c6186732a2061e2bf4c3a9a475304542c"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Mappy Code Rewrite

Mappy now will show **all** vanilla map markers.

Configuration has changed, now you can can configure per-icon rather than per-module.

This is a testing release, please test for bugs and report any feedback or changes you think would be good.