### PR TITLE
[Testing] Glamaholic 1.10.5

### DIFF
--- a/testing/live/Glamaholic/manifest.toml
+++ b/testing/live/Glamaholic/manifest.toml
@@ -1,12 +1,13 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = '621089f9676bb07873013238a50a37465bf26f2d'
+commit = '0df6635f62ed0b4fa0eac2c014777319040f8ad7'
 owners = [ 'caitlyn-gg' ]
 changelog = """
 **Bug Fixes**
-- Fixed a bug where dyes may be applied to the incorrect slot if the user had previously opened a context menu for another slot first
+- Fixed a bug causing items to be skipped on apply if they were in the first slot of the glamour dresser.
 
 **New Features**
-- Added Troubleshooting Mode to help track down an issue with plate slots applying inconsistently or not at all
-  - Activate through Settings -> "Troubleshooting mode", then check `/xllog` for messages starting with `[Troubleshooting]`
+None at this time.
+
+For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!
 """


### PR DESCRIPTION
**Bug Fixes**
- Fixed a bug causing items to be skipped on apply if they were in the first slot of the glamour dresser.

**New Features**
None at this time.

For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!