### PR TITLE
Weatherman 2.4.1.0

### DIFF
--- a/stable/Weatherman/manifest.toml
+++ b/stable/Weatherman/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/Weatherman.git"
 # The commit to check out and build from the repository.
-commit = "3bc72031c07acdf250a45f439fb17635a4d0d668"
+commit = "0785f705b9c48a31fb1290466cd013ecd0dab506"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"


### PR DESCRIPTION
- Dawntrail update
- Enabled usage in: solo quest battles, houses and inns, instanced quest areas, island sanctuary
- Fixed a bug where quick selector wasn't properly responding when having few weathers with same name