### PR TITLE
SubmarineTracker 1.9.3.8

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "1f4fa68859e2638193b41a978652fb196a110be2"
+commit = "2368949cda8853b0d3b4d515b58f4f50ab5ee4da"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "ffebe82929ee4885cf1e31c3245d53ba07278179"
+commit = "1f4fa68859e2638193b41a978652fb196a110be2"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Make the numbers option also work without the returning time enabled
  - This will enable the server bar entry for everyone, if you don't want it just disable the option in the settings
- Fix next return time not showing in /soverlay title