### PR TITLE
[Testing] Gauge-O-Matic 0.7.0.1

### DIFF
--- a/testing/live/GaugeOMatic/manifest.toml
+++ b/testing/live/GaugeOMatic/manifest.toml
@@ -1,24 +1,16 @@
 [plugin]
 repository = "https://github.com/itsbexy/gaugeomatic.git"
-commit = "eb5da579c9cb84b9d8ebe0208b4d1285091f5694"
+commit = "6fdc2b1ab50bb837f2c785b35e7fde6972ea716e"
 owners = [
     "ItsBexy",
 ]
 changelog = """
-- Updated for Dawntrail, with profiles added for VPR and PCT
-- Many jobs have new or modified default presets. If you are installing the plugin for the first time, these presets will be loaded automatically. If you have configuration data saved from a previous version of the plugin, your settings will remain as-is, but you may load the new defaults via the Presets window.
-- If you were previously tracking actions or status effects that no longer exist in 7.0, these will show up as blank entries in your Trackers tab. You can assign those widgets to something else, or simply delete them.
+## GAUGE TWEAKS
+- **Restored:** The tweaks to hide job gauges have been restored, as users have pointed out that the vanilla client option doesn't play very nice with the plugin.
+- **New Tweak for VPR:** *Ready to Reawaken Cue* will prompt the Serpent Offerings Gauge to light up and play the appropriate SFX after pressing Serpent's Ire, just as it would when reaching 50 gauge.
+- **New Tweaks for PCT:** *Reposition Canvases* and *Hide Easels* allow you to rearrange the layout of your three Canvases.
 
-### TRACKERS
-- Many new Statuses & Actions have been added in 7.0, and many existing ones have been deprecated. I'm working to keep the plugin caught up with these changes, but it's possible (likely) I've missed some!
-- A set of *Motif Deadline* trackers have been added for PCT. If a given motif has not yet been painted, this tracker will show the total time left to do so before your Muse cooldowns overcap/drift.
-
-### WIDGETS
-- **Removed:** The replica Huton Pinwheel widget has, sadly, been removed, as its texture asset no longer exists within the game files (But will the widget really be gone forever? Who knows...)
-
-### GAUGE TWEAKS
-- **Removed:** Now that the game itself gives the option to hide job gauges, that tweak has been removed for most jobs.
-- **Removed:** The Arcana Gauge no longer has visible text, so the option to change the font has naturally been removed.
-- **New Tweak for RDM:** **Magicked Swordplay Cue** will prompt the Balance Gauge to light up and play the appropriate SFX when Magicked Swordplay is at 3 stacks.
-- **New Tweak for VPR:** **Color-Code Vipersight** will recolor the gauge's effects to indicate your upcoming positional finisher.
+## MISC
+- Corrected the Hind/Flank Venom text in VPR's Tweak tab
+- Removed defunct timers from the MNK default preset
 """


### PR DESCRIPTION
## GAUGE TWEAKS
- **Restored:** The tweaks to hide job gauges have been restored, as users have pointed out that the vanilla client option doesn't play very nice with the plugin.
- **New Tweak for VPR:** *Ready to Reawaken Cue* will prompt the Serpent Offerings Gauge to light up and play the appropriate SFX after pressing Serpent's Ire, just as it would when reaching 50 gauge.
- **New Tweaks for PCT:** *Reposition Canvases* and *Hide Easels* allow you to rearrange the layout of your three Canvases.

## MISC
- Corrected the Hind/Flank Venom text in VPR's Tweak tab
- Removed defunct timers from the MNK default preset