### PR TITLE
Craftimizer 2.4.4.0

### DIFF
--- a/stable/Craftimizer/manifest.toml
+++ b/stable/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
-repository = "https://git.camora.dev/asriel/craftimizer.git"
-commit = "7ad073a7a3a425594866229b48218bacc482e1ce"
+repository = "https://git.camora.dev/asriel/Craftimizer.git"
+commit = "1cbcc77643940e52319802bcaf571d6d51f450f1"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"

--- a/stable/Craftimizer/manifest.toml
+++ b/stable/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/Craftimizer.git"
-commit = "1cbcc77643940e52319802bcaf571d6d51f450f1"
+commit = "703a8ac469ace273ed808bfeef43cb99b50ac4ed"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"


### PR DESCRIPTION
- Helpers can now be collapsed whenever you wish. When collapsed, they are effectively disabled. You no longer need to keep the settings window open to temporarily disable the synth helper. (Thanks for the suggestion anemoshi)
- When pinned, helpers now move (and appear) exactly with the window it's pinned to. No more jelly-like movement
- Progress bars now show that they go past 100% for difficult crafts (this is intended behavior, and not a bug)
  - The tooltip is augmented with extra information when this happens
- New synth helper config option "Simulate Only First Step" - choose whether to display stats for all or just the first step in the synth helper
- Fix simulator bug where Manipulation ticked for actions that do not increase the step count
- Minor refactors with commands (new aliases: /macroeditor & /macrolist)
- Faster startup time (less time being stuck on the loading screen)
- Minor text changes to make things more clear
- Changed config parsing from Json.NET parsing to STJ