### PR TITLE
ChatTwo 1.29.6

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "9597218319c59af9c11f0ce4b0c587badbb8c5df"
+commit = "bf27d3e85340bacbd58640f3765f94d5b23a2525"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Implement new channel switch logic
  - Tell Targets are now remembered after switching tabs

7.1 Notes:
- The newly added party number icons aren't supported with customs fonts right now, it will show a =
- Opening quest links from chat won't work for now