### PR TITLE
[testing] PvP Tracker v.2.1.7.0

### DIFF
--- a/testing/live/PvpStats/manifest.toml
+++ b/testing/live/PvpStats/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "d7bef219e06d89c6a8a4eb8b7820cf89d7d7083d"
+commit = "8eb02b5fe8a946321dffc9057fd963a377323bce"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Updated for version 7.0 and Dalamud apiX.
-* Rival Wings matches temporarily disabled.
+* Reworked tracker window refresh to load each tab asynchronously and to perform incremental refreshes.
+* Re-scaled stat color values for Crystalline Conflict.
+* Added KDA to Crystalline Conflict summary.
 """

--- a/testing/live/PvpStats/manifest.toml
+++ b/testing/live/PvpStats/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "8eb02b5fe8a946321dffc9057fd963a377323bce"
+commit = "8390edc91db59501d0d782ee5fd9e910420b5320"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
 * Reworked tracker window refresh to load each tab asynchronously and to perform incremental refreshes.
 * Re-scaled stat color values for Crystalline Conflict.
 * Added KDA to Crystalline Conflict summary.
+* Fixed team status not working for the FL/RW player filter.
 """


### PR DESCRIPTION
* Reworked tracker window refresh to load each tab asynchronously and to perform incremental refreshes. This should improve performance tremendously.
* Re-scaled stat color values for Crystalline Conflict.
* Added KDA to Crystalline Conflict summary.
* Fixed team status not working for the player filter for Frontline/Rival Wings.

Pretty much all of the changes are ImGui related. Nothing that interacts with the game should be different.