### PR TITLE
PvP Tracker v2.1.0.0

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,11 +1,9 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "854cc090a497295b4786027ca1941a112d32afd6"
+commit = "d7bef219e06d89c6a8a4eb8b7820cf89d7d7083d"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Fixed a bug where players from new Dynamis worlds would be added as extra players.
-* Rival Wings tracking (v2.0.0.0)
-* Frontline Battle high tracking (v2.0.3.0)
-* Other UI improvements (v2.0.4.0)
+* Updated for version 7.0 and Dalamud apiX.
+* Rival Wings matches temporarily disabled.
 """

--- a/testing/live/PvpStats/manifest.toml
+++ b/testing/live/PvpStats/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "b480e0422616038d2aea3e44e2014ab73f0ded01"
+commit = "d7bef219e06d89c6a8a4eb8b7820cf89d7d7083d"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Right-aligned all numeric values in summary and player/job tables.
-* Removed window max size constraints.
+* Updated for version 7.0 and Dalamud apiX.
+* Rival Wings matches temporarily disabled.
 """


### PR DESCRIPTION
* Updated for game version 7.0 and apiX compliance.

* Rival Wings tracking has been temporarily disabled since it's currently impossible to test the game mode.