### PR TITLE
Waitingway 2.2.0

### DIFF
--- a/stable/Waitingway.Dalamud/manifest.toml
+++ b/stable/Waitingway.Dalamud/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Waitingway.git"
-commit = "c9cc2194598a8a09fcda69f60d8970818cfa5f70"
+commit = "251fea4be625416c4c0ba5a5f889f2f39e9eb55b"
 owners = ["avafloww", "NPittinger", "WorkingRobot"]
 project_path = "Waitingway"


### PR DESCRIPTION
## New in-game queue estimates!

Whenever logging in to play, the character select screen will now have a small indicator for the last known queue size and time. View the queue times for the rest of your datacenter by pressing the "World" button.

New Features:
- Migrated the settings button to the native UI
- Added queue estimates in the character select screen and world select popup
- Minor server-side bug fixes and stats (Grafana) dashboard performance boosts