### PR TITLE
CrossUp 1.7.0.6 (Stable)

### DIFF
--- a/stable/CrossUp/manifest.toml
+++ b/stable/CrossUp/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/ItsBexy/CrossUp.git"
-commit = "817a5435e7190e333046fb46089eac0c7d3a5daf"
+commit = "52d4f1ef21c4e6da393c300d2c4bb2b63e23a843"
 owners = [
     "ItsBexy",
 ]
 changelog = """
-An issue with loading the plugin appears to have been resolved by a recent Dalamud update. This update reverts a temporary fix that was made in 1.7.0.3.
+- Updated for 7.1
 """


### PR DESCRIPTION
Uhhhh whoops, yeah, so, let's actually put the update in Stable this time