### PR TITLE
Update AutoMountBgm (stable)

### DIFF
--- a/stable/AutoMountBgm/manifest.toml
+++ b/stable/AutoMountBgm/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/PrincessRTFM/AutoMountBGM.git"
 owners = [ "PrincessRTFM",]
 project_path = ""
-commit = "b604afb8f2efbdc64a16b6e4192978cf5e2c4f7a"
-changelog = "Mount BGM will now be automatically disabled when unmounting, so that volume doesn't stutter when using a BGM-disabled mount."
+commit = "0e55f7c5bad46ef28e1f99c52426fcfbf8b9b4f4"
+changelog = "It's now possible to use the UI to control per-mount BGM settings without needing to actually get on the mount and use a command. Additionally, there are filtering options in the UI for simplicity. Finally, there's now an option to disable the BGM track \"Borderless\" (mount default) without needing to manually turn off BGM for the relevant mounts."


### PR DESCRIPTION
It's now possible to use the UI to control per-mount BGM settings without needing to actually get on the mount and use a command. Additionally, there are filtering options in the UI for simplicity. Finally, there's now an option to disable the BGM track "Borderless" (mount default) without needing to manually turn off BGM for the relevant mounts.