### PR TITLE
SubmarineTracker 1.9.2.7

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "7c15f2db6a73b00ccc2cf69ae19dfa2ec2ad8617"
+commit = "8d31e256e7e1b71edb11f98b344398a602c0dc1a"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Implement FC hiding
  - Affects all windows, only exception is /sloot
  - No notification for hidden FCs
  - New FC selection option for /sloot
- ImRaii all overlays and /shelpy
- Update loot overview with newest data