### PR TITLE
Allagan Tools 1.7.0.19

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,16 +1,20 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "a4c9785336742558340824880d91fcee13da354c"
+commit = "925a2e5b9edd4b392c98886495ba6079ac9e49f6"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.7.0.18"
+version = "1.7.0.19"
 changelog = """\
+### Added
+
+- Added a new section to the item window that displays the possible recipes for an item and the ingredients for each
+- Updated patch data for 7.05
+
 ### Fixed
 
-- Hopefully fully fixed column hiding not breaking the layout
-- Craft/Gather button columns now work as intended
-- Having an empty tooltip amount owned scope would sometimes make the tooltip show no owned items
+- Attempting to open the craft log via AT will no longer be allowed while crafting
+- Fixed a bug that would cause the Gather/Purchase/Buy column to break how right clicking interacted with the tables
 
 """


### PR DESCRIPTION
### Added

- Added a new section to the item window that displays the possible recipes for an item and the ingredients for each
- Updated patch data for 7.05

### Fixed

- Attempting to open the craft log via AT will no longer be allowed while crafting
- Fixed a bug that would cause the Gather/Purchase/Buy column to break how right clicking interacted with the tables