### PR TITLE
DelvUI release 2.2.0.6

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "1d959fa3d5afb079578de5f46aa9854e21d40616"
+commit = "6d4a3de871dec22095741ba20b0b4c6bcb7950f4"
 owners = ["Tischel"]
 project_path = "DelvUI"

--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "6d4a3de871dec22095741ba20b0b4c6bcb7950f4"
+commit = "3268537b4408985f44d829fd485924b899436882"
 owners = ["Tischel"]
 project_path = "DelvUI"

--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "3268537b4408985f44d829fd485924b899436882"
+commit = "9c2ddca59d21d4924502ce1828d4bd6989e9a7a4"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Fixed default job gauge flickering when "Hide Default Job Gauge" is enabled.
- Fixed Viper's Rattling Coil and Anguine Tribute bars not working properly with "Hide when Inactive".