### PR TITLE
Player Tags v1.11

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "ffa9f8497a8ba5c4594ae3896451871b6c7c59c4"
+commit = "19db0cdf4137ba259ee888db2fcb5e8f96d16649"
 owners = [
     "Pilzinsel64",
 ]

--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "52f8723f84c710feda245b9e533807db35625e44"
+commit = "ffa9f8497a8ba5c4594ae3896451871b6c7c59c4"
 owners = [
     "Pilzinsel64",
 ]
 project_path = "PlayerTags"
-changelog = """- Minor code optimizations
+changelog = """- Updated for API10 & Downtrail
 """

--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Pilzinsel64/PlayerTags.git"
-commit = "19db0cdf4137ba259ee888db2fcb5e8f96d16649"
+commit = "1b23cb5da80a9b1e4e9aefb7a90f5c0da79b675d"
 owners = [
     "Pilzinsel64",
 ]


### PR DESCRIPTION
- Updated for API10 & Downtrail
- Currently uses @nebel's changes bundled within Pilz.Dalamud (one single instance available for plugins using it) until it's merged into core Dalamud