### PR TITLE
Hybrid Camera 1.3.0.0

### DIFF
--- a/stable/HybridCamera/manifest.toml
+++ b/stable/HybridCamera/manifest.toml
@@ -1,10 +1,8 @@
 [plugin]
 repository = "https://github.com/Drahsid/HybridCamera.git"
-commit = "2649eb473c86f2105366c43d60dbd8d379933b33"
+commit = "ff9414f0115acebc6f43e997f4dc152c8f73cd63"
 owners = ["Drahsid"]
 project_path = "HybridCamera"
 changelog = """
-- Updated for 6.5
-- Updated for API9
-- Code Cleanup
+- Updated for API10/7.0
 """


### PR DESCRIPTION
API 10 update. Additionally, this adjusts the plugin so that it passes all validation issues which it previously failed.
On top of this, DrahsidLib was updated to API 10.

There is some extra code here relating to controller mode and tests/reverse engineering on movement from 6.x, but none of it is enabled.
