### PR TITLE
[Testing] Glamaholic 1.10.8

### DIFF
--- a/testing/live/Glamaholic/manifest.toml
+++ b/testing/live/Glamaholic/manifest.toml
@@ -1,16 +1,14 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = 'd85442b7603c30394a51db389cc83a0f4ec2a92a'
+commit = '4532b256a9cd33e19f5eb4fd4604b3b4a856e931'
 owners = [ 'caitlyn-gg' ]
 changelog = """
 **Bug Fixes**
-None at this time.
+- Fixed a bug related to plugin interop that could occasionally cause a crash when used.
 
 **New Features**
-- Separated Eorzea Collection features into a new menu.
-- Eorzea Collection imports are now automatically tagged as such.
-- Added the option to try a glamour on directly from EC without having to create a plate first.
-- Began support for interop with other plugins. Plugin interop features will only display if supported plugins are installed and enabled.
+- Added "Mass Import" for Eorzea Collection.
+- Added dye list + copy for Glamaholic plates.
 
 For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!
 """


### PR DESCRIPTION
**Bug Fixes**
- Fixed a bug related to plugin interop that could occasionally cause a crash when used.

**New Features**
- Added "Mass Import" for Eorzea Collection.
- Added dye list + copy for Glamaholic plates.

For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!