### PR TITLE
Accountant 1.7.0.0

### DIFF
--- a/stable/Accountant/manifest.toml
+++ b/stable/Accountant/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/Accountant.git"
-commit = "239ace1939dded9a9ff10002b6931074c42e86c5"
+commit = "de83d6575a3372be68bdd301c99e86a2bd38f24b"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
-  API11 and 7.1 update
- Changed FC handling slightly
- Changed Plot Tracking slightly, it now happens in the Demolition Tracker 
  - Instead of just naming them, plots can now configured to track their visits. 
  - Aside from the custom name (which should be migrated), plots can set a number of days until they show up in the timer window, and until they show as popup warnings. 
  - To track visits, you need to manually add players that should reset the remaining days.