### PR TITLE
PlayerTrack v3.4.4.0

### DIFF
--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "c4a356b58503af921d6987886af62d7fa0da1ef8"
+commit = "862079967b5f74e462b75da233b2498228748844"

--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "862079967b5f74e462b75da233b2498228748844"
+commit = "b1251f86d54a38376c2ce50c1c56c6bffe39ec55"


### PR DESCRIPTION
* Add feature to manually merge two players (settings > data > merge).
* Update processing so that missing content ids are added to existing players regardless of other settings.
* Fix issue where players were missing from Current Players.
* Fix more warnings related to out of framework object access.