### PR TITLE
SubmarineTracker 1.9.3.7

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "4705306db4194900a6c616d66425617522ebf46f"
+commit = "ffebe82929ee4885cf1e31c3245d53ba07278179"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- New option: show on route and done numbers in server bar entry [Default True]
- New option: remove hidden FCs from numbers [Default True]
- Removed the third number in the /soverlay title, it was never used