### PR TITLE
Update Tf2CriticalHitsPlugin for FFXIV 7.01

### DIFF
--- a/stable/Tf2CriticalHitsPlugin/manifest.toml
+++ b/stable/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
-repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "67ce7e09f4014b3634462718565d77aa7ca6f729"
-owners = ["Berna-L"]
+repository = "https://github.com/jkchen2/ffxiv-tf2-crit-plugin.git"
+commit = "3c35b6b86313a24eafeeab997e1b61cc62cbdffc"
+owners = ["jkchen2"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-Update for API 9.
+Updated for FFXIV 7.01
 """

--- a/stable/Tf2CriticalHitsPlugin/manifest.toml
+++ b/stable/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/jkchen2/ffxiv-tf2-crit-plugin.git"
-commit = "3c35b6b86313a24eafeeab997e1b61cc62cbdffc"
+commit = "b6119d295632cd145f90308c36de4cc5a5a69887"
 owners = ["jkchen2"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,14 +1,8 @@
 [plugin]
-repository = "https://github.com/Berna-L/ffxiv-tf2-crit-plugin.git"
-commit = "04c67c409ccbcba45e1a1342d036482521cc32f2"
-owners = ["Berna-L"]
+repository = "https://github.com/jkchen2/ffxiv-tf2-crit-plugin.git"
+commit = "3c35b6b86313a24eafeeab997e1b61cc62cbdffc"
+owners = ["jkchen2"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-[TF2-ish Critical Hits]
-- Add option per job to set a minimum time between sounds.
-  - For example, if you set the time as 1000 ms and a critical hit sound is played,
-  no other sound (be it for critical hit, direct hit, critical heal etc.) will be played for the next second.
-  - Keep it at 0 ms to use the current behavior.
-
-(Thanks to Grayve for the idea and everyone at the Discord thread for the feedback!)
+Updated for FFXIV 7.01
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/jkchen2/ffxiv-tf2-crit-plugin.git"
-commit = "3c35b6b86313a24eafeeab997e1b61cc62cbdffc"
+commit = "b6119d295632cd145f90308c36de4cc5a5a69887"
 owners = ["jkchen2"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """


### PR DESCRIPTION
This is a request to adopt the Tf2CriticalHitsPlugin, as the original author (Berna) has decided to stop development. I don't intend to do feature development, but at the very least wanted to get this plugin working on Dawntrail.

Berna's message on Discord regarding stopping development and leaving their plugins up for adoption: https://discord.com/channels/581875019861328007/1069307522269319178/1259198126376488960

Berna's message on GitHub in response to my request to have the plugin be adopted: https://github.com/Berna-L/ffxiv-tf2-crit-plugin/issues/7#issuecomment-2235056047

The bulk of the changes required for the update were compatibility changes for API 10. There are also a few smaller changes to how certain sound logic is handled (using FFXIVClientStructs for built-in sound playing instead of doing it in-house). I've done a fair amount of testing to confirm the behavior works as expected for both the crit sound effects, as well as the Countdown Jams feature, though admittedly, it's not 100% comprehensive.

Additionally, I've elected to keep Berna as the author, as I only intend to keep this plugin compatible with FFXIV/Dalamud updates. If this needs to change, please let me know.