### PR TITLE
DelvUI release 2.2.0.1

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "e69d250650d0294d400c0f65c466af159b91d538"
+commit = "406575627da09a302e9d37f806710005aef76745"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Fixed `[health:current-percent]` and `[mana:current-percent]` not working properly.
- Fixed mouseover not working when using other plugins like MOAction or ReAction.
- Fixed Party Frames not working when using the Trust party system.