### PR TITLE
Wotsit 1.0.5.3

### DIFF
--- a/stable/Dalamud.FindAnything/manifest.toml
+++ b/stable/Dalamud.FindAnything/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/goaaats/Dalamud.FindAnything.git"
-commit = "d946d497535b9716f819fb76be3471fd8c58b04e"
+commit = "17ff25cd36cbf244417f513a722b254fa9ed2870"
 owners = [
     "goaaats",
 ]


### PR DESCRIPTION
- Update for API 11.
- Greatly simplify `DalamudReflector` by using the new `IExposedPlugin` mechanism.
- Exclude leves from `isInCombatDuty` check (so mounts and so on can be used during leves).

Big thanks to nebel for this change.