### PR TITLE
XIVDeck 0.3.21

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "fccbc7012536149f5d0143496fdd80776d20c9ce"
+commit = "32cc7112c6dfa48d647c065c77d4a7429c8d1f6a"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Yo dawg, I heard you like features, so I removed some features from your features. Wait... that's not right. What?

Unfortunately, it is in fact time to say goodbye to a few things. Specifically:

* The "Use Penumbra IPC" checkbox has been removed and the feature has been turned on for everyone. This simplifies icon handling and paves the way for some new performance improvements in the future.
* The secret setting `ListenOnAllInterfaces` was removed, meaning XIVDeck will only accept connections from the local computer. This was necessary for security purposes, and was never properly exposed to end users.
  * If you somehow *were* using this secret config setting, I recommend you instead set up [an SSH tunnel](https://www.ssh.com/academy/ssh/tunneling) to securely forward your XIVDeck port to a different computer.

To keep everyone from getting too mad, a few improvements were made:

* API consumers now can read current gearset information by requesting Gearset ID 0 (or any negative number).
* Performance improvements to Gearset and Macro update watchers.
* Some minor tweaks to how game input is handled to resolve things faster

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.21).