### PR TITLE
ChatTwo 1.29.8

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "a648bcf60df7f1d79adc7545d88288ff6c6c0672"
+commit = "cb7df12005e3ccf1a6c16be0aa624520e952d462"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Potential fix for temp channel issues
  - If you notice temp channels behaving wrong, please report it in the discord thread