### PR TITLE
[Testing] Say What? 1.0.2.4

### DIFF
--- a/testing/live/WhatDidYouSay/manifest.toml
+++ b/testing/live/WhatDidYouSay/manifest.toml
@@ -1,11 +1,10 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/WhatDidYouSay.git"
-commit = "9f131df7fc7524cafd78ea09e6b9dfcd93bf9aa1"
+commit = "707d4d6e51dbadf616ebbadd5ab69fe235f422c3"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "WhatDidYouSay"
 changelog = '''
-- Added configuration options to override configuration for specific zones.
-- Added text commands("/saywhat ban" and "/saywhat unban") to override settings for the current zone.  These are just simplified toggles for new the settings in the config window.
+- Possible fix for speech bubbles showing on the wrong part of certain models.
 '''


### PR DESCRIPTION
Changes:
- Possible fix for speech bubbles showing on the wrong part of certain models.

If you get the opportunity to test this for correct behavior (it was reported to be an issue on the S-rank of Heritage Found), please let me know whether it solved the problem or not on the corresponding issue in this plugin's Github repo.  Please note that you will most likely not see any change with the current version of Chat Bubbles plugin enabled, so you will have to disable that if you want to test this.