### PR TITLE
[Testing] ItemUse 1.0.0.1

### DIFF
--- a/testing/live/ItemUse/manifest.toml
+++ b/testing/live/ItemUse/manifest.toml
@@ -1,12 +1,11 @@
 [plugin]
 repository = "https://github.com/PunishedPineapple/ItemUse.git"
-commit = "555f3e8c478b0bdfc1bf9eb285446a6456d5a551"
+commit = "c5d12cd8e1533e531ae37de1f0521aa7011e473e"
 owners = [
     "PunishedPineapple",
 ]
 project_path = "ItemUse"
 changelog = '''
-- Icons for coffer jobs have been moved into the item description.
-- Added optional highlighting of the text "Crafting Material" and "[Suitable for display in aquariums tier X and higher.]" in item descriptions.
-- The player's grand company is now determined automatically when displaying the GC icon.
+- Updated for Dalamud API 11.
+- Supporting code cleanup.
 '''


### PR DESCRIPTION
- Updated for Dalamud API 11.
- Supporting code cleanup.
- Known Issue: If Allagan Tools is installed and set to append anything to the item description, job icons for coffers will sometimes display after Allagan Tools' text instead of before.

Please report any other issues to this plugin's Github repo.