### PR TITLE
ChatTwo 1.29.2

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "0ea648ad6d61a1835e843734cd3b4b6b3ec7fc25"
+commit = "df503bf4f111121887fcc74255cdf123dcb697ca"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Allow tab key for cycling in auto-complete [thanks aemsle]
- Potential fix for emotes not working under iOS (safari) [thanks Ennea]