### PR TITLE
Simple Tweaks 1.10.1.1

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "f61d6e9ce15b69dd3ceddd292cdb0999be7fb6a4"
+commit = "49d7635fe94e0a4fcb8a65bbd77cc0fdfac547e8"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "49d7635fe94e0a4fcb8a65bbd77cc0fdfac547e8"
+commit = "217d02c3f6e3d4fbf36c5170d1cba972bb0bb334"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "217d02c3f6e3d4fbf36c5170d1cba972bb0bb334"
+commit = "59d9434e52b2e9c4334261d47f1f1322c7ee8c5f"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
nofranz

fixes potential memory corruption on disabling `Rename Chat Tabs`