### PR TITLE
MonsterDex 2.11.1

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/MonsterDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "d73af20ad43a49c7b540dfbe630f62eb37b649ed"
-changelog = "## 2.11.0 (2024-07-01)\n\n\n### Features\n\n* update for apix (c931c14)"
-version = "2.11.0"
+commit = "edfec7d9cada3fa9d4a39bf4a0e2ec6b73490a8b"
+changelog = "### 2.11.1 (2024-08-10)\n\n\n### Bug Fixes\n\n* correct bitmask on ContentType option not working for Overworld (41b6520)"
+version = "2.11.1"


### PR DESCRIPTION
### 2.11.1 (2024-08-10)


### Bug Fixes

* correct bitmask on ContentType option not working for Overworld (41b6520)