### PR TITLE
MacroMate 1.0.17.1

### DIFF
--- a/stable/MacroMate/manifest.toml
+++ b/stable/MacroMate/manifest.toml
@@ -1,12 +1,10 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "fbe7abb520b4b7da168b5512f864551bdf3e0d85"
+commit = "ee7016d515e86005a17cdc4e135b5bd1a2daae41"
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.17.0"
+version = "1.0.17.1"
 changelog = """
-- Added 'Import from Game' feature
-  See: `New > Import > From Game` and `Right Click > Import Here > From Game`
-- Added 'Bulk Delete' edit mode action
-- Allow Shift + Right Click to select nodes into edit mode
+- Fix IPC incorrectly overriding existing icons and links
+- Fix 'Update in Macro Mate' not updating macro text
 """


### PR DESCRIPTION
- Fix IPC incorrectly overriding existing icons and links
- Fix 'Update in Macro Mate' not updating macro text