### PR TITLE
Party Icons v1.2.0.0

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/nebel/xivPartyIcons.git"
-commit = "ec4c7d303e8a5e0cada4625e823060b4839f2d84"
+commit = "66fc223ab537ae0051c67470f6acd4172b5e56b3"
 owners = [
     "shdwp",
     "avafloww",
@@ -8,6 +8,3 @@ owners = [
     "nebel"
 ]
 project_path = "PartyIcons"
-changelog = """
-- Update for 6.5
-"""


### PR DESCRIPTION
**Additions**
- Added option to show both job/role and online status icons simultaneously for all display modes.
- Added the ability to configure which online status icons are shown or hidden and which icons are considered important.
- Added the ability to tweak nameplate appearance, including the ability to adjust icon visibility, position and size, set different icon sets per nameplate type, and configure how important online status icons are handled.
- Added two new icon sets: "Framed, role colored (small)" and "Embossed". Some other icon sets were also renamed for clarity.
- Added the ability to provide a custom scaling factor in addition to the existing Smaller/Medium/Bigger setting.
- Added the ability to show party numbers in place of roles for role-based display modes.

**Other improvements**
- Standardized icon set scaling so that "Gradient" is now of similar size to other icon sets.
- Improved context menu appearance and added an option to move context menu actions into a submenu (enabled by default).
- Improved the "Replace party numbers with role in Party List" option so it works even when using abbreviated names in the party list.
- Improved performance.

**Fixes**
- Fixed issues related to the game's built in option to show class or job icons interfering with the appearance of Party Icons nameplates. As a result, certain status icons should no longer incorrectly appear in strange places alongside nameplates.
- Fixed nameplates not being updated immediately when party roles change or after changing plugin settings.
- Fixed nameplate collision boxes. Previously "Role letters" and "Big job icon" modes especially had broken nameplate hitboxes and were often difficult or impossible to click, or had their clickable area in strange locations. The clickable area should now match the visible area more closely.
- Fixed some cases where nameplates could be temporarily scaled incorrectly for non-player targets.
- Fixed members with auto-assigned roles not having their role updated when their job changes.
- Fixed party list role icons not updating when using /psort.

**Notes**
- Now uses the Dalamud-provided NamePlateGui system for text-related nameplate changes.
- The default status icon behavior is now slightly different due to the old "priority status icons" system having been reworked.
	- When first opening the settings window, users will be presented with an Upgrade Guide and prompted to choose between using the new default settings, or settings which more closely match those of the old version with "priority status icons" either enabled or disabled.
	- The upgrade guide can be re-opened from the General tab of the settings window.
