### PR TITLE
TitleRoulette 4.2

### DIFF
--- a/stable/TitleRoulette/manifest.toml
+++ b/stable/TitleRoulette/manifest.toml
@@ -1,4 +1,4 @@
 [plugin]
 repository = "https://github.com/mabako/TitleRoulette.git"
-commit = "9eaa4e6fab96736639c1e307506ec8622125c545"
+commit = "efd2ff74b1129e4f415fd13934492c69e2c8a390"
 owners = ["carvelli", "mabako"]


### PR DESCRIPTION
- Added an option to switch between your preferred group when using /ptitle without any arguments (it no longer needs to be called 'default')
- Use TitleController instead of signatures
- Includes updates for API 11 compatibility