### PR TITLE
[Testing] DragoonMayCry v0.12.0.3

### DIFF
--- a/testing/live/DragoonMayCry/manifest.toml
+++ b/testing/live/DragoonMayCry/manifest.toml
@@ -1,19 +1,8 @@
 [plugin]
 repository = "https://github.com/Felscream/DragoonMayCry.git"
-commit = "af98698f5de0a2448ddbdd764072af25da4a18f0"
+commit = "b8550dc82ecf361ac5d5d714a6a2acfe32dcba0f"
 owners = ["Felscream"]
 project_path = "DragoonMayCry"
 changelog = '''
-- Added announcers and dynamic background music selectable on a job per job basis
-- Announcers :
-    - Default DmC5 (new default)
-    - DmC5 Balrog VA / Michael Schwalbe
-    - Nico
-    - Morisson
-- Dynamic BGM (experimental, only inside instances, will mute game's BGM)
-    - Bury the Light
-    - Devil Trigger
-    - Crimson Cloud
-- Changed some values, it shouls take longer to reach S, but it should be easier to maintain
-- Bugfixes
+- Bugfix : the plugin wouldn't initialize on some windows configuration
 '''


### PR DESCRIPTION
- The audio components wouldn't initialize on some windows configurations (only 1 case reported on windows 11). I had to send them a build to test the fix on their setup. Tested the fix on Linux and it still works fine. 
- Changed some wording on the configuration window