### PR TITLE
ChatTwo 1.26.4

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "7a27ca8ea85f3c8b0defeb8ef3a61e4128c8e997"
+commit = "1acd532ef13cb8533f55b02419402cfc098f4160"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- FIx chat hide command not working `[/chat2 (hide, show, toggle)]`