### PR TITLE
PlayerTrack v3.4.6.0

### DIFF
--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "862079967b5f74e462b75da233b2498228748844"
+commit = "929152b41328d223cbea8354cbc67e13a3fd0c0c"

--- a/stable/PlayerTrack/manifest.toml
+++ b/stable/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = [ "kalilistic" ]
 project_path = "PlayerTrack.Plugin"
-commit = "40bf14911702d4e7147b03bcb323757a81b2433d"
+commit = "862079967b5f74e462b75da233b2498228748844"


### PR DESCRIPTION
- Create new first seen field rather than relying on created.
- Update merge to properly set name, world, and first seen.
- Update styling on merge screen.
- Remove Visibility warning since Voidlist is fixed for now (but remains deprecated)