### PR TITLE
DelvUI release 2.2.0.2

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "406575627da09a302e9d37f806710005aef76745"
+commit = "23b7864c52d99177b4cd88421539c5b9e7cbed3c"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added subtractive color options to the Pictomancer's Pallete Bar.
- Added setting to the Pictomancer's Creature Canvas bar to show an empty drawing section when it contains Pom + Wings.
- Fixed shadows not working on chunked bars.
- Fixer Monk's Masterful Blitz Bar colors.