### PR TITLE
Graphics Config update 1.0.0.1

### DIFF
--- a/testing/live/GraphicsConfig/manifest.toml
+++ b/testing/live/GraphicsConfig/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Aida-Enna/GraphicsConfig.git"
-commit = "3f8ab441850e89a2b15762ad5c7a47ff47d5e435"
+commit = "3b7b1a32f73aa9207aa6840d449901d3ce3e0cf1"
 owners = ["Aida-Enna"]
 project_path = ""
-changelog = ""
+changelog = "- Fixed an issue where watching the pre-cutscene in a duty would overwrite the loaded duty preset\n-Fixed an issue where InDuty would trigger when you were queuing via DF"


### PR DESCRIPTION
- Fixed an issue where watching the pre-cutscene in a duty would overwrite the loaded "In Duty" preset
- Fixed an issue where "In Duty" would trigger when you were queuing via DF