### PR TITLE
Tracky 1.5.4.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "fe78950241949b49a0037e0aec08c55f56d44a5e"
+commit = "b2a3070e574855923703f00fdb6882420499891f"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Prevent crash to desktop if your history has too much data
  - History is now limited to 1 month 