### PR TITLE
[Testing] Update FCNameColor to 5.0.1.0

### DIFF
--- a/testing/live/FCNameColor/manifest.toml
+++ b/testing/live/FCNameColor/manifest.toml
@@ -1,17 +1,9 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "9df61370a508fe6b3010aca932d5d2c4cb0c3bb4"
+commit = "bda9fd3d0696e9f50407f1dc2e8ad658260a5843"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
-- Update for 6.5
-- Reworked configuration to reduce config size
-- Add ignore friends option
-- Add ability to change the group for the player's own FC
-- Allowed for additional FC list to scale for longer lists
-- Wrote migration from old config to new config
-- Switched over to new method of doing the nameplates, this should alleviate issues with name abbreviation settings
-- Add additional logic for ensuring a group always exists
-  This should alleviate some of the crashing issues.
-- Made it so that opening the config with /fcnc or through the plugin installer toggles the config on and off
+- Fixed issue where players without titles would show as having an empty title if the "Only color FC tag" option is enabled
+- Updated error handling for the rest of FCNC to continue working if the character can't be found on Lodestone due to them being new or set to private
 """


### PR DESCRIPTION
- Fixed issue where players without titles would show as having an empty title if the "Only color FC tag" option is enabled
- Updated error handling for the rest of FCNC to continue working if the character can't be found on Lodestone due to them being new or set to private