### PR TITLE
DelvUI release 2.2.0.8

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "e5552bd9d393fe1085f5cb153e01c83a4061d85f"
+commit = "804e59fe8abe1c06da307814a4c550af5c911b01"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Updated Viper's Vipersight Bar according to the changes in patch 7.05.
- Removed Viper's Noxious Gnash bar.
- Added the `company-formatted` text tag.
- Changed Mug to Dokumori in Party Cooldowns.
- Fixed Ninja's Suiton Bar (now called Shadow Walker Bar).
- Fixed chat being spammed with hotbar commands.
- Fixed soft targeting support for the Enemy List.
- Fixed Chocobo showing up as a Viper in the party list.
- Fixed Dark Knight's Blood Weapon Stacks being 3 instead of the previous 5.
- Fixed support for the Pet Nicknames plugin.