### PR TITLE
DelvUI release 2.2.1.1

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "ac0854ed165d0872204a1904e25c85f54903b24f"
+commit = "8efd2bb9c06b962cd447715a0b46e57807ab7965"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Removed `Misc > HUD Options > Support Special Mouse Clicks` setting:
  * This has been replaced with the `/delvui mouse on/off` command.
  * This feature should only be used by players that have actions bound to special mouse buttons that otherwise wouldn't work when hovering DelvUI elements.

- Added a Window Clipping setting for third party plugins:
  * This setting can be used to prevent DelvUI elements to be drawn on top of other plugins.
  * Please note that this requires the developers of each plugin to implement the feature.
  * Umbra already supports this as of version 2.2.17.

- Fixed inconsistencies with mouse clicks on various DelvUI elements.