### PR TITLE
Party Icons 1.2.2.0

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/nebel/xivPartyIcons.git"
-commit = "face9eeec2f77bf45d90c509e55d09b7e5d60400"
+commit = "b2efcf0f3884255912dce0ac5d99bc6b45281bcc"
 owners = [
     "shdwp",
     "avafloww",


### PR DESCRIPTION
- Update for 7.1
- Disabled the "replace party numbers with role in Party List" feature for now. This is hopefully only temporary but more work is required to make it work properly in 7.1
- Fixed an issue where nameplates could temporarily be shown in an incorrect state after certain loading screens