### PR TITLE
Aether Compass 1.6.5.0

### DIFF
--- a/testing/live/AetherCompass/manifest.toml
+++ b/testing/live/AetherCompass/manifest.toml
@@ -1,9 +1,5 @@
 [plugin]
-repository = "https://github.com/yomishino/FFXIVAetherCompass.git"
-commit = "d66f1c86e65e31925dbb51d88598822619d0e19b"
-owners = [ "yomishino" ]
-changelog = """Patch 6.3 Update
-
-- New compass Eureka Elementals for detecting elementals in Eureka (by apetih)
-- Other minor update and bug fixes to Island Sanctuary Compass
-"""
+repository = "https://github.com/Cytraen/AetherCompass.git"
+commit = "96e3b3d4a45c8a3ee0186dd13bcd3f0e06bba8ac"
+owners = [ "Cytraen" ]
+changelog = "Update for 7.1"


### PR DESCRIPTION
nofranz

Last update in official repo was pre-API v9, and nobody's been able to get a hold of the developer since at least April.
Most recent commit is just a boatload of cleanup, [this](https://github.com/Cytraen/AetherCompass/compare/d66f1c86e65e31925dbb51d88598822619d0e19b...0487b4cc0bc2c4d5f1cc663a5383de4699dd6784) is the actual diff.