### PR TITLE
MacroMate 1.0.11.1

### DIFF
--- a/stable/MacroMate/manifest.toml
+++ b/stable/MacroMate/manifest.toml
@@ -1,10 +1,9 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "eee7b2184f2c7d9ea84c00b156c11c983b118b3b"
+commit = "6064bc4bb4716d788960a605a77a85ac1d496871"
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.11.0"
+version = "1.0.11.1"
 changelog = """
-- Added 'Sort' feature
-- Linked macro names can now be up to 20 characters long (previously limit was 14)
+- Fix issue when saving macros that contain auto-translate payloads
 """


### PR DESCRIPTION
- Fix issue when saving macros that contain auto-translate payloads