### PR TITLE
[Testing] Allagan Market 1.0.0.4

### DIFF
--- a/testing/live/AllaganMarket/manifest.toml
+++ b/testing/live/AllaganMarket/manifest.toml
@@ -1,21 +1,14 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/AllaganMarket.git"
-commit = "8e7a449599edb0e2cd01901d23bbcb8decf24b3a"
+commit = "a59c7e69902373425f2c7c3b3652390760adcbcc"
 owners = [
     "Critical-Impact",
 ]
 project_path = "AllaganMarket"
-version = "1.0.0.3"
+version = "1.0.0.4"
 changelog = """\
-**New Features**
-- The retainer list and retainer sale list can now be highlighted, there is a toggle on the overlay and in the settings making it easier to see at a glance which items have stale pricing or are undercut.
-- Added a icon column for the sales/sold lists
-
 **Fixes**
-- Numeric columns will now sort properly
-- Retainers without classes will show a more appropriate icon
-- The recommended price should factor in the undercut amount
-- The sale/sold menus in both grid/list views should now be identical
-
-Barring any major bugs, this is the last release before this gets moved out of testing.
+- Retainer ordering will be tracked properly which will fix any highlighting related issues
+- Viewing the current offerings for an item will mark it as updated at that point and clear any highlighting on that line
+- The undercut logic should now consider your own items undercut until you've got them at the correct price
 """


### PR DESCRIPTION
**Fixes**
- Retainer ordering will be tracked properly which will fix any highlighting related issues
- Viewing the current offerings for an item will mark it as updated at that point and clear any highlighting on that line
- The undercut logic should now consider your own items undercut until you've got them at the correct price