### PR TITLE
[Testing] OpenerCreator 0.0.7

### DIFF
--- a/testing/live/OpenerCreator/manifest.toml
+++ b/testing/live/OpenerCreator/manifest.toml
@@ -7,11 +7,13 @@ changelog = """
 Updates:
 - Update openers from level 90 to level 100 
 - Fix a bug that would crash the plugin due to trying to load old actions on saved openers
+
 Missing openers:
 - Missing MNK openers due to potency changes on patch 7.0.1
 - Missing BRD openers due to too much RNG (looking into a solution)
 - Missing SAM openers due to resources not being updated yet
 - Missing some non-standard openers due to potency changes on patch 7.0.1
+
 Issues:
 - Saving openers fails to some users (under investigation)
 """

--- a/testing/live/OpenerCreator/manifest.toml
+++ b/testing/live/OpenerCreator/manifest.toml
@@ -1,6 +1,17 @@
 [plugin]
 repository = "https://github.com/herulume/OpenerCreator.git"
-commit = "69bc6e7d7f62fa14f416221ff9fee09c854e703c"
+commit = "e77429533e810a4e452e4534626c5cee5ae20012"
 owners = ["herulume", "Sevii77"]
 project_path = "OpenerCreator"
-changelog = "Update Dalamud API"
+changelog = """
+Updates:
+- Update openers from level 90 to level 100 
+- Fix a bug that would crash the plugin due to trying to load old actions on saved openers
+Missing openers:
+- Missing MNK openers due to potency changes on patch 7.0.1
+- Missing BRD openers due to too much RNG (looking into a solution)
+- Missing SAM openers due to resources not being updated yet
+- Missing some non-standard openers due to potency changes on patch 7.0.1
+Issues:
+- Saving openers fails to some users (under investigation)
+"""

--- a/testing/live/OpenerCreator/manifest.toml
+++ b/testing/live/OpenerCreator/manifest.toml
@@ -15,5 +15,5 @@ Missing openers:
 - Missing some non-standard openers due to potency changes on patch 7.0.1
 
 Issues:
-- Saving openers fails to some users (under investigation)
+- Saving openers fails for some users (under investigation)
 """


### PR DESCRIPTION
Updates:
- Update openers from level 90 to level 100 
- Fix a bug that would crash the plugin due to trying to load old actions on saved openers

Missing openers:
- Missing MNK openers due to potency changes on patch 7.0.1
- Missing BRD openers due to too much RNG (looking into a solution)
- Missing SAM openers due to resources not being updated yet
- Missing some non-standard openers due to potency changes on patch 7.0.1

Issues:
- Saving openers fails for some users (under investigation)