### PR TITLE
ChatTranslated 3.1.0.4

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "19e45045b5cd20e2671ee127f239f92ef079c8b2"
+commit = "8c557c6bc69a650ddd0b92e971d8a17fefdc9cfb"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
-Fix conflict with chat bubbles.
+No longer translate message handled by other plugins like the visibility plugin.
+Update OpenAI API key format to actually make it usable.
+Add an option to hide original message when outputting translation.
 """
 [plugin.secrets]
 cfv3 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdA9i5EbwP580i9qnhn7aIbFOqBucfkgHyMiAw/g6WM\ntC8wuOicNTjNOxH1iSThh28b81JDAWE4hNUvwJhTJo87Ez+zLNvN4yffULGt\nPGrNoCAT0lgBFA+LsaOYPohc0XMre0Js6YGMAgYsuD4aypFqIvKz/uwb6NPc\nc4/JkJoFCZSEmivpdzOmOxbCK7km6JsA3tI4+hLtmvvAKZyzejyc8Xa2gfUk\nwLcyIanJ\n=9maw\n-----END PGP MESSAGE-----\n"

--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "8c557c6bc69a650ddd0b92e971d8a17fefdc9cfb"
+commit = "340229ec88494a9f5358f986380579c9a648ec42"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """


### PR DESCRIPTION
No longer translate message handled by other plugins like the visibility plugin.
Update OpenAI API key format to actually make it usable.
Add an option to hide original message when outputting translation.