### PR TITLE
Allagan Tools 1.7.0.12

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,22 +1,24 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "66cd4b22e4dd56bb566c43bd7a417bedadf19e68"
+commit = "e5c7084eb0c7ea13125a4c324bfbb666b8810035"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.7.0.11"
+version = "1.7.0.12"
 changelog = """\
-**New Features**
-- Grand company turn in column/filter added
-- Character owner column added
-- Items that are grand company turn-ins will now display that in the Uses/Rewards section of the more item window
-- Add in inventory scope picker for "Amount Owned" tooltip allowing you to pick which items are shown
+### Added
 
-**Bug Fixes**
-- Labels in the wizard should no longer be cut off
-- Tetris has returned!
+- The output items of craft lists can now be ordered based on the "Output Ordering" setting by class or name
+- Added a "Is custom delivery hand in?" column/filter
+- Added a new menu in craft lists that allows you to clear all items and import/export the contents of the list(to your clipboard)
+- Added a new hotkey for opening the lists window
+- The item window has a new "Owned" section showing all the locations of items within your characters that the plugin knows about
+### Fixed
 
-More fixes and features to come, stay tuned
+- Certain columns were not showing as available to add within craft lists
+- The active search scopes were not fully working
+- All slash commands that open AT windows will now toggle instead of only opening
+- The configuration wizard's labels should no longer clip
 
 """


### PR DESCRIPTION
### Added

- The output items of craft lists can now be ordered based on the "Output Ordering" setting by class or name
- Added a "Is custom delivery hand in?" column/filter
- Added a new menu in craft lists that allows you to clear all items and import/export the contents of the list(to your clipboard)
- Added a new hotkey for opening the lists window
- The item window has a new "Owned" section showing all the locations of items within your characters that the plugin knows about
### Fixed

- Certain columns were not showing as available to add within craft lists
- The active search scopes were not fully working
- All slash commands that open AT windows will now toggle instead of only opening
- The configuration wizard's labels should no longer clip