### PR TITLE
Tracky 1.5.3.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "f76db1d05465babe7edf24d4297597bc0c72d088"
+commit = "fe78950241949b49a0037e0aec08c55f56d44a5e"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Gacha tables show unlocked checkmark [Enabled by default, only 3.0 and 4.0]
- Add more desynthesis records [4.1mil now]