### PR TITLE
Craftimizer 2.5.1.0

### DIFF
--- a/stable/Craftimizer/manifest.toml
+++ b/stable/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Craftimizer.git"
-commit = "10bb95d9d8ce38dc38a3a532c9e01cc0e9070a2b"
+commit = "c9171c1db6a7512a8b8274d1f3fa0ab1d9eb9217"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"


### PR DESCRIPTION
- Crafting log helper now takes your HQ ingredients into account. Thanks khelzor for the suggestion!
- Some bug fixes related to the synthesis helper having the incorrect recipe or step count.