### PR TITLE
[Testing] OpenerCreator 0.0.8

### DIFF
--- a/testing/live/OpenerCreator/manifest.toml
+++ b/testing/live/OpenerCreator/manifest.toml
@@ -1,19 +1,25 @@
 [plugin]
 repository = "https://github.com/herulume/OpenerCreator.git"
-commit = "e77429533e810a4e452e4534626c5cee5ae20012"
+commit = "44aa3e3d0b1bed356586eca6c2179ac73b04afd1"
 owners = ["herulume", "Sevii77"]
 project_path = "OpenerCreator"
 changelog = """
 Updates:
-- Update openers from level 90 to level 100 
-- Fix a bug that would crash the plugin due to trying to load old actions on saved openers
+- Add mouseover for catch-all action
+- Centre countdown
+- Improve UI
+  - Add colour when a job role filter is selected
+  - Clean opener creator tab
+- Add the settings tab
+  -  Make countdown opt-in
+  - Move the countdown timer to settings
+ - Fix bug where players could save an opener linked to the job ANY (
+   - Fixes: Saving openers fails for some users 
+ - Add a setting to stop analysing actions on the first mistake
+ - Add basis for multi-action groups
+ - Add proper category tag
+ - Internal refactors
 
-Missing openers:
-- Missing MNK openers due to potency changes on patch 7.0.1
-- Missing BRD openers due to too much RNG (looking into a solution)
-- Missing SAM openers due to resources not being updated yet
-- Missing some non-standard openers due to potency changes on patch 7.0.1
-
-Issues:
-- Saving openers fails for some users (under investigation)
+Known Issues:
+- Custom openers are loaded but fail to be analysed (bug introduced before this update)
 """


### PR DESCRIPTION
Updates:
- Add mouseover for catch-all action
- Centre countdown
- Improve UI
  - Add colour when a job role filter is selected
  - Clean opener creator tab
- Add the settings tab
  -  Make countdown opt-in
  - Move the countdown timer to settings
 - Fix bug where players could save an opener linked to the job ANY (
   - Fixes: Saving openers fails for some users 
 - Add a setting to stop analysing actions on the first mistake
 - Add basis for multi-action groups
 - Add proper category tag
 - Internal refactors

Known Issues:
- Custom openers are loaded but fail to be analysed (bug introduced before this update)

