### PR TITLE
Talk Copy 1.1.0.0

### DIFF
--- a/stable/TalkCopy/manifest.toml
+++ b/stable/TalkCopy/manifest.toml
@@ -1,8 +1,17 @@
 [plugin]
 repository = "https://github.com/Glyceri/TalkCopy.git"
-commit = "915f3a0bf87f93a09c8beab02b3e939438d75345"
+commit = "0a2d9aec08b9869197401691ab67ecd07d2cd493"
 owners = ["Glyceri",]
 	changelog = """
-    [1.0.0.0]
-    Updated for ApiX
+    [1.1.0.0]
+    Added the command /talkcopy settings
+    Added the command /talkcopy logs
+    Added a new Log window
+    Added more settings to the settings menu
+
+    Now capable of copying Subtitles (togglable)
+    Now capable of copying Toasts (togglable)
+    Now capable of copying Battle Toasts (togglable)
+    Now capable of copying Error Toasts (togglable)
+    Now capable of copying Area Name Toasts (togglable)
 """


### PR DESCRIPTION
Added the command /talkcopy settings
Added the command /talkcopy logs

Added a new Log window
Added more settings to the settings menu

Now capable of copying Subtitles (togglable)
Now capable of copying Toasts (togglable)
Now capable of copying Battle Toasts (togglable)
Now capable of copying Error Toasts (togglable)
Now capable of copying Area Name Toasts (togglable)