### PR TITLE
DelvUI release 2.2.0.3

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "23b7864c52d99177b4cd88421539c5b9e7cbed3c"
+commit = "095a90db07e50ca3ccbe19609ef725d9970cc759"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added `[name:abbreviate]`, `health:percent-hidden` and `level:hidden` text tags.
  * For more info check https://github.com/DelvUI/DelvUI/wiki/Text-Formatting

- Added several improvements to the Viper Hud:
  * Added hind/rear skill colors.
  * Serpent Offering can now be shown in chunks.
  * Added reawakened timer toggle.
  * Added color option to show when Reawakened is ready to be used.

- Attempt to fix inputs from not working when the plugin is updated.
- Fixed Ninja's Kunai's Bane not being tracked properly in the Trick Attack Bar.
- Fixed right click context menu not working on the Party Frames.