### PR TITLE
[Testing] Pet Nicknames v2.2.0.0

### DIFF
--- a/testing/live/PetRenamer/manifest.toml
+++ b/testing/live/PetRenamer/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "b1013ca53c53287901e2d6d5ae932466f020732c"
+commit = "2f128810c8a7583dd46bea64890732408c4a90e7"
 owners = ["Glyceri",]
 	changelog = """
-    [2.1.1.2]
-    Added the pet list button back (I lost it during aetheryte travel... sorry)
-    Fixed some german emote stuff (Badly...)
+    [2.2.0.0]
+    Massive performance increase (This requires the testing branch)
+    Nicknames for Tooltips on the (mini)map in alliance raids should now work (probably, I ran like 20 alliance raids, it all looked fine)
+    Companion Type images are now also visible in the petlist
+    Better refresh on certain elements, namely the party list and tooltips when updated via IPC. (Stuff like target bars will still require you to retarget someone/thing for it to update, sorry)
 """


### PR DESCRIPTION
    Massive performance increase (This requires the testing branch)
    Nicknames for Tooltips on the (mini)map in alliance raids should now work (probably, I ran like 20 alliance raids, it all looked fine)
    Companion Type images are now also visible in the petlist
    Better refresh on certain elements, namely the party list and tooltips when updated via IPC. (Stuff like target bars will still require you to retarget someone/thing for it to update, sorry)