### PR TITLE
Waitingway 2.2.2

### DIFF
--- a/stable/Waitingway.Dalamud/manifest.toml
+++ b/stable/Waitingway.Dalamud/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Waitingway.git"
-commit = "35f6c835d041b790e6a90276ce912c692836355a"
+commit = "6697dd6c3509915ce22880cd55ddeb0d72bb1e7b"
 owners = ["WorkingRobot"]
 project_path = "Waitingway"


### PR DESCRIPTION
- Fixes crashing when clicking the "World" tab in the Character Selection screen.
- Redesigned the UI layout of the "World" tab to keep up with 7.1 changes.
- Fixed bug where the Waitingway settings button turned into a different icon.