### PR TITLE
Title Edit v3.0.1.2

### DIFF
--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,10 +1,22 @@
 [plugin]
-repository = "https://github.com/RokasKil/TitleEditPlugin.git"
-commit = "80d759a3f994dd6a01fbc955c4ec791aa456aaaa"
+repository = "https://github.com/RokasKil/TitleEdit.git"
+commit = "a18a433c4c6fcef114a6cd58cad25302e8d688cb"
 owners = [
     "RokasKil",
 ]
 project_path = "TitleEdit"
 changelog = """
-- Fixed new bundled presets not actually being bundled
+Moved Title Edit V3 from testing to stable branch
+- Completely rewritten the plugin
+- Added Character Select support with the ability give your character a mount
+- Added in game preset editing and live preview
+- Fixed the preset not loading on start up issues
+- Fixed saving and loading presets with sub levels (The Empty, Elysion and others)
+- Added experimental support for world layout saving
+- Added festival saving support
+- Added the ability to recolor title screen UI
+- Added the ability to roll the camera in title screen
+- Added the ability to save multiple groups of presets to cycle through randomly
+- Added an option to hide your name in character select to ease preset sharing
+- Added character select presets by Thorian, Kamgigari and bot_
 """

--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/RokasKil/TitleEdit.git"
-commit = "a18a433c4c6fcef114a6cd58cad25302e8d688cb"
+commit = "5b3e3609ddb86e76eb1c9f794125bb9296b56dcb"
 owners = [
     "RokasKil",
 ]


### PR DESCRIPTION
Moving to stable, changelog since last testing version:
- Fixed the "Live edit" button tooltip not showing up correctly
- Added character select presets by Thorian, Kamgigari and bot_

Full changelog:
- Completely rewritten the plugin
- Added Character Select support with the ability give your character a mount
- Added in game preset editing and live preview
- Fixed the preset not loading on start up issues
- Fixed saving and loading presets with sub levels (The Empty, Elysion and others)
- Added experimental support for world layout saving
- Added festival saving support
- Added the ability to recolor title screen UI
- Added the ability to roll the camera in title screen
- Added the ability to save multiple groups of presets to cycle through randomly
- Added an option to hide your name in character select to ease preset sharing
- Added character select presets by Thorian, Kamgigari and bot_