### PR TITLE
[Testing] Altoholic v0.0.0.20

### DIFF
--- a/testing/live/Altoholic/manifest.toml
+++ b/testing/live/Altoholic/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "b233d0d12764b4ef0b9466a85170992e55702fb2"
+commit = "215e1af167b225eb060b278e0ee6600b8f947b30"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
-changelog = "Version 0.0.0.19: Add Moogle Treasure Trove event rewards tab, fix retainer market listing"
+changelog = "Version 0.0.0.20: Add unlocked duty backend, current equipped facewear and ornament (not listed yet). Fix details page facewear slot. Add old moogle trove rewards"


### PR DESCRIPTION
Version 0.0.0.20:
* Add unlocked duty back-end.
* Current equipped facewear and ornament (not listed yet). 
* Fix details page facewear slot. 
* Add old moogle trove rewards