### PR TITLE
Market Board 1.7.1

### DIFF
--- a/stable/MarketBoardPlugin/manifest.toml
+++ b/stable/MarketBoardPlugin/manifest.toml
@@ -1,6 +1,17 @@
 [plugin]
 repository = "https://github.com/fmauNeko/MarketBoardPlugin.git"
-commit = "a929c39e851b09e8ee99013765336bdfa68fc143"
+commit = "2d3f6af753599dfab06901659cb24a1bf3535637"
 owners = ["fmauNeko"]
 project_path = "MarketBoardPlugin"
-changelog = "- Better Universalis error handling"
+changelog = """\
+- Add \"Remove from favorites\" context menu option in favorites
+- Add Context menu integration to non-inventory windows. For now, that includes:
+  - Chat
+  - Crafting Log
+  - Gathering Log
+  - Grand Company Supply
+  - Item Search / In-Game Market Board
+- Fix Universalis / Ko-Fi buttons appareance
+- Fix max level still set at 90
+- Refactor Universalis code to make it more resilient\
+"""


### PR DESCRIPTION
- Add "Remove from favorites" context menu option in favorites
- Add Context menu integration to non-inventory windows. For now, that includes:
  - Chat
  - Crafting Log
  - Gathering Log
  - Grand Company Supply
  - Item Search / In-Game Market Board
- Fix Universalis / Ko-Fi buttons appareance
- Fix max level still set at 90
- Refactor Universalis code to make it more resilient