### PR TITLE
XIVDeck 0.3.19

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "99279ec293a49cd6ce5afee22065a1bfedf0690e"
+commit = "eaeaa3bd31d142df5c1c954658df86798a0d0368"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
"*Changing legend into fact, We shall ride into history.*" With apologies to Elton John, of course. 

A very small change this time, just support for Patch 7.0 and the ability to put Facial Accessories on your Stream Deck now. Nothing fancy this time.

Full release notes, testing notes, and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.19).