### PR TITLE
Party Icons v1.2.1.0

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/nebel/xivPartyIcons.git"
-commit = "66fc223ab537ae0051c67470f6acd4172b5e56b3"
+commit = "face9eeec2f77bf45d90c509e55d09b7e5d60400"
 owners = [
     "shdwp",
     "avafloww",


### PR DESCRIPTION
- Add "Save as static" context menu option which will save the selected player's current role as a static role. This option must be enabled in the settings first.
- Fixes an issue where party/alliance chat modifications would cause issues when saved into a Chat2 database.
- Attempts to fix an issue where the zone-in notification sometimes mentioned the wrong content type (e.g. Masked Carnivale). Please let me know if this works or not.