### PR TITLE
PlayerTrack v3.4.1.0

### DIFF
--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "862079967b5f74e462b75da233b2498228748844"
+commit = "dcb14e6831408a97f1f1636d2d5ff7fd3f9fc29c"

--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "f7e519782183773ff654d41fc5be10ac33270285"
+commit = "862079967b5f74e462b75da233b2498228748844"


### PR DESCRIPTION
_This is the same release that went to testing for a few days except nameplates (thanks Nebel) are back._

**General**
- Update for Dawntrail / apiX.
- Replace lodestone lookups with game data (content id).
- Add manual lodestone lookup so can still open profile.
- Allow duplicate names to show in some rare cases (i.e. reusing old name).
- Show name/world change alerts now display immediately on encountering the player.
- Fix issue where encounter duration would display incorrectly at < 1m.
- Add warning about Visibility integration going away (since VoidList is deprecated).
- Move from custom to dalamud context menu offering.
- Fix issue where custom nameplates wouldn't show for dead players.

**Removed Settings**
- Remove option to sync with lodestone since this feature is replaced.
- Remove option to hide context menu indicator since not supported.

**History Warning**
Due to the migration from lodestone id to game data, there is a very very low risk of bad merges. This happens if someone reuses someone else's name+world id before you encounter them again. This is so rare that I don't consider this a significant concern, but I wanted to share with you for transparency.

**Important Notes**
- Context Menus do not support the blacklist.
- Visibility integration will be going-away since VoidList is deprecated.