### PR TITLE
DelvCD release 1.1.1.0

### DIFF
--- a/stable/DelvCD/manifest.toml
+++ b/stable/DelvCD/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvCD.git"
-commit = "444ad29fa9db4d8048a6ca9ff71df9b218020672"
+commit = "8a660a84ec0aead439246fb9830353031d810c17"
 owners = ["Tischel"]
 project_path = "DelvCD"


### PR DESCRIPTION
- Added Dynamic Groups that automatically layout their elements.
- Updated Monk's Job Gauge triggers.
- Fixed fonts sometimes not loading.
- Fixed input text for items, status and cooldown triggers being limited to 32 characters.