### PR TITLE
[Testing] Malmstone Calculator v1.0.6.5

### DIFF
--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "2904048bcff8a2ecb8e8770f379fc52bb9297281"
+commit = "40ec0e9400dcfd7400daa62b4ef765352b233d3a"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """

--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,11 +1,11 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "98b1736f9f578f4d66698de321ae7cc85a534ce3"
+commit = "2904048bcff8a2ecb8e8770f379fc52bb9297281"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """
-- Added option to automatically stop showing toast/chat notifications after reaching a series level
-- Added preliminary Frontline losing streak bonus tracking
-- Added tooltips with Series EXP values for each game mode
+Bug Fixes:
+- Fix an issue where initial Frontline stats is cached before player is loaded
+- Fix UI bug where toggling Frontline bonus off and on doesn't mark data as potentially outdated
 """
 

--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "40ec0e9400dcfd7400daa62b4ef765352b233d3a"
+commit = "8fdfb016aa8045849a87a17b42ecd6675c7fe025"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """

--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,11 +1,12 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "8fdfb016aa8045849a87a17b42ecd6675c7fe025"
+commit = "8dd8dc166e98a50d35918a2715808b39208aa6d7"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """
 Bug Fixes:
 - Fix an issue where initial Frontline stats is cached before player is loaded
 - Fix UI bug where toggling Frontline bonus off and on doesn't mark data as potentially outdated
+- Fix initial PVP profile data loading to handle alts
 """
 


### PR DESCRIPTION
Bug Fixes:
- Fix an issue where initial Frontline stats is cached before player is loaded
- Fix UI bug where toggling Frontline bonus off and on doesn't mark data as potentially outdated