### PR TITLE
Chatter Updated to v1.2.0--events

### DIFF
--- a/stable/Chatter/manifest.toml
+++ b/stable/Chatter/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/jlkeesey/Chatter.git"
-commit = "23866e5c838f17b438cb397300954de1778f3ed7"
+commit = "82b5f8f11bb66f026f81a3007cb81cb91ff9e6b9"
 owners = ["jlkeesey"]
 project_path = "Chatter"
 changelog = "Added events."

--- a/stable/Chatter/manifest.toml
+++ b/stable/Chatter/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/jlkeesey/Chatter.git"
-commit = "00df5c80f95c448e73e0946cf21752f57f6c9cd1"
+commit = "23866e5c838f17b438cb397300954de1778f3ed7"
 owners = ["jlkeesey"]
 project_path = "Chatter"
-changelog = "Added Restart button."
+changelog = "Added events."


### PR DESCRIPTION
Added support for timed events.

* Timed events are groups that can be started from the main panel and will automatically stop or deactivate when the time runs out. This can be used for short events like Eternal Bonding ceremonies.

* The /chatter command now opens the main window which has controls for running Chatter. The configuration window command is now /chattercfg. You can also open the config from the new main window.