### PR TITLE
TPie release 1.9.1.0

### DIFF
--- a/stable/TPie/manifest.toml
+++ b/stable/TPie/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Tischel/TPie.git"
-commit = "e13862c306496343e2e34cd63aba4afbd8a419e3"
+commit = "7c4e96c75e9b78d7920419c6ff1453bb171de558"
 owners = ["Tischel"]
 project_path = "TPie"
-changelog = "- Added support for Dawntrail and Dalamud API 10."
+changelog = "- Added setting to Nested Ring Elements so they can be activated by clicking instead of hovering."


### PR DESCRIPTION
- Added setting to Nested Ring Elements so they can be activated by clicking instead of hovering.