### PR TITLE
Title Edit v3.0.2.3

### DIFF
--- a/stable/TitleEdit/manifest.toml
+++ b/stable/TitleEdit/manifest.toml
@@ -1,12 +1,11 @@
 [plugin]
 repository = "https://github.com/RokasKil/TitleEdit.git"
-commit = "d9e83314ee4be29e3d35c3732e48ccdb0983d96d"
+commit = "e24a5ce8760a647485b572322b9e6e82a8df2c22"
 owners = [
     "RokasKil",
 ]
 project_path = "TitleEdit"
 changelog = """
-- Fixed camera ignoring the zoom curve on initial load to the character select screen
-- Fixed character select camera position values being transferred to the retainer creation
-- Fixed a typo in the "Aetherial Sea" character select option
+- Fixed Dawntrail title screen music not playing when switching to title screen for chracter select
+- Added an option to not interrupt BGM when switching between screens with the same track (ON by default)
 """


### PR DESCRIPTION
- Fixed Dawntrail title screen music not playing when switching to title screen for chracter select
- Added an option to not interrupt BGM when switching between screens with the same track (ON by default)