### PR TITLE
[Testing] Malmstone Calculator 1.0.7.0

### DIFF
--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "644a57b60b48621bebbfc4c519027416d3f2fdae"
+commit = "4f014747e772eed082e7904c7e6d78c5ef8ec6e1"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """
@@ -8,5 +8,6 @@ Features:
 - Tracks Series Level above 30, even if you claim the "Extra Level" rewards
 - Option to modify PVP Profile and Series Malmstone GUI to show Series Levels above 30
 - Organize Configuration into tabs
+- Add a warning message about not gaining Series EXP for the people who somehow reach 100 unclaimed extra level rewards (infinite levels above Level 30)
 """
 

--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -7,6 +7,6 @@ changelog = """
 Features:
 - Tracks Series Level above 30, even if you claim the "Extra Level" rewards
 - Option to modify PVP Profile and Series Malmstone GUI to show Series Levels above 30
-- Organize Configuation into tabs
+- Organize Configuration into tabs
 """
 

--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,12 +1,12 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "8dd8dc166e98a50d35918a2715808b39208aa6d7"
+commit = "880e621b92574f79c2db16a73eb18b6a01249936"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """
-Bug Fixes:
-- Fix an issue where initial Frontline stats is cached before player is loaded
-- Fix UI bug where toggling Frontline bonus off and on doesn't mark data as potentially outdated
-- Fix initial PVP profile data loading to handle alts
+Features:
+- Tracks Series Level above 30, even if you claim the "Extra Level" rewards
+- Option to modify PVP Profile and Series Malmstone GUI to show Series Levels above 30
+- Organize Configuation into tabs
 """
 

--- a/testing/live/Malmstone/manifest.toml
+++ b/testing/live/Malmstone/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/pinapelz/ffxiv-malmstone.git"
-commit = "880e621b92574f79c2db16a73eb18b6a01249936"
+commit = "644a57b60b48621bebbfc4c519027416d3f2fdae"
 owners = ["pinapelz"]
 project_path = "Malmstone"
 changelog = """


### PR DESCRIPTION
- Tracks Series Level above 30, even if you claim the "Extra Level" rewards
- Option to modify native PVP Profile and Series Malmstone GUI to show Series Levels above 30
- Organize Configuration into tabs
-  Add a warning message about not gaining Series EXP for the people who somehow reach 100 unclaimed extra level rewards (infinite levels above Level 30)