### PR TITLE
ChatTwo 1.28.0

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "f22b917164ffd7b4d9228c23f0ed00e9eda0cf50"
+commit = "4d341679abb389d8224c59912df057d03998d858"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Fix M4S tooltips being shown as encrypted text