### PR TITLE
[Testing] Allagan Market 1.0.0.1

### DIFF
--- a/testing/live/AllaganMarket/manifest.toml
+++ b/testing/live/AllaganMarket/manifest.toml
@@ -1,22 +1,14 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/AllaganMarket.git"
-commit = "65b52d8cd6e9ee71440985eba1c56f26faf34971"
+commit = "26dbdf7a8b530e5dc0671ee72103a6c7bb2a60e8"
 owners = [
     "Critical-Impact",
 ]
 project_path = "AllaganMarket"
-version = "1.0.0.0"
+version = "1.0.0.1"
 changelog = """\
-**Allagan Market**
-- First release of Allagan Market, a plugin for tracking your active retainer sales, history and helping you track when you've been undercut.
-- The plugin is still a bit rough around the edges but the following features are available:
-  - Sale/History tracking
-  - Grid/list modes for sale/history
-  - A sale summary screen
-  - DTR bar integration
-  - An overlay to help you update your active sales
-  - Exports for sales/history/summary
-  - Integration with universalis
-  - Chat notifications when you get undercut
-- Please post issues on the github if you can replicate otherwise there will be a post in the #plugin-help-forum section
+**Fixes:**
+- Collapsing and expanding worlds in the main interface should work now
+- The retainers shown in the overlay will now only show ones owned by the currently logged in character
+
 """


### PR DESCRIPTION
**Fixes:**
- Collapsing and expanding worlds in the main interface should work now
- The retainers shown in the overlay will now only show ones owned by the currently logged in character