### PR TITLE
ChatTwo 1.26.0

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "b4f8ce59d3f5a3218ab72a26647f7242d5f7bc88"
+commit = "70989da680d3743d3380755b977902750032b2d9"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Replace all sigs with CS version
- Fix flags not working in reply mode
- Force the main chat log to be always open
- Prevent emotes inside auto translation