### PR TITLE
[Testing] Glamaholic 1.10.3

### DIFF
--- a/testing/live/Glamaholic/manifest.toml
+++ b/testing/live/Glamaholic/manifest.toml
@@ -1,7 +1,12 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = '5514325c0255ef42c8a76ae2115428cdd73a9a33'
+commit = '30f5008025016b32c0b72bd0ccff74be53f544cf'
 owners = [ 'caitlyn-gg' ]
 changelog = """
+**Bug Fixes**
 - Fixed a bug when applying Glamaholic plates wherein dyes would not be correctly identified or show in the preview.
+
+**New Features**
+- Added "Export as Text" feature, available in the button bar at the bottom of the glamour edit and preview pane.
+- Added "Fill with New Emperor" options to fill empty slots with New Emperor either in-plate or when applying or trying a plate on.
 """

--- a/testing/live/Glamaholic/manifest.toml
+++ b/testing/live/Glamaholic/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = 'ad78fa160102201d5550cdeb6b5b397f59517b7d'
+commit = '555d3ab55dc62c360dd25271f816b8e16dbe1a46'
 owners = [ 'caitlyn-gg' ]
 changelog = """
-- Eorzea Collection importing now uses the new EC API (shoutout Edeon and the EC team for this!)
+- Fixed a bug when applying Glamaholic plates wherein dyes would not be correctly identified or show in the preview.
 """

--- a/testing/live/Glamaholic/manifest.toml
+++ b/testing/live/Glamaholic/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = '555d3ab55dc62c360dd25271f816b8e16dbe1a46'
+commit = '5514325c0255ef42c8a76ae2115428cdd73a9a33'
 owners = [ 'caitlyn-gg' ]
 changelog = """
 - Fixed a bug when applying Glamaholic plates wherein dyes would not be correctly identified or show in the preview.


### PR DESCRIPTION
**Bug Fixes**
- Fixed a bug when applying Glamaholic plates wherein dyes would not be correctly identified or show in the preview.

**New Features**
- Added "Export as Text" feature, available in the button bar at the bottom of the glamour edit and preview pane.
- Added "Fill with New Emperor" options to fill empty slots with New Emperor either in-plate or when applying or trying a plate on.