### PR TITLE
Tracky 1.5.2.1

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "890de6c81ddad3dbd1d0ea4a6e9c0cab25be87f4"
+commit = "f5b2d4c27177d3ebdd6340ee06b957a0c66d282c"
 owners = [
     "Infiziert90",
 ]

--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "f5b2d4c27177d3ebdd6340ee06b957a0c66d282c"
+commit = "3b8186af3c28ed32d905948b72f74ba6b0f1ab69"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Improve the tracked data for revisits [upload only]
  - The nature of this data makes it only useful in a bigger set, that's why it won't be saved locally