### PR TITLE
Simple Tweaks 1.10.3.4

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "d283412d5e023b29e61a922a206792bff8da8a78"
+commit = "6d18ea780278c339d8a322e287a872f0870f2648"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
Fixes various reported issues
- Fixed `No Sell List` not working from main inventory
- Fixed `Additional Item Info` not displaying info
- Fixed `Colour Duty Roulette Names` not working
- Fixed `Scenario Progression Display` showing wildly incorrect values

Added ability to disable tweaks until a specific FFXIVClientStructs version is loaded by dalamud.
- Disabled `Improved Crafting Log` until updated.