### PR TITLE
DelvCD release 1.2.0.1

### DIFF
--- a/stable/DelvCD/manifest.toml
+++ b/stable/DelvCD/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/DelvUI/DelvCD.git"
-commit = "e1fed44f4cddf1ccca492ae484a6e072caca96d4"
+commit = "ee4e96ebbfa5bc0cea6a983a41409c185e787391"
 owners = ["Tischel"]
 project_path = "DelvCD"


### PR DESCRIPTION
- Added keybind label tag for Actions and Items.
- Fixed Dark Knight's Darkside duration.
- Fixed issues with invalid icon identifiers:
  * A lot of the game's icons game files where moved around in 7.1.
  * If you have auras that are not showing, you might need to manually re-enter the Action/Status names/ids so DelvCD can find the right icons again.