### PR TITLE
Update Tidy Chat v.1.3.2

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "70a7b3f9d50eff8be8617aed7e3b7717000d6495"
+commit = "19ebf17f76a5395c65ad962374d433ea8d6ea092"
 owners = [
     "NadyaNayme",
 ]
 project_path = "TidyChat"
-changelog = "Fix improved instance messaging for instances 4-6. Maybe fix materia attachment filter for certain name settings."
+changelog = "- Custom filters for the Gathering channel should properly check the Gathering channel and the GatheringSystem channel instead of only the GatheringSystem channel."


### PR DESCRIPTION
- Bugfix for custom filters

Turns out that ustom filters meant for the Gathering channel should check the Gathering channel and not only the GatheringSystem channel so that they actually...you know... work?