### PR TITLE
Snooper 1.3.0.0

### DIFF
--- a/stable/Snooper/manifest.toml
+++ b/stable/Snooper/manifest.toml
@@ -1,7 +1,10 @@
 [plugin]
 repository = "https://codeberg.org/Linneris/dalamud-snooper.git"
-commit = "c39433005697abc177849121afe659ed82226eb9"
+commit = "d79d13d33e3d6babe23ad53afdc65138dca70a48"
 owners = ["Maia-Everett"]
 project_path = "Snooper"
-version = "1.2.1.2"
-changelog = """Updated for Dawntrail."""
+version = "1.3.0.0"
+changelog = """
+* Chat messages loaded from log files (rather than sent in the current game session) are now dimmed out.
+* Fixed a bug where failing to open log files for writing prevented Snooper from functioning properly.
+"""


### PR DESCRIPTION
* Chat messages loaded from log files (rather than sent in the current game session) are now dimmed out.
* Fixed a bug where failing to open log files for writing prevented Snooper from functioning properly.
