### PR TITLE
Craftimizer 2.5.2.0

### DIFF
--- a/stable/Craftimizer/manifest.toml
+++ b/stable/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Craftimizer.git"
-commit = "7ba0e65bb028f14ae8025bfe7e536c34a18409cb"
+commit = "4b4cc9f9d96329aa12970feab9f8a7c36f163007"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"


### PR DESCRIPTION
- Add a warning when trying to use Macro Mate integration when it isn't installed
- Fix Craftimizer assuming you weren't a specialist when you had no delineations
- Switched to ExdSheets 2, meaning Craftimizer no longer uses 400 MB ram when idle (and things like the recipe search is faster and more responsive)
- Fixed some minor UI bugs/typos