### PR TITLE
[Testing] DragoonMayCry v0.6.4

### DIFF
--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "d8d3ed6fd36d95c1318cef02eacb59831cd5a147"
+commit = "9fa8b2120f72c1af3df90fbd8bd7ac9cc754cdf0"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
-changelog = "Added a final encounter rank based on time spent in each tier."
+changelog = "Added a final encounter rank based on time spent in each tier. Disabled for PvP. Bugfixes around the active outside instance option."

--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "9fa8b2120f72c1af3df90fbd8bd7ac9cc754cdf0"
+commit = "fe317a6be7bf2b40f6ee2321ddeb0fcd59b5a640"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
 changelog = "Added a final encounter rank based on time spent in each tier. Disabled for PvP. Bugfixes around the active outside instance option."

--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "ab3d8b1033ebdd421c8d0dbfd4ea3702898a9eae"
+commit = "d8d3ed6fd36d95c1318cef02eacb59831cd5a147"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
-changelog = "First submission, still WiP"
+changelog = "Added a final encounter rank based on time spent in each tier."


### PR DESCRIPTION
### Feature
- Added a final rank at the end of combat based on time spent in each tier. Can only be betwen D and S.
 
### Adjustments
- Delaying you GCD while in rank S or above sets you back to B.

### Bugfixes
- Disabled for PvP since job actions are completely different from PvE and keeping uptime is not relevant.
- Bugfixes around the 'Active outside instance' option. When it was disabled in combat and enabled a bit of time later on an other encounter, data from the previous encounter would be kept and resume as if it was the same encounter.

### Already existing but not documented
- Dying or taking a damage down sets you back to D rank.
- Expected damage output between each tier is based on your iLvl at the start of the encounter.
