### PR TITLE
ChatTwo 1.26.3

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "625d7596d341cf15d37a9a9890a595bf882ac5c7"
+commit = "7a27ca8ea85f3c8b0defeb8ef3a61e4128c8e997"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Fix linkshell rotation not working