### PR TITLE
PvP Tracker v2.0.4.1

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "c3abdb22823584ebba61bfd4e66f2b8951186753"
+commit = "854cc090a497295b4786027ca1941a112d32afd6"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Added match caching for increased performance.
-* Added Frontline support.
+* Fixed a bug where players from new Dynamis worlds would be added as extra players.
+* Rival Wings tracking (v2.0.0.0)
+* Frontline Battle high tracking (v2.0.3.0)
+* Other UI improvements (v2.0.4.0)
 """


### PR DESCRIPTION
* Pushing current testing to stable + a bug fix for Crystalline Conflict where the player list will include extra entries for players from new Dynamis worlds.

The diff compared to the testing version is: https://github.com/wrath16/PvpStats/compare/b480e04..854cc09