### PR TITLE
XIVDeck 0.3.20

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "eaeaa3bd31d142df5c1c954658df86798a0d0368"
+commit = "fccbc7012536149f5d0143496fdd80776d20c9ce"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
The attempt to make XIVDeck better continues, eventually.

* Adds a new API endpoint for listing registered macros
* Fix some bad API assumptions for the Stream Deck SDK
  * Remove zh and ko translations, as they were empty and caused some odd bugs.
* Some minor performance tweaks

A huge thank you to @SilentSwordmaiden for releasing their [StreamController Plugin](https://github.com/SilentSwordmaiden/StreamController-XIVDeck-Plugin) for Linux users!

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.20).