### PR TITLE
[Testing] Title Edit v3.0.1.0

### DIFF
--- a/testing/live/TitleEdit/manifest.toml
+++ b/testing/live/TitleEdit/manifest.toml
@@ -1,18 +1,14 @@
 [plugin]
 repository = "https://github.com/RokasKil/TitleEdit.git"
-commit = "47c3c68f7e1dd86b3ef0bfc2d9b48d452af3826d"
+commit = "bdf267711bb7cfc0cd37915f208d5d49adfa43d0"
 owners = [
     "RokasKil",
 ]
 project_path = "TitleEdit"
 changelog = """
-- Completely rewritten the plugin
-- Added Character Select support with the ability give your character a mount
-- Added in game preset editing and live preview
-- Hopefully fixed the preset not loading on start up issues
-- Added experimental support for world layout saving
-- Added festival saving support
-- Added the ability to recolor title screen UI
-- Added the ability to roll the camera in title screen
-- Added the ability to save multiple groups of presets to cycle through randomly
+- Fixed saving and loading scenes with sub levels (The Empty, Elysion and others)
+- When switching between characters within the same group the scene will no longer reload
+- Character select camera curve will act the same as vanilla
+- Added an option to change the default preset author name
+- Updated the about section
 """


### PR DESCRIPTION
- Fixed saving and loading scenes with sub levels (The Empty, Elysion and others)
- When switching between characters within the same group the scene will no longer reload
- Character select camera curve will act the same as vanilla
- Added an option to change the default preset author name
- Updated the about section