### PR TITLE
Himbeertoni Raid Tool 1.7.0.0

### DIFF
--- a/stable/HimbeertoniRaidTool/manifest.toml
+++ b/stable/HimbeertoniRaidTool/manifest.toml
@@ -2,7 +2,18 @@
 repository = "https://github.com/Koenari/HimbeertoniRaidTool.git"
 owners = [ "Koenari" ]
 project_path = "HimbeertoniRaidTool"
-commit = "2a1d3b991284aa22be42c6cbddfe53210c14b758"
+commit = "bc840b90ecc64409f297c1191e4fcd65b4f0beac"
 changelog = """
-New Feature: Automatically switch character in solo tab to currently logged in one
-    Bugfix: Ignoring lower ilvl gear works again"""
+New Feature: Gearsets can have an alias. If an alias is set it is shown instead of the name in the Ui
+      This is editable even for sets from etro or XivGearApp
+    User Interface: Gearset origin is now shown in selection dropdown
+    General: Updated for 7.1
+    User Interface: New layout for the stats
+    User Interface: Overhauled item tooltips
+    Bugfix: Deleted sets get correctly removed from the gear/bis list
+    BiS: Update gear set buttons now work for XivGearApp (like they did for etro)
+    User Interface: Searching gear from database now actually shows useful information
+    User Interface: New layout for inventory/wallet
+    User Interface: Job selection buttons are bigger to have enough space for level 100 jobs
+Known Issues:
+    Known Issue: Previous wallet and inventory data is lost"""


### PR DESCRIPTION
    New Feature: Gearsets can have an alias. If an alias is set it is shown instead of the name in the Ui
      This is editable even for sets from etro or XivGearApp
    User Interface: Gearset origin is now shown in selection dropdown
    General: Updated for 7.1
    User Interface: New layout for the stats
    User Interface: Overhauled item tooltips
    Bugfix: Deleted sets get correctly removed from the gear/bis list
    BiS: Update gear set buttons now work for XivGearApp (like they did for etro)
    User Interface: Searching gear from database now actually shows useful information
    User Interface: New layout for inventory/wallet
    User Interface: Job selection buttons are bigger to have enough space for level 100 jobs
Known Issues:
    Known Issue: Previous wallet and inventory data is lost