### PR TITLE
TargetLines 1.6.0.0

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,13 +1,9 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "afa643a240e655d376577960a47a1d8a12373555"
+commit = "7d42e7d020bac36ce0b130343042c02261dc471e"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
-- UI occlusion now checks for line intersections, so there should no longer be segments appearing if it's rect overlaped a UI element, but did not intersect it under certain circumstances
-- Fixed a bug which would cause the end cap to have the wrong opacity when 'Fade to End' is enabled
-- Adjusted the rendering of the end caps so they appear uniform
-- Fixed issue where the first/third person transition for lines which target or source the player would appear disjointed
-- Minor optimizations in the broad phase of UI occlusion
+- Updated for API10/7.0
 """
 


### PR DESCRIPTION
api 10 update. I think the only thing new here is a cheater check which should never run on an official build of the plugin.