### PR TITLE
Update EngageTimer v2.4.1.0

### DIFF
--- a/stable/EngageTimer/manifest.toml
+++ b/stable/EngageTimer/manifest.toml
@@ -1,11 +1,8 @@
 [plugin]
 repository = "https://github.com/xorus/EngageTimer.git"
-commit = "8173ff5416dfb86326548c5833b54a4ba994020b"
+commit = "870a38f916b3c02918460c48d88185e088fb85f6"
 owners = ["xorus"]
 changelog = """\
-- DT compatibility
-- Update for API10:
-  - Use new texture loading for countdown
-  - Migrate to the new font system, the floating window contents might be blurry, this will be fixed soon when I can implement font customization instead of always using the default dalamud one
-- Fix countdown being rounded instead of floored in floating window when disabling decimals
+- Option to hide the stopwatch/floating window in cutscenes
+- Enabling light effect animation would show an error texture and required a plugin restart to be loaded properly 
 """


### PR DESCRIPTION
- Option to hide the stopwatch/floating window in cutscenes
- Enabling light effect animation would show an error texture and required a plugin restart to be loaded properly