### PR TITLE
DelvUI release 2.3.1.0

### DIFF
--- a/stable/DelvUI/manifest.toml
+++ b/stable/DelvUI/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvUI.git"
-commit = "193e55313814e526ca4c8fd94cc6cdc051d3ea6f"
+commit = "0b4c281483c4f5a9b8e2bebefd087f9b1f9eeaa4"
 owners = ["Tischel"]
 project_path = "DelvUI"


### PR DESCRIPTION
- Fixed several issues with the Party Frames and Party Cooldowns.
- Fixed Ready Check Status icon in the Party Frames.
- Removed the Player Order Override setting from Party Frames:
  * This is now possible through the game's systems.
  * In order to simplify the logic, DelvUI's Party Frames will follow the order in the game's party list at all times.