### PR TITLE
ChatTwo 1.29.1

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "a9da2cafc2131fd94d19e22acaf76ce57507c666"
+commit = "0ea648ad6d61a1835e843734cd3b4b6b3ec7fc25"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**Webinterface**
- Log lines render limit for faster loading performance
- Display if channel selection is locked
  - The webinterface will show "(Locked)" and prevent clicking the channel switcher

**Other Things**
- More loc updates