### PR TITLE
PvP Tracker v2.1.1.0

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -4,6 +4,11 @@ commit = "d7bef219e06d89c6a8a4eb8b7820cf89d7d7083d"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Updated for version 7.0 and Dalamud apiX.
-* Rival Wings matches temporarily disabled.
+* Added team stats to Frontline and Rival Wings match details.
+* Added an option to show/hide team stats to the match details window.
+* Added 'By expansion' to time filter.
+* Added options for changing alpha and text color for match scoreboard rows.
+* Left-aligned match duration in all match lists.
+* Removed auto-resize option from CC match details.
+* Other small UI tweaks.
 """

--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "d7bef219e06d89c6a8a4eb8b7820cf89d7d7083d"
+commit = "9b7051d4fd395c0a802a14937c5befaec39a93d6"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """


### PR DESCRIPTION
* Added team stats to Frontline and Rival Wings match details.
* Added an option to show/hide team stats to the match details window.
* Added 'By expansion' to time filter.
* Added options for changing alpha and text color for match scoreboard rows.
* Left-aligned match duration in all match lists.
* Removed auto-resize option from CC match details. (this causes headaches).
* Other small UI tweaks.