### PR TITLE
Update PlayerTags to v1.12.1

### DIFF
--- a/stable/PlayerTags/manifest.toml
+++ b/stable/PlayerTags/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://git.pilzinsel64.de/pilzinsel64/playertags.git"
-commit = "9901f98c5b637b50358fd161df3fb4b72dc54c85"
+commit = "098d77bcc27d943dac181d65dace8354061208a4"
 owners = [
     "Pilzinsel64",
 ]


### PR DESCRIPTION
Minor fix for Pilz.Dalamud's ActivityContextManager that I missed for some reason.