### PR TITLE
XIVDeck 0.3.22

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "32cc7112c6dfa48d647c065c77d4a7429c8d1f6a"
+commit = "fb65aaeba12e5027b3785fd609fac48d73771fde"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
I would normally put my usual changelog quip here, but I've burned all of that energy on writing Dalamud status updates. So, uh, enjoy Patch 7.1 compatibility I guess!

- No feature changes or fixes this patch, sorry.

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.22).