### PR TITLE
ChatTwo 1.28.2

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "9d6fcd2abe23bea82d7d182e5417b8f40935ffa1"
+commit = "117d9fc45c7d5bd0f98c3da0f8549eaf2c1b363e"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**Added**
- Implement 24-hour clock timestamp option [default false]

**Fixes**
- Bozja/Eureka tells should work again
- Invites in Bozja/Eureka should work again
  - Added a notification that warns about fails duo missing player id
- Hide activity channels are now saved across sessions

**Misc**
- Loc updates