### PR TITLE
Update AutoMountBgm (stable)

### DIFF
--- a/stable/AutoMountBgm/manifest.toml
+++ b/stable/AutoMountBgm/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/PrincessRTFM/AutoMountBGM.git"
 owners = [ "PrincessRTFM",]
 project_path = ""
-commit = "702ab417188802edc7e8cf8adb9054262cd7124a"
-changelog = "Updated to patch 7.0 and new API, fixed the \"disable Borderless\" option not being actually implemented. Closes #2."
+commit = "d81474d26d2db538cb4fe03108ba22c609720c51"
+changelog = "The UI controls for toggling BGM per-mount were inverted. This has been fixed, and the UI should now show the BGM state of mounts correctly."


### PR DESCRIPTION
The UI controls for toggling BGM per-mount were inverted. This has been fixed, and the UI should now show the BGM state of mounts correctly.