### PR TITLE
RoleplayProfiles 1.2.0.0

### DIFF
--- a/stable/RoleplayProfiles/manifest.toml
+++ b/stable/RoleplayProfiles/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://codeberg.org/Linneris/dalamud-roleplay-profiles.git"
-commit = "5cfc4bc3abf0a32bc28aee6f04016045287383cb"
+commit = "c4ade08e38e97d443ab810f39f4a73e2b856d509"
 owners = ["Maia-Everett"]
 project_path = "RoleplayProfiles"
 changelog = """
-* The plugin no longer asks for the user password to log in. Instead, it opens an in-browser authorization page.
-* Characters from all regions are now supported thanks to the cross-region character profiles website, Central Archives (https://centralarchives.org).
+* Updated for Dawntrail.
+* Character profiles will only display when there is a profile to display. No "Loading" or "Profile not found".
 """


### PR DESCRIPTION
* Updated for Dawntrail.
* Character profiles will only display when there is a profile to display. No "Loading" or "Profile not found".