### PR TITLE
SubmarineTracker 1.9.2.2

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "188be47e7521d83cf35340250dae391feabe616e"
+commit = "cbfe2172b66ac34a6d2d0f9972a8b0dbe46c59fd"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fix bug that occurred when registering new submarines 
- Add a small warning that deletion is currently disabled