### PR TITLE
[Testing] Allagan Market 1.0.0.3

### DIFF
--- a/testing/live/AllaganMarket/manifest.toml
+++ b/testing/live/AllaganMarket/manifest.toml
@@ -1,25 +1,21 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/AllaganMarket.git"
-commit = "040b67822cb5c7af7adefb2d48bde72b7bde2dc7"
+commit = "8e7a449599edb0e2cd01901d23bbcb8decf24b3a"
 owners = [
     "Critical-Impact",
 ]
 project_path = "AllaganMarket"
-version = "1.0.0.2"
+version = "1.0.0.3"
 changelog = """\
 **New Features**
-- The latest market prices are cached so that undercuts can be calculated on the fly even if you change settings
-- Undercut/undercut on login/sale notifications can be disabled/enabled and have their chat type configured
-- Undercut messages can be configured to be grouped
-- The undercut recommended price can be configured
-- The NQ/HQ comparison used when determining if an item has been undercut can be configured on a global/item level
-- Added a /amarket alias(PR from TheOddball)
+- The retainer list and retainer sale list can now be highlighted, there is a toggle on the overlay and in the settings making it easier to see at a glance which items have stale pricing or are undercut.
+- Added a icon column for the sales/sold lists
 
 **Fixes**
-- The UI should eat less FPS
-- Column sorting in the list view is fixed
-- Added some additional checks in case the sale items CSV gets into a bad state
-- Fixed an exception related to the marketboard item request hook
-- "Item Update" renamed to "Stale Pricing" to hopefully make it clearer
-- Hopefully fixed the scaling issues on the overlay windows
+- Numeric columns will now sort properly
+- Retainers without classes will show a more appropriate icon
+- The recommended price should factor in the undercut amount
+- The sale/sold menus in both grid/list views should now be identical
+
+Barring any major bugs, this is the last release before this gets moved out of testing.
 """


### PR DESCRIPTION
**New Features**
- The retainer list and retainer sale list can now be highlighted, there is a toggle on the overlay and in the settings making it easier to see at a glance which items have stale pricing or are undercut.
- Added a icon column for the sales/sold lists

**Fixes**
- Numeric columns will now sort properly
- Retainers without classes will show a more appropriate icon
- The recommended price should factor in the undercut amount
- The sale/sold menus in both grid/list views should now be identical

Barring any major bugs, this is the last release before this gets moved out of testing.