### PR TITLE
Wholist v1.4.4.0

### DIFF
--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "414cdf72396c14ef47847ffcfdbfe99fc392cd45"
+commit = "467149807323a611c2d0b247b5f510f69a5f1afd"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
- Updates for Dawntrail
- Removes IPC due to it being buggy anyways.
- Small redesign to the settings UI.
- Disables the `/tell` functionality until/if XivCommon is updated.