### PR TITLE
Congratulations 1.3.0.0

### DIFF
--- a/stable/Congratulations/manifest.toml
+++ b/stable/Congratulations/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/jkchen2/ffxiv-congratulations-plugin.git"
 commit = "8a395e49d69ac09f2c639189b230b3f6ad74ab01"
-owners = ["Berna-L"]
+owners = ["jkchen2"]
 project_path = "Congratulations"
 changelog = """
 Updated for FFXIV 7.01

--- a/stable/Congratulations/manifest.toml
+++ b/stable/Congratulations/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
-repository = "https://github.com/Berna-L/ffxiv-congratulations-plugin.git"
-commit = "51631abb71636e2a49e3a27701a78ced94145c1d"
+repository = "https://github.com/jkchen2/ffxiv-congratulations-plugin.git"
+commit = "8a395e49d69ac09f2c639189b230b3f6ad74ab01"
 owners = ["Berna-L"]
 project_path = "Congratulations"
 changelog = """
-Update to API 9 / patch 6.5.
+Updated for FFXIV 7.01
 """

--- a/testing/live/Congratulations/manifest.toml
+++ b/testing/live/Congratulations/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/jkchen2/ffxiv-congratulations-plugin.git"
 commit = "8a395e49d69ac09f2c639189b230b3f6ad74ab01"
-owners = ["Berna-L"]
+owners = ["jkchen2"]
 project_path = "Congratulations"
 changelog = """
 Updated for FFXIV 7.01

--- a/testing/live/Congratulations/manifest.toml
+++ b/testing/live/Congratulations/manifest.toml
@@ -1,9 +1,8 @@
 [plugin]
-repository = "https://github.com/Berna-L/ffxiv-congratulations-plugin.git"
-commit = "ff798850f123fbd3626184d711b06adfceb54295"
+repository = "https://github.com/jkchen2/ffxiv-congratulations-plugin.git"
+commit = "8a395e49d69ac09f2c639189b230b3f6ad74ab01"
 owners = ["Berna-L"]
 project_path = "Congratulations"
 changelog = """
-- Update testing branch to the latest version on stable.
-- Validated on 6.38 (commendations number address is still correct and the triggers to update it and play the sound are still OK).
+Updated for FFXIV 7.01
 """


### PR DESCRIPTION
This is a request to adopt the Congratulations plugin, as the original author (Berna) has decided to stop development. I don't intend to do feature development, but at the very least wanted to get this plugin working on Dawntrail.

(This is another plugin from Berna that I am adopting, the first one being the [Tf2CriticalHitsPlugin](https://github.com/goatcorp/DalamudPluginsD17/pull/4053))

Berna's message on Discord regarding stopping development and leaving their plugins up for adoption: https://discord.com/channels/581875019861328007/1069307522269319178/1259198126376488960

Berna's message on GitHub in response to my request to have the plugin be adopted: https://github.com/Berna-L/ffxiv-tf2-crit-plugin/issues/7#issuecomment-2235056047

Additionally, like before, I've elected to keep Berna as the author, as I only intend to keep this plugin compatible with FFXIV/Dalamud updates. If this needs to change, please let me know.