### PR TITLE
OrchestrionPlugin 2.2.0.5 -> 2.2.0.6

### DIFF
--- a/stable/orchestrion/manifest.toml
+++ b/stable/orchestrion/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lmcintyre/OrchestrionPlugin.git"
-commit = "66d8de6636159d8cee589835004a0eaecd519e2a"
+commit = "5b4c9d7908c09893f47c3a08a1ba6bd3f1e71065"
 owners = [
     "lmcintyre",
 ]


### PR DESCRIPTION
- Add Japanese translation
- Add German translation
- Add Spanish translation
- Fix Chinese-Simplified translation-related bug that prevented the plugin from starting

Sincere thank you to all those who contribute translations on Crowdin. Without their *free* labor there would be no translations of the Orchestrion plugin.