### PR TITLE
Map Party Assist v2.2.1.0

### DIFF
--- a/stable/MapPartyAssist/manifest.toml
+++ b/stable/MapPartyAssist/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/wrath16/MapPartyAssist.git"
-commit = "d23ba559f889d30caa870c99bf81b4b65e6d1595"
+commit = "60ea13c0a70caa91f03923e9933f54ab2496e52a"
 owners = ["wrath16"]
 project_path = "MapPartyAssist"
 changelog = """
-* Update for 7.0.
+* Sets portal for map when duty is unknown.
 """


### PR DESCRIPTION
Prep for patch 7.05: 

* Setting map portal even when duty is unknown.

* (Curently disabled) implementation of feature to record unknown duties to be parsed later.

* Some in-progress re-factoring.