### PR TITLE
Umbra 2.2.40

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,19 +1,21 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "61f44f86434fbd2fb899c64ba576f7781c4a9938"
+commit = "1bdb912904171db5f507b8187924e72862667077"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.2.39
+# Umbra 2.2.40
+
+## New Additions
+
+- Added an option to change the display mode of the experience bar in the Gearset Switcher widget: "Never", "Hide When Full" and "Always". (By [alexpado](https://github.com/alexpado))
+- Added an option to override the color of the experience bar in the Gearset Switcher widget. (By [alexpado](https://github.com/alexpado))
+- Added an option to the Gearset Switcher that allows you to customize the width of gearset buttons in the popup.
+- Added an option to the Stacked Clocks widget to enable/disable the popup.
+- Added a "Return" action to the Teleport Widget's Miscellaneous menu.
 
 ## Fixes & Improvements
-
-### Gearset Switcher
-- Progressbar now properly scale with the global UI Scale (By [alexpado](https://github.com/alexpado))
-
-### Durability Widget
-- Progressbar now properly scale with the global UI Scale (By [alexpado](https://github.com/alexpado))
-- Better layout for margins in split mode, which allow better scaling, too. (By [alexpado](https://github.com/alexpado))
+- Ensure the experience bar in the Gearset Switcher widget stretches across the full width of the widget. (Related Discord thread: [Gearset Switcher widget - Experience Bar](https://discord.com/channels/1263935915517149298/1292289493830991965)) (By [alexpado](https://github.com/alexpado))
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 2.2.40

## New Additions

- Added an option to change the display mode of the experience bar in the Gearset Switcher widget: "Never", "Hide When Full" and "Always". (By [alexpado](https://github.com/alexpado))
- Added an option to override the color of the experience bar in the Gearset Switcher widget. (By [alexpado](https://github.com/alexpado))
- Added an option to the Gearset Switcher that allows you to customize the width of gearset buttons in the popup.
- Added an option to the Stacked Clocks widget to enable/disable the popup.
- Added a "Return" action to the Teleport Widget's Miscellaneous menu.

## Fixes & Improvements
- Ensure the experience bar in the Gearset Switcher widget stretches across the full width of the widget. (Related Discord thread: [Gearset Switcher widget - Experience Bar](https://discord.com/channels/1263935915517149298/1292289493830991965)) (By [alexpado](https://github.com/alexpado))
