### PR TITLE
DailyDuty v5.2.0.3

### DIFF
--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "c26d92359e5d198380f6b685ea359f232b4bc897"
+commit = "df7298214ec80c0f8b8780140c9904bea2421bc5"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"

--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "f544d493b7864f4ed796d6ff52b6032139b2fbfc"
+commit = "4d04b144aeb3fea37b565a5680b6a0718911e908"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"

--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "4d04b144aeb3fea37b565a5680b6a0718911e908"
+commit = "c26d92359e5d198380f6b685ea359f232b4bc897"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
Remove Teleporter Plugin dependency.
Fix Raids Modules not updating to new duties.
Fix Jumbo Cactpot time calculation.
Fix plugin opening config window on load.