### PR TITLE
MonsterDex 2.11.2

### DIFF
--- a/stable/DeepDungeonDex/manifest.toml
+++ b/stable/DeepDungeonDex/manifest.toml
@@ -2,6 +2,6 @@
 repository = "https://github.com/wolfcomp/MonsterDex.git"
 owners = [ "wolfcomp" ]
 project_path = "DeepDungeonDex"
-commit = "edfec7d9cada3fa9d4a39bf4a0e2ec6b73490a8b"
-changelog = "### 2.11.1 (2024-08-10)\n\n\n### Bug Fixes\n\n* correct bitmask on ContentType option not working for Overworld (41b6520)"
-version = "2.11.1"
+commit = "a397321b5103272805ac8943fcdcc73a840031cf"
+changelog = "### 2.11.2 (2024-08-13)\n\n\n### Bug Fixes\n\n* certain mobs not being displayed correctly in deep dungeon (e6b00d8)\n* stop window from trying to continuously resize (d4a2100)"
+version = "2.11.2"


### PR DESCRIPTION
### 2.11.2 (2024-08-13)


### Bug Fixes

* certain mobs not being displayed correctly in deep dungeon (e6b00d8)
* stop window from trying to continuously resize (d4a2100)