### PR TITLE
Update AutoMountBgm (stable)

### DIFF
--- a/stable/AutoMountBgm/manifest.toml
+++ b/stable/AutoMountBgm/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/PrincessRTFM/AutoMountBGM.git"
 owners = [ "PrincessRTFM",]
 project_path = ""
-commit = "0e55f7c5bad46ef28e1f99c52426fcfbf8b9b4f4"
-changelog = "It's now possible to use the UI to control per-mount BGM settings without needing to actually get on the mount and use a command. Additionally, there are filtering options in the UI for simplicity. Finally, there's now an option to disable the BGM track \"Borderless\" (mount default) without needing to manually turn off BGM for the relevant mounts."
+commit = "7713fb491d32dec20be49a096bb1776c1ccfe239"
+changelog = "The mount list can now be filtered by the BGM track filename played, making it easy to track down all mounts playing the same song. There's a new button to enable/disable BGM for all mounts visible in the list, to go with the filtering improvements."


### PR DESCRIPTION
The mount list can now be filtered by the BGM track filename played, making it easy to track down all mounts playing the same song. There's a new button to enable/disable BGM for all mounts visible in the list, to go with the filtering improvements.