### PR TITLE
TitleEdit 2.3.0.0

### DIFF
--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,7 +1,11 @@
 [plugin]
-repository = "https://github.com/lmcintyre/TitleEditPlugin.git"
-commit = "5cc4a8432a524ddf2fe6dc7d03eae489b8b1f194"
+repository = "https://github.com/RokasKil/TitleEditPlugin.git"
+commit = "b787ae5de6e16aa84aba8521a018a7eb8a5eb652"
 owners = [
-    "lmcintyre",
+    "RokasKil",
 ]
 project_path = "TitleEdit"
+changelog = """
+- Updated for Dawntrail
+- Added Dawntrail logo and title menu options
+"""


### PR DESCRIPTION
 - Updated for Dawntrail
 - Moved some old stuff onto CS 
 - Changed the logic a bit since Dawntrail title menu operates differently and was messing stuff up