### PR TITLE
Adopting Dalamud.FullscreenCutscenes and Dalamud.LoadingImage

### DIFF
--- a/stable/Dalamud.FullscreenCutscenes/Dalamud.FullscreenCutscenes.toml
+++ b/stable/Dalamud.FullscreenCutscenes/Dalamud.FullscreenCutscenes.toml
@@ -1,7 +1,7 @@
 [plugin]
-repository = "https://github.com/goaaats/Dalamud.FullscreenCutscenes.git"
-commit = "0cf8c7ed36e5c061dc64cce74b8894847e99fdd8"
+repository = "https://github.com/MapleHinata/Dalamud.FullscreenCutscenes.git"
+commit = "0913753c7874210f62f1ad9e37635887901bc4bd"
 owners = [
-    "goaaats",
+    "MapleHinata",
 ]
 project_path = "Dalamud.FullscreenCutscenes"

--- a/stable/Dalamud.LoadingImage/manifest.toml
+++ b/stable/Dalamud.LoadingImage/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
-repository = "https://github.com/goaaats/Dalamud.LoadingImage.git"
-commit = "fd25d8c5cbd7c48b88dfba80916bcfe761629f36"
+repository = "https://github.com/MapleHinata/Dalamud.LoadingImage.git"
+commit = "3c89f036177f0d364e6d141ae6b1948132a7cfc0"
 owners = [
-    "goaaats",
+    "MapleHinata",
 ]
 project_path = "Dalamud.LoadingImage"


### PR DESCRIPTION
As discussed on Discord, I'm adopting these two plugins. (Thanks goat and Franz!)

Those changes can be seen below, but they are basically just API11 updates (and updates for game changes on the case of LoadingImage)
https://github.com/goaaats/Dalamud.FullscreenCutscenes/compare/main...MapleHinata:Dalamud.FullscreenCutscenes:main
https://github.com/goaaats/Dalamud.LoadingImage/compare/master...MapleHinata:Dalamud.LoadingImage:master