### PR TITLE
Teamcraft List Maker v1.0.0.2

### DIFF
--- a/testing/live/TeamcraftListMaker/manifest.toml
+++ b/testing/live/TeamcraftListMaker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Aida-Enna/TeamcraftListMaker.git"
-commit = "77e6e8f1f6fcb87b363553d97860f30c3b7f811e"
+commit = "734ecc52d4a390806fba52e392fd31c5551d9491"
 owners = ["Aida-Enna"]
 project_path = ""
-changelog = ""
+changelog = "- Removed the settings button (there are no settings)\n- Added a few items to the tags\n- Version bump"


### PR DESCRIPTION
- Removed the settings button
- Added a few items to the tags
- Version bump

I bumped it to 1.0.0.2 since one of the files was set as 1.0.0.1 so I figured it would just be better to get everything on the same page rather than chance some inconsistency or issue.