### PR TITLE
PriceInsight 2.9.3.0

### DIFF
--- a/stable/PriceInsight/manifest.toml
+++ b/stable/PriceInsight/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-priceinsight.git"
-commit = "ed50930b7814dbb924d497e3d53b369f269ccefb"
+commit = "ff4d108266d53d3348f81aef9e7b0fcb97aa2b10"
 owners = ["Kouzukii"]
 project_path = ""
 changelog = """
-Improve caching to counteract universalis instability
+- Reduce number of universalis requests to stay within rate limit
+- Clarify error message
 """

--- a/stable/PriceInsight/manifest.toml
+++ b/stable/PriceInsight/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Kouzukii/ffxiv-priceinsight.git"
-commit = "ff4d108266d53d3348f81aef9e7b0fcb97aa2b10"
+commit = "18307dfdf2a9f7a7910fd504e70212b3f4683f16"
 owners = ["Kouzukii"]
 project_path = ""
 changelog = """


### PR DESCRIPTION
Update to 2.9.3.0 again since it was reverted in #4041 before.
Newest ClientStructs build no longer errors on SetText.