### PR TITLE
Umbra 2.2.29

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,20 +1,15 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "a90f736ff475e53fe53223a3739f81d51a9a71e6"
+commit = "58f1b2a634d21e28f2e916516992f51b42defcb5"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.2.28
-
-## New Additions
-
-- Added "Right-click" options to the "Custom Button" widget that allows you to add an additional command or website to open when right-clicking a custom button.
-- Added a "Revert to default value" button that appears in Umbra's Settings Window when a value has changed under General- or Marker settings.
+# Umbra 2.2.29
 
 ## Fixes & Improvements
 
-- Fixed some world markers disappearing on certain camera angles.
-- Fixed search not working in the Shortcut Panel's Macro Picker window.
+- Removed excessive padding on most widgets in non-decorative mode. This will move most widgets closer to each other. If this bothers you, either increase the item spacing in toolbar settings, or increase the "Horizontal button padding" in the widgets to increase the spacing. Note that this change only affects widgets that have decorations turned off.
+- Fixed the minimum icon ID limit of 14 on the shortcut panel. This was clearly a bug and not an intended "limitation".
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 2.2.29

## Fixes & Improvements

- Removed excessive padding on most widgets in non-decorative mode. This will move most widgets closer to each other. If this bothers you, either increase the item spacing in toolbar settings, or increase the "Horizontal button padding" in the widgets to increase the spacing. Note that this change only affects widgets that have decorations turned off.
- Fixed the minimum icon ID limit of 14 on the shortcut panel. This was clearly a bug and not an intended "limitation".
