### PR TITLE
PlayerTrack v3.4.0.0

### DIFF
--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "21b95670a744d0e1270fdcded0546e3ed4042ecb"
+commit = "862079967b5f74e462b75da233b2498228748844"


### PR DESCRIPTION
_I'll release this to test for a few days to confirm there's no issues. As always, please only use PlayerTrack testing if you are comfortable restoring your database from a backup._

**General**
- Update for Dawntrail / apiX.
- Replace lodestone lookups with game data (content id).
- Add manual lodestone lookup so can still open profile.
- Allow duplicate names to show in some rare cases (i.e. reusing old name).
- Show name/world change alerts now display immediately on encountering the player.
- Fix issue where encounter duration would display incorrectly at < 1m.
- Add warning about Nameplates being disabled.
- Add warning about Visibility integration going away (since VoidList is deprecated).
- Move from custom to dalamud context menu offering.

**Removed Settings**
- Remove option to sync with lodestone since this feature is replaced.
- Remove option to hide context menu indicator since not supported.

**Important Notes**
- Nameplates are disabled until future dalamud update.
- Context Menus do not support the blacklist.
- Visibility integration will be going-away since VoidList is deprecated.

**History Warning**
Due to the migration from lodestone id to game data, there is a very very low risk of bad merges. This happens if someone reuses someone else's name+world id before you encounter them again. This is so rare that I don't consider this a significant concern, but I wanted to share with you for transparency.