### PR TITLE
QuestTracker v1.1.0.0 

### DIFF
--- a/stable/QuestTracker/manifest.toml
+++ b/stable/QuestTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/isaiahcat/QuestTracker.git"
-commit = "dc09a186dee77431476f13b65895aa15579b3a26"
+commit = "e7bfa7fc0f2125389a70b1761fe2a72c751e501d"
 owners = ["isaiahcat"]
 project_path = "QuestTracker"
-changelog = "Update seasonal quests"
+changelog = "Support for Dalamud 11.0.0 and 7.1"

--- a/testing/live/QuestTracker/manifest.toml
+++ b/testing/live/QuestTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/isaiahcat/QuestTracker.git"
-commit = "dc09a186dee77431476f13b65895aa15579b3a26"
+commit = "e7bfa7fc0f2125389a70b1761fe2a72c751e501d"
 owners = ["isaiahcat"]
 project_path = "QuestTracker"
-changelog = "Update seasonal quests"
+changelog = "Support for Dalamud 11.0.0 and 7.1"


### PR DESCRIPTION
Support for 7.1
Updated to Dalamud 11.0.0
Updated to Lumina 5
Updated plugin version
Fixed bug [Quest Tracker gets confused by two “On Track” quests](https://github.com/isaiahcat/QuestTracker/issues/2)