### PR TITLE
SubmarineTracker 1.9.3.5

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "48f5edadb0fad3b65d6cdcc2e04d715d64588668"
+commit = "dbb22eb794093b63d5953238622b540ab4d83acf"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fix incorrect rank being used for leveling tab
- Submarine cache got replaced by a simple calculation, this should prevent cache related errors