### PR TITLE
Graphics Config 1.0.0.5

### DIFF
--- a/stable/GraphicsConfig/manifest.toml
+++ b/stable/GraphicsConfig/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Aida-Enna/GraphicsConfig.git"
-commit = "9a3b8e4c4288a37b6ca18ae78cb9e89da1b8d887"
+commit = "1ee125d98471a143a080ae41d6a5e632fbd195bb"
 owners = ["Aida-Enna"]
 project_path = ""
-changelog = "- Fixed a bug that caused old presets to change your settings to the lowest res/windowed mode on game load if it was the last preset loaded"
+changelog = "- Move preset directory to PluginConfigs appdata folder to avoid stupid windows permissions stuff and fall in line with how other plugins store things."


### PR DESCRIPTION
- Move preset directory to PluginConfigs appdata folder to avoid stupid windows permissions stuff and fall in line with how other plugins store things.