### PR TITLE
Umbra 2.2.33

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,30 +1,19 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "4f8a1adacd652bd75792714731d40256ef2ce371"
+commit = "c44a520e2542d814bfe0baaf7a47f66e4cf11428"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.2.32
+# Umbra 2.2.33
 
 ## New Additions
 
-- Added a **Dynamic Menu** widget that is meant to be a successor of the "Custom Menu" widget. This one allows adding the same types of entries to be added like the ones from the Shortcut panel widget, as well as a "Custom entry" that has the same options as the existing Custom Menu / Button widgets. You can right-click items in this menu to start customizing.
-- Added a centralized place for number formatting that allows you to specify a custom decimal- and thousands separator in the General Settings category in the Settings window. All widgets showing numeric values will adhere to these options.
-- Added an "icon size" option to all toolbar widgets that use the "Icon Button Widget" base (volume, markers control, plugin list, battle effects, etc.)
+- Replaced all "Icon ID" input fields with an **Icon Picker**. Clicking on this type of control will open a new Icon Picker window that shows categorized icons. You can still use a custom icon ID by specifying it in the "Icon ID" input field in the icon picker window if the icon you are looking for is not in the default categorized sets.
+- Added a "Horizontal Padding" option to Icon Button Widget types. This allows you to increase the width of icon buttons in case you've disabled decorations.
 
 ## Fixes & Improvements
 
-- Fixed a potential crash that might occur when restarting the plugin from the settings window while the appearance tab is active.
-- Fixed an issue where select (dropdown) input controls were no longer visible when opening the settings window for the second time.
-- The Unified Main Menu widget will now hide the avatar image if the icon id is set to 0.
-- Streamlined all icon button widgets (volume, markers control, plugin list, battle effects) to all share the same configuration options.
-
-## Additional changes for developers
-
-- The window system is no longer internal and can be used by plugin authors.
-- Input control nodes are no longer internal and can be used by plugin authors.
-- A generic "VariablesWindow" has been added that allows creating windows that show a list of categorized input controls for an arbitrary list of variables. The new Dynamic Menu widget uses this to allow users editing custom menu entries. A future update will replace the Widget Settings window with this variant as well.
-- A new "FormatNumber" method has been added to "I18N". This method allows formatting a number that complies with user settings for decimal- and thousands separators.
+- The **Plugin List Widget** now adheres to default icon button widget settings.
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 2.2.33

## New Additions

- Replaced all "Icon ID" input fields with an **Icon Picker**. Clicking on this type of control will open a new Icon Picker window that shows categorized icons. You can still use a custom icon ID by specifying it in the "Icon ID" input field in the icon picker window if the icon you are looking for is not in the default categorized sets.
- Added a "Horizontal Padding" option to Icon Button Widget types. This allows you to increase the width of icon buttons in case you've disabled decorations.

## Fixes & Improvements

- The **Plugin List Widget** now adheres to default icon button widget settings.
