### PR TITLE
DelvCD release 1.1.0.2

### DIFF
--- a/stable/DelvCD/manifest.toml
+++ b/stable/DelvCD/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvCD.git"
-commit = "45f2d7944e9b8a7bd0f38fd3205c26781105bafd"
+commit = "3f0c7c6c50fe4edccba8e1255c08252cb0c27d18"
 owners = ["Tischel"]
 project_path = "DelvCD"


### PR DESCRIPTION
- Added "Action Highlighted" condition to Cooldown Triggers.
- Updated Monk's Job Gauge data.
- Updated Summoner's Job Gauge data.
- Fixed Samurai's Combo Ready not working for some actions.