### PR TITLE
VFXEditor v1.9.0.1

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "36493ade3dbd7fb711c46bd3b288e19c44b9234d"
+commit = "cbdb119c5f6f2127ebc924ada2bd10fed0db06a8"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Updated for 7.0
- `.kdb` editor
- `.shpk` v7
- Fixed some crashes and bugs
- Added `.tmb` track import/export
- Known issue: Penumbra integration is disabled
- Known issue: `.png` texture importing can cause some color channels to get flipped
- Known issue: `.mtrl` tile textures are broken