### PR TITLE
Snooper 1.4.0.0

### DIFF
--- a/stable/Snooper/manifest.toml
+++ b/stable/Snooper/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://codeberg.org/Linneris/dalamud-snooper.git"
-commit = "d79d13d33e3d6babe23ad53afdc65138dca70a48"
+commit = "b6796cae28a23668e10ed3040d55da5a90828bbe"
 owners = ["Maia-Everett"]
 project_path = "Snooper"
-version = "1.3.0.0"
+version = "1.4.0.0"
 changelog = """
-* Chat messages loaded from log files (rather than sent in the current game session) are now dimmed out.
-* Fixed a bug where failing to open log files for writing prevented Snooper from functioning properly.
+* Log messages now display dates (not just times) when the date is different from today, so that old messages loaded from log files will have more context to them.
+* Fixed a bug where log windows didn't auto-scroll to the very end.
 """


### PR DESCRIPTION
* Log messages now display dates (not just times) when the date is different from today, so that old messages loaded from log files will have more context to them.
* Fixed a bug where log windows didn't auto-scroll to the very end.
