### PR TITLE
JustBackup, QuestAway and EnemyListHP updates

### DIFF
--- a/stable/EnmityHp/manifest.toml
+++ b/stable/EnmityHp/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/EnmityHp.git"
 # The commit to check out and build from the repository.
-commit = "ba11f0d8e280437aa2d8390e7bb9b98d1ae79508"
+commit = "2c544ca5dea9c8dd76c74193b43232e0f1450471"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"

--- a/stable/JustBackup/manifest.toml
+++ b/stable/JustBackup/manifest.toml
@@ -5,7 +5,7 @@
 # must be accessible (i.e. no `git` or `ssh` URLs, as the agent cannot clone those)
 repository = "https://github.com/NightmareXIV/JustBackup.git"
 # The commit to check out and build from the repository.
-commit = "fb3ab850d937c190c0ad2d06171c7f6859bdb59a"
+commit = "41ccf22a2fa52421b1344d2b8b0026e56b6396d0"
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
     "Limiana"

--- a/stable/QuestAWAY/manifest.toml
+++ b/stable/QuestAWAY/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/NightmareXIV/QuestAWAY.git"
-commit = "0b88eb9ddcf184bfe4c75f89400e3e27f3ecec67"
+commit = "64933a32a4156cc592122d3ae90b56974849a019"
 owners = [
     "Limiana",
 ]


### PR DESCRIPTION
EnemyListHP:
- Updated for 7.1, no functional changes

QuestAway: 
- Updated for 7.1, no functional changes

JustBackup:
- Updated for 7.1
- Excluded certain know plugins' folders and files that have too large size and no value for backup (logs, caches, etc)
- Lowered file copy thread priority, which reduces lag caused by file copying process