### PR TITLE
Dialog Copy 1.2.0.0

### DIFF
--- a/stable/TalkCopy/manifest.toml
+++ b/stable/TalkCopy/manifest.toml
@@ -1,8 +1,11 @@
 [plugin]
 repository = "https://github.com/Glyceri/TalkCopy.git"
-commit = "7d71e04fea01e17122a43d909b71418b4fca8b27"
+commit = "2c87c668c9c3e13a6bca8619a69063dd6540504a"
 owners = ["Glyceri",]
 	changelog = """
-    [1.1.0.3]
-    Updated the logo because I was getting nominations for the old one...
+    [1.2.0.0]
+    Now automatically copies the text of tooltips.
+    Added a Text Copy Mode. This allows you to copy text from ANY text element on the screen. (Default entry is: 'Ctrl' + 'Shift' + 'Space')
+    Text will now properly parse and no longer display '=' from time to time.
+    You can now disable metadata in copied text.
 """


### PR DESCRIPTION
    Now automatically copies the text of tooltips.
    Added a Text Copy Mode. This allows you to copy text from ANY text element on the screen. (Default entry is: 'Ctrl' + 'Shift' + 'Space')
    Text will now properly parse and no longer display the '=' symbol (hopefully).
    You can now disable metadata in copied text.