### PR TITLE
ChatTwo 1.29.9

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "56eff572b7f658eb0a16df84a7cdc201e96577ad"
+commit = "1a1995759a955d0d0298bd879b11fbb3c36fa44c"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Handle NBSP payloads
  - Only affects french speaking people with weird windows settings 
- Use ingame version of axis font
  - This affects the new party number symbols
  - And it won't work for the webpage version