### PR TITLE
[Testing] Gauge-O-Matic 0.8.0.2

### DIFF
--- a/testing/live/GaugeOMatic/manifest.toml
+++ b/testing/live/GaugeOMatic/manifest.toml
@@ -1,22 +1,25 @@
 [plugin]
 repository = "https://github.com/itsbexy/gaugeomatic.git"
-commit = "40c555169f005b7f1e09da66f4f726a429bc2b75"
+commit = "4bd1d038605855377e590ff52843f3ce4bcd4de6"
 owners = [
     "ItsBexy",
 ]
 changelog = """
 ## INTERFACE
-- The plugin UI now displays the icons for actions, status effects, and jobs.
-- Tooltips within the plugin have been substantially updated, and now include more comprehensive details about tracked data.
+- Updated the Widget Settings windows to use tabbed navigation
+- Added job icons to the main window navigation
 
-## ACTION TRACKERS
-The plugin has been updated extensively under the hood to fetch job action data from the game client, rather than relying on a manually-maintained file. This means many actions that were previously not included will now be selectable to track. The plugin will also more easily keep up with future changes to job actions that come with client patches.
-- Action names will now match the client localization settings.
-- The logic for using State Indicator widgets and Bar widgets with actions has been updated (check tracker tooltips for details)
+## TRACKERS
+- Added general trackers for the Combo Timer and GCD
 
-These changes will hopefully not impact your saved configuration data, but it's possible that you will need to make adjustments.
+## WIDGETS
+- **New Counter Widget:** *Coil Diamonds*, recreating the diamonds from VPR's Vipersight gauge.
+- **New Counter Widget:** *Palette Pearls*, recreating the white & black paint stacks from PCT's Palette Gauge.
+- **Improved Counter Widget:** *Meditation Gems* can now extend to display any amount of stacks/charges, instead of being restricted to exactly 3.
 
-## PRESETS
-- Fixed an issue wherein certain widgets would not keep all of their configuration values intact when saved/loaded as presets
-- Certain jobs have had their default presets updated. As always, your existing configurations will not be changed, but you can use the Presets window to load these new defaults.
+## MISC FIXES
+- Fixed an issue wherein the Oath Gauge couldn't fully be hidden in simple mode.
+- Fixed an issue wherein using mods to alter the shape of your minimap would affect the appearance of certain widgets.
+- Fixed the status effect Eukrasian Dyskrasia being incorrectly marked as a self-buff (whoops!)
+- Linked the Guardian and Sentinel status effects
 """


### PR DESCRIPTION
## INTERFACE
- Updated the Widget Settings windows to use tabbed navigation
- Added job icons to the main window navigation

## TRACKERS
- Added general trackers for the Combo Timer and GCD

## WIDGETS
- **New Counter Widget:** *Coil Diamonds*, recreating the diamonds from VPR's Vipersight gauge.
- **New Counter Widget:** *Palette Pearls*, recreating the white & black paint stacks from PCT's Palette Gauge.
- **Improved Counter Widget:** *Meditation Gems* can now extend to display any amount of stacks/charges, instead of being restricted to exactly 3.

## MISC FIXES
- Fixed an issue wherein the Oath Gauge couldn't fully be hidden in simple mode.
- Fixed an issue wherein using mods to alter the shape of your minimap would affect the appearance of certain widgets.
- Fixed the status effect Eukrasian Dyskrasia being incorrectly marked as a self-buff (whoops!)
- Linked the Guardian and Sentinel status effects