### PR TITLE
Update FCNameColor to 5.0.0.1

### DIFF
--- a/stable/FCNameColor/manifest.toml
+++ b/stable/FCNameColor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "7ea412fe6a47a1cea8860dd9e2c3cf080ac1c003"
+commit = "fa3817fe8cd64721cafc268a39791eb47ccb37f6"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """


### PR DESCRIPTION
Quick fix to fix an issue where titles displaying at the bottom would show up missing part of its colour.