### PR TITLE
Pet Nicknames v2.1.2.3

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "1409203f60cd140dfa072e27c88d6d1e95dfba67"
+commit = "128f7d8a704d39c6c4e32dec43430b27e888b10e"
 owners = ["Glyceri"]
 	changelog = """
     [2.1.2.3]

--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "42c198aa692694715fd4ec79b945f9344d7da478"
+commit = "1409203f60cd140dfa072e27c88d6d1e95dfba67"
 owners = ["Glyceri"]
 	changelog = """
-    [2.1.2.2]
-    Better Party List Resolve (AKA, if 2 people in your party have the same name, I now know who is who c:)
+    [2.1.2.3]
+    Fixes a couple bugs.
+    The party list will now refresh in real time when updating names.
 """


### PR DESCRIPTION
Fixes a bug where the party list cast bars would always thing the local player was the caster.
The party list will now refresh in real time when updating names.