### PR TITLE
Mappy v3.1.0.4

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "8e584e59eb763ab29b57f16a96cff6d2afc11a48"
+commit = "0669b853331dd7cc69002356d1708228608a3801"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Rename Map Selection Window, to actually say Map Selection Window.
Add double-click to confirm to selection windows, double clicking an entry in the Map Selection Window (within 500ms) will auto-confirm the selection and take the map there, no more need to click "Confirm"