### PR TITLE
[Testing] Altoholic v0.0.0.11

### DIFF
--- a/testing/live/Altoholic/manifest.toml
+++ b/testing/live/Altoholic/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "e21bc98f6fd0eb5628064270f462cac543be8862"
+commit = "296c80a84bac5944dc54d256beb67619d7ddde3f"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
-changelog = "Version 0.0.0.10: Fix missing condition for 0.0.0.9"
+changelog = "Version 0.0.0.11: Database migration"


### PR DESCRIPTION
* Migrate database provider from litedb to sqlite
  * Data should migrate without issue however in the case it doesn't, disable the plugin and manually delete the current database file in the plugin config folder before re-enabling.