### PR TITLE
TitleRoulette 4.1

### DIFF
--- a/stable/TitleRoulette/manifest.toml
+++ b/stable/TitleRoulette/manifest.toml
@@ -1,4 +1,4 @@
 [plugin]
 repository = "https://github.com/mabako/TitleRoulette.git"
-commit = "7b30a40ad99d824f7aabbf1651f30a8f94f880e8"
+commit = "9eaa4e6fab96736639c1e307506ec8622125c545"
 owners = ["carvelli", "mabako"]


### PR DESCRIPTION
Fix check for whether title list is loaded (I'm fairly certain this worked pre-hotfix), so that we again check for at least one known unlocked title.