### PR TITLE
Pet Nicknames v2.2.0.4

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,11 +1,10 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "69c46fae34f81a5fa561a71f78f9baeea752f5ea"
+commit = "9fb2cde217a6ff3900010b4c7c928c6f31a96cf3"
 owners = ["Glyceri"]
 	changelog = """
-    [2.2.0.3]
-    Fixed an issue where the Petlist incorrectly thought the selected user was the local user.
-    Fixed an issue where users wouldn't transform into IPC users upon receiving IPC data (this clears manual shares unless synced, this is intentional from now on).
-    Fixed an issue where users with zero pets would show up in the Petlist. This was impossible to occur before, since the implementation of sync this occurs when someone has zero pets.
-    Added a subtle outline on input fields that are empty.
+    [2.2.0.4]
+    Empty data will get send over IPC a lot less. (This shouldn't happen actually, I just haven't found the underlying issue yet.)
+    Made the rename window's minimum width slightly smaller so people won't hamstring themselves into not seeing the input field.
+    Added a couple tags so people will find the plugin via very specific search querries easier.
 """


### PR DESCRIPTION
- Empty data will get send over IPC a lot less. (This shouldn't happen actually, I just haven't found the underlying issue yet.)
- Made the rename window's minimum width slightly smaller so people won't hamstring themselves into not seeing the input field.
- Added a couple tags so people will find the plugin via very specific search querries easier.