### PR TITLE
[Testing] DragoonMayCry v0.12.0.2

### DIFF
--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,10 +1,19 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "8f517002fe4ef5e65b6bb892192bd606d980479d"
+commit = "02b60559f5d8b1e19d4ce083175d344f8a16e18e"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
 changelog = '''
-v0.7.5
+- Added announcers and dynamic background music selectable on a job per job basis
+- Announcers :
+    - Default DmC5 (new default)
+    - DmC5 Balrog VA / Michael Schwalbe
+    - Nico
+    - Morisson
+- Dynamic BGM (experimental, only inside instances, will mute game's BGM)
+    - Bury the Light
+    - Devil Trigger
+    - Crimson Cloud
+- Changed some values, it shouls take longer to reach S, but it should be easier to maintain
 - Bugfixes
-- Reworked the configuration ui
 '''

--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "ed593a476ba509edc3a23765db6d266d0b4ef015"
+commit = "af98698f5de0a2448ddbdd764072af25da4a18f0"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
 changelog = '''

--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "02b60559f5d8b1e19d4ce083175d344f8a16e18e"
+commit = "1bfd94d44f0103c7c72f66c5ce1ad5af9b11585f"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
 changelog = '''

--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "1bfd94d44f0103c7c72f66c5ce1ad5af9b11585f"
+commit = "ed593a476ba509edc3a23765db6d266d0b4ef015"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
 changelog = '''


### PR DESCRIPTION
- Sound files are now downloaded separately from https://github.com/Felscream/DragoonMayCry/releases/tag/v0.12.0.0 instead of being bundled directly with the plugin.
- Files are extracted into the DragoonMayCry's pluginConfigs directory.
- Each time the plugin is loaded, it will do a file integrity check on the additional assets.
- If the integrity check fails, the user is notified, existing assets are deleted  and new ones are downloaded from the link above.
- Added more sound effects and dynamic background music selectable on a job-per-job basis.
- Dynamic background music is opt-in, and only playable inside non PvP instances. 
- If the user configured a job to use dynamic background music, it will mute the game's BGM when they enter an instance with that job.
- The game BGM state is restored when they leave the instance, or choose a job inside the instance which doesn't have dynamic music enabled.
- Dynamic BGM files are cached in memory when the user enters an instance. They are cleared only when the plugin is disabled.
- Lots of duplicated code in the FSM namespace