### PR TITLE
ChatTwo 1.27.9

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "7b0acf3855ac033c3184025c844721938a2a83d6"
+commit = "e41a59ac84129364a10135ece5076e9963576c8c"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**Fonts**
- Uses dalamud font chooser
- Italic font version can be chosen
- **Config options related to fonts have been reset**
- Old font names and sizes used are displayed for up to a month

**LiteDB**
- Migration option removed
- Old files can still be deleted in the database tab

**Keybinds**
- Avoids overriding modifiers after leaving a vanilla text box [thanks dean]
  - This would prevent you from holding e.g. Ctrl between multiple vanilla text boxes
- Reworks linkshell rotation code to fix issues with LS number gaps causing linkshell rotation to not function [thanks dean]

**Textures**
- Switch to dalamuds internal texture cache
- Role icons are now compatible with penumbra [thanks mopi]

Note:
To get the previous font also as italic, install this <https://fonts.google.com/noto/specimen/Noto+Sans> and pick Noto Sans Regular + Noto Sans Italic