### PR TITLE
ChatTranslated v2.1.2.1

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "71588416f56625d242d01b7f485b2adf85245003"
+commit = "3102eba5da16673e94340ca0c98bf6498bc398fc"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
-Performance boosts, especially when using the main window.
+Re-add Korean support.
+Didn't know that changing Dalamud font settings allow users to render Korean in plugin windows.
 """
 [plugin.secrets]
 cfv2 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAVF7lQi3ll0QVVHXhrxWWvn56lJGXqQmi7PSprdGJ\nnAEwPWuybeVbiv23purRpMKyRd0Tnnm/wswuf3TJFebn+5Kr2RZctJCK4y6L\nKoGsLHON0lgBxcrMMmv4IHrxs+M7L0Rcsriaw8dI1anSCxrlafxK7g6i+Xsx\nRa57QCwJOd8rMDhmuG9H+LdJZGtcSZHiZr+UapqCJaFZOEt1dYMoZlgcCLyA\nMB4PURNf\n=9CF1\n-----END PGP MESSAGE-----\n"


### PR DESCRIPTION
Re-add Korean support.
Didn't know that changing Dalamud font settings allow users to render Korean in plugin windows.