### PR TITLE
ChatTranslated 3.2.0.1

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "b9909a0b9b2c09a52e7877494969eb8b9653eecb"
+commit = "1176c042fa5cbd5850426b9e3c264924ca3cc9c4"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """

--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,10 +1,13 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "1adb0f92c807855952181c35e0027a8e427ff29c"
+commit = "b9909a0b9b2c09a52e7877494969eb8b9653eecb"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
-Add Italian as supported language.
+New localization strings.
+Added an option to output colored translation strings.
+
+experimental: RAG support for OpenAI translations.
 """
 [plugin.secrets]
 cfv3 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdA9i5EbwP580i9qnhn7aIbFOqBucfkgHyMiAw/g6WM\ntC8wuOicNTjNOxH1iSThh28b81JDAWE4hNUvwJhTJo87Ez+zLNvN4yffULGt\nPGrNoCAT0lgBFA+LsaOYPohc0XMre0Js6YGMAgYsuD4aypFqIvKz/uwb6NPc\nc4/JkJoFCZSEmivpdzOmOxbCK7km6JsA3tI4+hLtmvvAKZyzejyc8Xa2gfUk\nwLcyIanJ\n=9maw\n-----END PGP MESSAGE-----\n"


### PR DESCRIPTION
New localization strings.
Added an option to output colored translation strings.

experimental: RAG support for OpenAI translations.