### PR TITLE
TitleEdit v3.0.2.0

### DIFF
--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,22 +1,13 @@
 [plugin]
 repository = "https://github.com/RokasKil/TitleEdit.git"
-commit = "5b3e3609ddb86e76eb1c9f794125bb9296b56dcb"
+commit = "2964fad591c1e2f341a8b58f59b890ebc88ef554"
 owners = [
     "RokasKil",
 ]
 project_path = "TitleEdit"
 changelog = """
-Moved Title Edit V3 from testing to stable branch
-- Completely rewritten the plugin
-- Added Character Select support with the ability give your character a mount
-- Added in game preset editing and live preview
-- Fixed the preset not loading on start up issues
-- Fixed saving and loading presets with sub levels (The Empty, Elysion and others)
-- Added experimental support for world layout saving
-- Added festival saving support
-- Added the ability to recolor title screen UI
-- Added the ability to roll the camera in title screen
-- Added the ability to save multiple groups of presets to cycle through randomly
-- Added an option to hide your name in character select to ease preset sharing
-- Added character select presets by Thorian, Kamgigari and bot_
+- Fixed UI overrides not working with vanilla title screens
+- Fixed crashes when used in a client without all the expansions
+- Added an option to select what title screen movie should play
+- Remember the last used directory when exporting or importing a preset to a file
 """


### PR DESCRIPTION
- Fixed UI overrides not working with vanilla title screens
- Fixed crashes when used in a client without all the expansions
- Added an option to select what title screen movie should play
- Remember the last used directory when exporting or importing a preset to a file