### PR TITLE
TargetLines 1.6.1.0

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "7d42e7d020bac36ce0b130343042c02261dc471e"
+commit = "842f64ac35c5a4a3b24ab92f46cb5cbab9bb124c"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
-- Updated for API10/7.0
+- Fixed null reference in certain unnatural circumstances
+- Minor improvements to the performance of fancy lines when there are a high number of lines
+- Added option to filter party/alliance
 """
 

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "842f64ac35c5a4a3b24ab92f46cb5cbab9bb124c"
+commit = "1643e120b75a28e34f40bfc76492e9305dd145f1"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "1643e120b75a28e34f40bfc76492e9305dd145f1"
+commit = "f19f6e3d5cd4ff6abe9d69ede8de21b641de35a6"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
 - Fixed null reference in certain unnatural circumstances
+- Fixed rare case where lines would try to initialize with 0 samples
 - Minor improvements to the performance of fancy lines when there are a high number of lines
 - Added option to filter party/alliance
 """


### PR DESCRIPTION
Fixed a null reference exception in certain unnatural circumstances, minor improvements to the performance of fancy lines when there are a very high number of lines, and added option to filter party/alliance.