### PR TITLE
DailyDuty v5.1.0.2

### DIFF
--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "e03a39f843a14595486f0299b8bb639c3f59a96e"
+commit = "c180779dcbba58d395e93df878276ba68cefff5e"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
Now clears selected duties when clicking on any module link that involves the duty finder.

Added "Only Show Expert Complete" option when tomecapped, this option will mark the Expert Roulette as complete when you are at your weekly capped tome limit.