### PR TITLE
Craftimizer 2.4.4.1

### DIFF
--- a/stable/Craftimizer/manifest.toml
+++ b/stable/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://git.camora.dev/asriel/Craftimizer.git"
-commit = "703a8ac469ace273ed808bfeef43cb99b50ac4ed"
+commit = "90f53de3d88344084bb2413161c8051ef073dc3d"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"


### PR DESCRIPTION
Bug fixes to deal with issues in 2.4.4.0:
- Config bug with action pools (your settings are safe if you left them unmodified, they just weren't read from properly)
- A possible race condition when initializing data could cause the plugin to fail to load (previous startup speed increase is reverted)