### PR TITLE
Umbra 2.2.31

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,22 +1,20 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "944e49b206ffcc7d6860e9d3587820cfdc4f2ce6"
+commit = "5b332695888c9e52dd8d1f07218d95f93430be6b"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.2.30
+# Umbra 2.2.31
 
 ## New Additions
 
-- Added a **Stacked Clock** widget. I've decided to add this as a separate widget since the options this one provides would otherwise severely conflict with features of the existing clock widget. This one also allows you to define custom time formats.
-- Added a standalone **Coordinates** widget that shows your coordinates on the current map.
-- Added a configurable center point to the world marker's compass system.
-- Added an option to Hide the Auxiliary bar when your weapon is drawn.
-- Added the ability to right-click the mute buttons of individual channels in the volume widget popup.
+- Volume Control Widget: Added buttons to toggle whether audio channels continue to play while the game is in the background. The master channel toggles the "Play sounds when window is not active" setting.
+- Coordinates widget: Added a "two-label" option that condenses the widget by showing the X and Y values as two separate smaller labels.
 
 ## Fixes & Improvements
 
-- Location Widget: Switch to "Single label" mode if sub-label (district or coordinates) is empty to ensure the text is centered properly in all situations.
+- Shortcut Panel: Added support for all `/micon` variants. Big thanks to Haselnussbomber for making this possible!
+- Stacked Clock: Let the bottom clock use the same text color as the top one.
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 2.2.31

## New Additions

- Volume Control Widget: Added buttons to toggle whether audio channels continue to play while the game is in the background. The master channel toggles the "Play sounds when window is not active" setting.
- Coordinates widget: Added a "two-label" option that condenses the widget by showing the X and Y values as two separate smaller labels.

## Fixes & Improvements

- Shortcut Panel: Added support for all `/micon` variants. Big thanks to Haselnussbomber for making this possible!
- Stacked Clock: Let the bottom clock use the same text color as the top one.
