### PR TITLE
[Testing] ZDs 1.0.0.2

### DIFF
--- a/testing/live/ZDs/manifest.toml
+++ b/testing/live/ZDs/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Zeffuro/ZDs.git"
-commit = "37676121811f9ad51a9a9dca8248b3639328e213"
+commit = "13b61146adaca3620fdb64b8f61d131cbbfb3b56"
 owners = ["Zeffuro"]
 project_path = "ZDs"


### PR DESCRIPTION
# 1.0.0.1
- Fixed BRD Bloodletter under Mage's Ballad and MCH Heat Blast affecting the cooldown of Gauss Round and Ricochet.  