### PR TITLE
ChatTwo 1.29.0

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "117d9fc45c7d5bd0f98c3da0f8549eaf2c1b363e"
+commit = "a9da2cafc2131fd94d19e22acaf76ce57507c666"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**New Feature Added [Not enabled by default]**
- A web interface has been added
  - *This will not function if your game client is offline or you are logged out of the game*

**Main Features**
- View in-game chat on any device that has a web browser functionality
- Can send chat messages through the web interface directly into the game itself
- Easily copy & paste messages
- Option for automatic starting the web interface feature

**Security**
- This feature is not intended to be used outside of your local, private network
- Do not forward ports that are described inside the chat2 options panel
- Never share your authentication code under any circumstances
- Multi-box support is not provided, the web interface will track only the first client

**Additional Features soon to be Added**
- Display errors as small notifications inside the web interface

**Planned Features**
- Multiple Tabs support
- Browser specific settings
- Stylization support

**Additional Permissions Note**
- Users that wish to expand this to apps or other platforms are welcome to do so

*Note: An FAQ will be provided in the chat2 thread on the dalamud discord, linked in the About section*

**Other Updates**
- Removed the old font tooltips
- Massive loc update