### PR TITLE
DelvUI release 2.2.1.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "f7249097a69597bc92b57cafe2bc6024661f4d0f"
+commit = "ac0854ed165d0872204a1904e25c85f54903b24f"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Added `Misc > HUD Options > Support Special Mouse Clicks` setting:
  * This setting should only be used if you have actions bound to special mouse buttons such as mousewheel, M3, M4, etc.
  * If you don't use those mouse buttons, you should leave this setting disabled.

- Fixed DelvUI elements "eating" mouse clicks from other windows that are on top of them.