### PR TITLE
[Testing] Party Icons v1.2.0.0

### DIFF
--- a/testing/live/PartyIcons/manifest.toml
+++ b/testing/live/PartyIcons/manifest.toml
@@ -1,14 +1,10 @@
 [plugin]
-repository = "https://github.com/shdwp/xivPartyIcons.git"
-commit = "03b9ce7e6d2e9b7ca53e27dd1d3cfbd0cfa70586"
+repository = "https://github.com/nebel/xivPartyIcons.git"
+commit = "c61f9b251c84b67fa3ed954bbd46cbb002c51113"
 owners = [
     "shdwp",
     "avafloww",
-    "squidmade",
+    "abashby",
+    "nebel"
 ]
 project_path = "PartyIcons"
-changelog = """
-- In the settings window, Testing Mode and the General tab now flash when enabled 
-- Fixed a bug when converting v1 to v2 config where Game Default chat settings resulted in role colors being enabled
-- Refactored UI code
-"""


### PR DESCRIPTION
**Additions**
- Added option to show both job/role and online status icons simultaneously for all display modes.
- Added the ability to configure which online status icons are shown or hidden and which icons are considered important.
- Added the ability to tweak nameplate appearance, including the ability to adjust icon visibility, position and size, set different icon sets per nameplate type, and configure how important online status icons are handled.
- Added two new icon sets: "Framed, role colored (small)" and "Embossed". Some other icon sets were also renamed for clarity.
- Added the ability to provide a custom scaling factor in addition to the existing Smaller/Medium/Bigger setting.
- Added the ability to show party numbers in place of roles for role-based display modes.

**Other improvements**
- Standardized icon set scaling so that "Gradient" is now of similar size to other icon sets.
- Improved context menu appearance and added an option to move context menu actions into a submenu (enabled by default).
- Improved the "Replace party numbers with role in Party List" option so it works even when using abbreviated names in the party list.
- Improved performance.

**Fixes**
- Fixed issues related to the game's built in option to show class or job icons interfering with the appearance of Party Icons nameplates. As a result, certain status icons should no longer incorrectly appear in strange places alongside nameplates.
- Fixed nameplates not being updated immediately when party roles change or after changing plugin settings.
- Fixed nameplate collision boxes. Previously "Role letters" and "Big job icon" modes especially had broken nameplate hitboxes and were often difficult or impossible to click, or had their clickable area in strange locations. The clickable area should now match the visible area more closely.
- Fixed some cases where nameplates could be temporarily scaled incorrectly for non-player targets.
- Fixed members with auto-assigned roles not having their role updated when their job changes.
- Fixed party list role icons not updating when using /psort.

**Notes**
- The default status icon behavior is now slightly different due to the old "priority status icons" system having been reworked.
- If you want to replicate the old behavior of "priority status icons" being ON, go to the Appearance tab and change the appropriate nameplate style as follows:
  - Set "Swap Style" to "Replace"
  - Set the "Overworld" status icon setting to to "Overworld (Legacy)".
- If you want to replicate the old behavior of "priority status icons" being OFF, go to the Appearance tab and change the appropriate nameplate style as follows:
  - Uncheck "Status Icon > Show"
