### PR TITLE
VFXEditor v1.9.1.2

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "2e99a307b07dab71380b9dbe86e36910734041e8"
+commit = "f04ecbe2e4127ac0f902b1841ae82f2cf0aad11a"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- `.avfx` parsing fix
- `.uld` parsing fix
- Fixed wrong paths for SD icons
- `.pdb` work
- New `.tmb` entries
- Reverted some changes to `.png` importing
- NPC `.atch` list
- Fixed rotation for some `.sklb` bones
- Moved some stuff to framework thread
- Refactored `.mtrl` parsing
- Added sphere selector for materials
- Some refactoring for material shaders