### PR TITLE
Umbra 2.1.9

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,24 +1,19 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "7a294e72bce77420727ab2361e33a89906a75d20"
+commit = "e5f2579f8ce368dc984b4370fff17ad937dbade1"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.1.8
+# Umbra 2.1.9
 
-## New additions
-
-- Added world markers for party members. Ideal when participating in FATE trains!
-- Added an option to set a fixed width to some widgets (location, weather, gearset, etc.) to help stabilize your toolbar layout a bit.
-- Added an indicator (counter) to the "Add Widget" window that shows how many instances of that widget type are currently on your toolbar. This should make it easier to find newly added widget types.
-- Added a right-click action to the Companion Widget to open the native companion window.
-- Added a click action to the Location widget to open and close the world map.
+This is a small update that addresses some issues with the previous release.
 
 ## Fixes & Improvements
 
-- Implemented a simple validation system for custom plugins to ensure they don't break Umbra itself due to breaking changes.
-- Permanently removed interactivity on the Spacer widget due to an issue with ImGui requiring clickable 'windows' being 32x32 pixels in size. This caused for overlap on neighboring widgets, resulting in them not being clickable anymore.
-- Fixed buttons overlapping in the Companion Widget popup when using German languages (by [Bloodsoul](https://github.com/Bloodsoul))
+- Fixed some widgets appearing to be non-interactable due to a neighboring widget overlapping them with an invisible box.
+- Fixed party member markers showing up in the game world when they shouldn't.
+- Fixed an issue where the text of some world markers did not render correctly in French.
+- Fixed the "auto-close popup" option for the gearset switcher.
 
 Visit the Umbra Discord server for the latest updates and information: https://discord.gg/xaEnsuAhmm
 """


### PR DESCRIPTION
# Umbra 2.1.9

This is a small update that addresses some issues with the previous release.

## Fixes & Improvements

- Fixed some widgets appearing to be non-interactable due to a neighboring widget overlapping them with an invisible box.
- Fixed party member markers showing up in the game world when they shouldn't.
- Fixed an issue where the text of some world markers did not render correctly in French.
- Fixed the "auto-close popup" option for the gearset switcher.

Visit the Umbra Discord server for the latest updates and information: https://discord.gg/xaEnsuAhmm