### PR TITLE
[Testing] Market Board 1.7.0

### DIFF
--- a/testing/live/MarketBoardPlugin/manifest.toml
+++ b/testing/live/MarketBoardPlugin/manifest.toml
@@ -1,6 +1,17 @@
 [plugin]
 repository = "https://github.com/fmauNeko/MarketBoardPlugin.git"
-commit = "eef61d41c76e4fb8ebb28b5c86c441b4dd488357"
+commit = "9f647104c2fc7d251705710feb5e8a24b32075c4"
 owners = ["fmauNeko"]
 project_path = "MarketBoardPlugin"
-changelog = "- Fixed charts not showing up\n- Improved item name sorting by handling roman numbers\n- Clicking on an item's icon will copy the item name to the clipboard\n\n- Migrate UI to Dalamud's WindowSystem\n- Internal code cleanup and improvements"
+changelog = """\
+- Add \"Remove from favorites\" context menu option in favorites
+- Add Context menu integration to non-inventory windows. For now, that includes:
+  - Chat
+  - Crafting Log
+  - Gathering Log
+  - Grand Company Supply
+  - Item Search / In-Game Market Board
+- Fix Universalis / Ko-Fi buttons appareance
+- Fix max level still set at 90
+- Fix potential issues in Universalis-related code"\
+"""


### PR DESCRIPTION
- Add "Remove from favorites" context menu option in favorites
- Add Context menu integration to non-inventory windows. For now, that includes:
  - Chat
  - Crafting Log
  - Gathering Log
  - Grand Company Supply
  - Item Search / In-Game Market Board
- Fix Universalis / Ko-Fi buttons appareance
- Fix max level still set at 90
- Fix potential issues in Universalis-related code