### PR TITLE
[Testing] Gauge-O-Matic 0.8.1.1

### DIFF
--- a/testing/live/GaugeOMatic/manifest.toml
+++ b/testing/live/GaugeOMatic/manifest.toml
@@ -1,9 +1,14 @@
 [plugin]
 repository = "https://github.com/itsbexy/gaugeomatic.git"
-commit = "30d86198b2435734b914566c5c51e1e4ced19893"
+commit = "7c8e6f4fba391af523bbf818b72c66472e11a167"
 owners = [
     "ItsBexy",
 ]
 changelog = """
-Implemented a further fix for Bloodletter and other charge action trackers.
+- Updated for 7.1 / api11
+- Corrected Living Muse cooldown length when below level 96
+- The `Oath Sigil` widget now respects the option to hide the wings
+- Updated Chakra Gauge Tracker to account for 10 chakras
+- Fixed SMN's Attunement trackers to show time in seconds instead of in milliseconds
+- Attempted fix for an issue wherein the plugin failed to track highlighted actions with adjusted IDs (for example, Chaotic Spring)
 """


### PR DESCRIPTION
- Updated for 7.1 / api11
- Corrected Living Muse cooldown length when below level 96
- The `Oath Sigil` widget now respects the option to hide the wings
- Updated Chakra Gauge Tracker to account for 10 chakras
- Fixed SMN's Attunement trackers to show time in seconds instead of in milliseconds
- Attempted fix for an issue wherein the plugin failed to track highlighted actions with adjusted IDs (for example, Chaotic Spring)