### PR TITLE
Simple Tweaks 1.10.3.2

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "3102b6f9798b8eafcab2cf94c9d555df10c65634"
+commit = "c5287634658b65cdf23b1233546b033f7cbde3bd"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***Tweak Changes***
- **`Show ID`**
  - Added option to show original action ID alongside resolved.
  - Fixed ID being cut off on items with long category names, like BLM weapons.
  - Fixed ID being incorrect with latest dalamud versions
  