### PR TITLE
[Testing] WTSync 0.10.0.0

### DIFF
--- a/testing/live/WTSync/manifest.toml
+++ b/testing/live/WTSync/manifest.toml
@@ -1,17 +1,12 @@
 [plugin]
 repository = "https://github.com/KhloeLeclair/WTSync.git"
-commit = "5a92a241242af948a2f413c2dad3fb493f28b2d7"
+commit = "13590f6dbfae485381dae6cfbac0263df9dc499e"
 owners = [ 
 	"KhloeLeclair"
 ]
 project_path = ""
 changelog = """
-- Added configuration for various colors used in the WTSync UI.
-- Added option to colorize the server bar entry when in a matching duty.
-- Added notice that you can disable the server bar entry from Dalamud's settings, along with a helpful link.
-- Changed: Use the server bar entry to warn the player if the current duty is in their Wondrous Tails but has already been claimed.
-- Changed: Use sections for the settings window to organize things a bit better.
-- Fixed: Incorrect level range being displayed for Crystaline Conflict.
-- Fixed: The party state displaying incorrectly if you first load the plugin within a duty.
-- Fixed: Do not try to load images for Wondrous Tails entries if the image scale is set to 0.
+- Added a button to force WTSync to re-submit your current status to the server, in case your party members aren't seeing your status correctly.
+- Fixed the WTSync interface not opening if you're riding someone else's mount while using the option to Open with Wondrous Tails.
+- Changed some layout code to work better with different font and style settings, which will hopefully fix an issue with the settings window growing infinitely.
 """


### PR DESCRIPTION
- Added a button to force WTSync to re-submit your current status to the server, in case your party members aren't seeing your status correctly.
- Fixed the WTSync interface not opening if you're riding someone else's mount while using the option to Open with Wondrous Tails.
- Changed some layout code to work better with different font and style settings, which will hopefully fix an issue with the settings window growing infinitely.