### PR TITLE
Disable overrides

### DIFF
--- a/overrides.toml
+++ b/overrides.toml
@@ -1,3 +1,3 @@
 [channel_tracks]
-testing-live = "apiX"
-stable = "apiX"
+#testing-live = "apiX"
+#stable = "apiX"


### PR DESCRIPTION
Disables overrides so all builds go against stable Dalamud. They're currently pointing to `stg` which may contain API surfaces not present in Dalamud proper.