### PR TITLE
Glamaholic 1.10.6 (Testing -> Stable)

### DIFF
--- a/stable/Glamaholic/manifest.toml
+++ b/stable/Glamaholic/manifest.toml
@@ -1,5 +1,17 @@
 [plugin]
-repository = 'https://git.anna.lgbt/anna/Glamaholic.git'
-commit = 'e86866ae6f44ce33220b11e38fdf100804be9240'
-owners = [ 'lojewalo' ]
-changelog = 'API 9'
+repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
+commit = '7fd99029d0a4bd1c6f5689cf22be693f0bbf4295'
+owners = [ 'caitlyn-gg' ]
+changelog = """
+Glamaholic has been adopted!
+
+Updated for Dawntrail & API X.
+
+**New Features**
+- Added "Export as Text" feature, available in the button bar at the bottom of the glamour edit and preview pane.
+- Added "Fill with New Emperor" options to fill empty slots with New Emperor either in-plate or when applying or trying a plate on.
+- Added Troubleshooting Mode to help track down potential issues
+  - Activate through Settings -> "Troubleshooting mode", then check `/xllog` for messages starting with `[Troubleshooting]`
+
+If you encounter any issues, please enable troubleshooting mode (see above) and let us know in the Glamaholic thread of the Plugin Help Forum on Discord. Thanks!
+"""


### PR DESCRIPTION
Glamaholic has been adopted and updated for Dawntrail & API X!

**New Features**
- Added "Export as Text" feature, available in the button bar at the bottom of the glamour edit and preview pane.
- Added "Fill with New Emperor" options to fill empty slots with New Emperor either in-plate or when applying or trying a plate on.
- Added Troubleshooting Mode to help track down potential issues
  - Activate through Settings -> "Troubleshooting mode", then check `/xllog` for messages starting with `[Troubleshooting]`

If you encounter any issues, please enable troubleshooting mode (see above) and let us know in the Glamaholic thread of the Plugin Help Forum on Discord. Thanks!