### PR TITLE
Gearset Helper v2.4.0.0

### DIFF
--- a/stable/GearsetHelperPlugin/manifest.toml
+++ b/stable/GearsetHelperPlugin/manifest.toml
@@ -1,13 +1,13 @@
 [plugin]
 repository = "https://github.com/KhloeLeclair/GearsetHelperPlugin.git"
-commit = "38a490044f346ac901e177e3bbfed48cf6c5d7d0"
+commit = "b39aead334bd9140b38438a444e79b706d9362f4"
 owners = [ 
 	"KhloeLeclair"
 ]
 project_path = "GearsetHelperPlugin"
 changelog = """
-- Updated for 7.0 / apiX.
-- Added a notice to the Calculated section that math hasn't been updated for Dawntrail and may be inaccurate.
-- Fixed errors in calculating average item level with some jobs and gear pieces.
-- Fixed error in how base stats were calculated.
+- Added GCD tier calculations.
+- Added support for exporting gearsets to XivGear.app
+- Added tool-tips to various icon buttons.
+- Fixed exporting Pictomancer and Viper gearsets to Ariyala.
 """


### PR DESCRIPTION
- Added GCD tier calculations.
- Added support for exporting gearsets to XivGear.app
- Added tool-tips to various icon buttons.
- Fixed exporting Pictomancer and Viper gearsets to Ariyala.