### PR TITLE
ChatTwo 1.26.2

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "17ff8fffeb990ba217475528b993d4af86880205"
+commit = "625d7596d341cf15d37a9a9890a595bf882ac5c7"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "70989da680d3743d3380755b977902750032b2d9"
+commit = "17ff8fffeb990ba217475528b993d4af86880205"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Fix tell reply hotkey not working
- Save the FFXIV font to disk instead of redownloading it on every startup
  - This should prevent errors if your DNS is giving up
- Make Linkshells appear in selection again