### PR TITLE
PvP Tracker v2.1.3.0

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "19a9331b4c6feb56a26e38397ef5235ea247024d"
+commit = "d7205aa541a45538ff1484bc2628fe8289e2d22f"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Updated and re-enabled Rival Wings match tracking for Dawntrail.
-* Fixed a bug where table data would be offset on the Frontline match details window.
+* Added config option to make scoreboard columns stretch-able.
+* Fixed filter name display for non-standard styles/fonts.
+* Fixed win rate coloring on Frontline summary.
 """

--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "b52071f38f7a1fb033e6a4afdb10f93e305bbd6c"
+commit = "aaa4baa6f56dd1e914cca574cbb6c846b04773db"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """

--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "aaa4baa6f56dd1e914cca574cbb6c846b04773db"
+commit = "a839b2c8b83d40946cf206c16b75d246f3832f80"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """

--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "d7205aa541a45538ff1484bc2628fe8289e2d22f"
+commit = "b52071f38f7a1fb033e6a4afdb10f93e305bbd6c"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
 * Added config option to make scoreboard columns stretch-able.
 * Fixed filter name display for non-standard styles/fonts.
 * Fixed win rate coloring on Frontline summary.
+* FL and RW match details are now affected by "Always show player team on left".
+* Added an option to order FL teams by placement.
 """


### PR DESCRIPTION
* Added config option to make scoreboard columns stretch-able.
* Fixed filter name display for non-standard styles/fonts.
* Fixed win rate coloring on Frontline summary.
* FL and RW match details are now affected by "Always show player team on left".
* Added an option to order FL teams by placement.