### PR TITLE
PvP Tracker v2.1.12.0

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "d0dae497d69e586e2aeeac5caa2ab4bedb9d9d42"
+commit = "25594f4e971decfea9176070422559435d899fe0"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
@@ -11,4 +11,5 @@ changelog = """
 * Added NAND, NOR and partial match logic to the tags filter.
 * Added a function on the Matches to mass set tags.
 * Some refresh performance optimizations.
+* Fixed team filters not working on match details windows.
 """

--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,12 +1,14 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "c2f97a1c781648ad13719ebf836357ddc875ee63"
+commit = "d0dae497d69e586e2aeeac5caa2ab4bedb9d9d42"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Reworked and largely removed most read interlocks, which should improve performance.
-* Limited player tab CSV export to 100 rows at a time for performance reasons.
-* Increased Rival Wings match stats discard grace period from 10s to 40s after the match starts.
-* Fixed Crystalline Conflict KDA color scaling.
-* Fixed Frontline Job tab filter not persisting.
+* Added Frontline Records tab.
+* Improved Crystalline Conflict Records tab refresh performance significantly.
+* Added 'By patch' as a time filter option.
+* Added relational options to the time filter when filtering by ranked season, expansion or patch.
+* Added NAND, NOR and partial match logic to the tags filter.
+* Added a function on the Matches to mass set tags.
+* Some refresh performance optimizations.
 """


### PR DESCRIPTION
* Added Frontline Records tab.
* Improved Crystalline Conflict Records tab refresh performance significantly.
* Added 'By patch' as a time filter option.
* Added relational options to the time filter when filtering by ranked season, expansion or patch.
* Added NAND, NOR and partial match logic to the tags filter.
* Added a function on the Matches to mass set tags.
* Some refresh performance optimizations.