### PR TITLE
Waitingway 2.1.0

### DIFF
--- a/stable/Waitingway.Dalamud/manifest.toml
+++ b/stable/Waitingway.Dalamud/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Waitingway.git"
-commit = "50cd052db86fe12c49748564878f3f86d63c231b"
+commit = "31eecf4a4a4700c22ebf34236c641dd83b5d39a0"
 owners = ["avafloww", "NPittinger", "WorkingRobot"]
 project_path = "Waitingway"


### PR DESCRIPTION
- Much better ETA, now always useful and accurate to the second!
- Much better collection of queue data
- Better handling when re-entering a queue
- Fixed integration with the Rich Presence plugin
- View what's happening in your queue under the hood
- Notifications now remind you how soon to requeue to not lose your spot
- Notifications now show any error message the client provides
- Notifications now include your player's name
- Added support for the worlds that were added on June 11
- Added a menu item on the main menu screen