### PR TITLE
 DelvUI release 2.2.0.10

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "03d97468a842f11243af8cbe24bceea56c120bd6"
+commit = "f7249097a69597bc92b57cafe2bc6024661f4d0f"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Fixed Party Cooldowns not working properly:
  * Added some cooldowns that were missing.
  * Cooldowns that have an upgraded version now work for the old and new abilities.
  * Actions that share the same cooldown should work properly now.
  * Fixed Starry Muse's icon.

- Added Window Clipping support for other plugins.