### PR TITLE
[Testing] Bartender v1.1.2

### DIFF
--- a/testing/live/Bartender/manifest.toml
+++ b/testing/live/Bartender/manifest.toml
@@ -1,11 +1,16 @@
 [plugin]
 repository = "https://github.com/AtaeKurri/Bartender.git"
-commit = "dd34acc81a84bb2effa882991d164b6600c218fa"
+commit = "dabb3046fd7da31299c645e44433e23f823cdc98"
 owners = ["AtaeKurri"]
 project_path = "Bartender"
 changelog = """
-# v1.1.1
+# v1.1.2
 
-- Added localization for slot deletion and slot transparency.
-- Added a new setting for populating newly created profiles with the current hotbars.
+- Added Misc. Condition "Is Targeting".
+- Added Misc. Condition "Is Minion Out".
+- Added Misc. Condition "Is Mount Out".
+- Profiles loaded by Condition Sets now have matching colors for active and inactive.
+
+- Fixed a bug with HQ item icons not being displayed.
+- Fixed a bug with shifting slots inside hotbars.
 """


### PR DESCRIPTION
# v1.1.2

- Added Misc. Condition "Is Targeting".
- Added Misc. Condition "Is Minion Out".
- Added Misc. Condition "Is Mount Out".
- Profiles loaded by Condition Sets now have matching colors for active and inactive.
- Fixed a bug with HQ item icons not being displayed.
- Fixed a bug with shifting slots inside hotbars.