### PR TITLE
SubmarineTracker 1.9.2.1

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "5a7f8bb1b2646ddc9dd0d5608c77425934f5f78a"
+commit = "188be47e7521d83cf35340250dae391feabe616e"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fix submarine names behaving weirdly
  - This fix will only apply after talking to the submarine interface