### PR TITLE
Pet Scale 2.0.0

### DIFF
--- a/testing/live/PetScale/manifest.toml
+++ b/testing/live/PetScale/manifest.toml
@@ -1,8 +1,14 @@
 [plugin]
 repository = "https://github.com/Kurochi51/PetScale.git"
-commit = "e57e44a668265b669a7e64de3c775fb3bc73057a"
+commit = "f88152c4123ff32a97122dff9c33fb504ba6fc20"
 owners = ["Kurochi51"]
 project_path = "PetScale"
 changelog = """
-- New plugin that allows you to control the scale of summoner pets
+- Switched pet matching to use ContentId, thus eliminating false-positive matches
+- Added support for custom sizes of MCH, SCH, DRK, and fixed-size SMN pets
+- Pet custom size will not be set in PvP
+- Added the ability to add a new entry by typing the character name in the Character filter box
+- Fixed bug where fairy setting would always set a size
+- Pets will revert to their vanilla size when an entry is removed, if they're still around
+- Slowed down the plugin by only 3.5 times instead of 4.5 times
 """


### PR DESCRIPTION
It's time for my non-rewrite! After numerous sacrifices to our ImGui God, Omar, I added a mostly-intelligible way to set custom sizes for pets. SMN pets affected by `/petsize` were intentionally excluded, I might come back to this if there's interest, but I felt like it would go against the original intention of the plugin.

I tested this as much as I could on my own & with randoms, and it seems to work fine™. Right now the custom size for any given pet is arbitrarily limited to their vanilla size, and the higher of 4 * vanilla size or 4.
The vfx related scaling that I left laying around isn't used right now, it doesn't seem like pets actually respect it.

- Switched pet matching to use ContentId, thus eliminating false-positive matches
- Added support for custom sizes of MCH, SCH, DRK, and fixed-size SMN pets
- Pet custom size will not be set in PvP
- Added the ability to add a new entry by typing the character name in the Character filter box
- Fixed bug where fairy setting would always set a size
- Pets will revert to their vanilla size when an entry is removed, if they're still around
- Slowed down the plugin by only 3.5 times instead of 4.5 times
