### PR TITLE
Umbra 2.2.16

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,28 +1,22 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "ba2c69c011eed370e543df99dcb76672972b5d2b"
+commit = "67116eb89fdc8ada3d43a1f8d01afd02733a16b7"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.2.15
+# Umbra 2.2.16
 
-## Shortcut Panel
+## New Additions
 
-Have you ever found yourself in need of more hotbars for things that aren't job-related? This update introduces a new widget, the "**Shortcut Panel**", which is effectively an additional hotbar (panel). It looks similar to the Emote widget but instead of only being capable of holding emotes, it can contain a whole bunch of stuff, including items from your inventory, mounts, minions, stored macros, and even shortcuts to your commonly used crafting recipes.
-
-The panel allows you to customize the amount of rows and columns, up to a maximum of 16. Similar to the "Emote List" widget, it also supports up to 4 categories. This means that a single category can hold a maximum of 256 slots, or 1024 over all 4 categories in total.
-
--# Although this widget shares similarities to the Emote List widget, this widget is meant to be a _general purpose_ widget, meaning it does not have any type-specific settings. It is _not_ designed for customization of names, icon colors, or any other type-specific settings like toggling the option to send emotes to chat for example.
+- Added a "Key Item Picker" to the "Shortcut Panel" widget. This means that you can now pin your Wondrous Tails book to your shortcut panel, amongst other things.
 
 ## Fixes & Improvements
 
-- Added "Looking to Meld" & "Looking for Party" statuses to the "Online Status" widget.
-- Fixed the Societal Relations widget automatically expanding in width when a custom UI scale was used.
-- Fixed an issue in the drawing library where the "gap" between nodes did not take custom UI scale into account.
-- Fixed the "Main Menu Button" popups not syncing properly.
-- Fixed a couple of minor translation issues.
-
--# This is a rather large update, meaning it may take a little while for it to become available.
+- Added _partial_ support for custom icons set via `/micon` and `/macroicon` in stored macros. Gearset icons and ID's (from SimpleTweaks' Extended Macro Icon tweak) are now picked up by the shortcut panel widget.
+- Implemented shared clip-region support for DelvUI. This should make sure that DelvUI no longer intercepts mouse clicks when an Umbra widget or window is on top of a DelvUI element.
+- Fixed correct macros not being selected correctly from the Macro picker in the shortcut panel widget.
+- Fixed the Societal Relations widget from growing horizontally while UI scale is < 100.
+- Fixed the bottom padding (or lack thereof) of the shortcut panel widget.
 
 Visit the Umbra Discord server for the latest updates and information: https://discord.gg/xaEnsuAhmm
 """


### PR DESCRIPTION
# Umbra 2.2.16

## New Additions

- Added a "Key Item Picker" to the "Shortcut Panel" widget. This means that you can now pin your Wondrous Tails book to your shortcut panel, amongst other things.

## Fixes & Improvements

- Added _partial_ support for custom icons set via `/micon` and `/macroicon` in stored macros. Gearset icons and ID's (from SimpleTweaks' Extended Macro Icon tweak) are now picked up by the shortcut panel widget.
- Implemented shared clip-region support for DelvUI. This should make sure that DelvUI no longer intercepts mouse clicks when an Umbra widget or window is on top of a DelvUI element.
- Fixed correct macros not being selected correctly from the Macro picker in the shortcut panel widget.
- Fixed the Societal Relations widget from growing horizontally while UI scale is < 100.
- Fixed the bottom padding (or lack thereof) of the shortcut panel widget.