### PR TITLE
Himbeertoni Raid Tool 1.6.2.0

### DIFF
--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,8 +2,8 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "1175081f4e4e032a8b37ebf177226794295739a5"
+commit = "3cb7b8423a506865a51d47d5bf0795cfe1bfdb41"
 changelog = """
-General: Added loot information for normal raids and extremes
-    General: Corrected HP calculation for levels above 90
-    Lodestone Connector: PCT and VIP fixed"""
+General: Now supports switching back to Endwalker raid tiers
+    BiS: Added support for XivGear.app
+    Known Issue: XivGear.app sets are not automatically updated yet"""


### PR DESCRIPTION
    General: Now supports switching back to Endwalker raid tiers
    BiS: Added support for XivGear.app
    Known Issue: XivGear.app sets are not automatically updated yet