### PR TITLE
DelvUI release 2.2.0.5

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "821fda03605e5b4ac1805af2df729d04d4943477"
+commit = "1d959fa3d5afb079578de5f46aa9854e21d40616"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Updated Monk's Fury Stacks Bar for 7.01 patch changes.
- Fix Bard's Radiant Finale duration in Party Cooldowns.
- Fixed Who's Talking Indicator in Party Frames.
- Fixed default job gauges sometimes getting stuck after disabling `Misc > HUD Options > Hide Default Job Gauge`.