### PR TITLE
EurekaHelper - Update for API 11 and Update Ownership (v2.0.0.0)

### DIFF
--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,12 +1,9 @@
 [plugin]
-repository = "https://github.com/snorux/EurekaHelper.git"
-commit = "ec64acfb769b2f3bef8fa442b3fde2fb101a0f31"
-owners = ["snorux"]
+repository = "https://github.com/KangasZ/EurekaHelper.git"
+commit = "7f02ad6a780059cbd0a01c90923293bd9274887b"
+owners = ["snorux", "KangasZ"]
 project_path = "EurekaHelper"
 changelog = """
-Elemental Manager
-- Added crowdsourced positions
-
-Misc
-- Updated to API 9
+- Added support for patch 7.1 and API 11
+- Changed owners
 """

--- a/stable/EurekaHelper/manifest.toml
+++ b/stable/EurekaHelper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KangasZ/EurekaHelper.git"
-commit = "7f02ad6a780059cbd0a01c90923293bd9274887b"
+commit = "40560c63f33de41afa9ce49b7cc283a0b82c57a5"
 owners = ["snorux", "KangasZ"]
 project_path = "EurekaHelper"
 changelog = """


### PR DESCRIPTION
Willing to adopt this plugin until Snowy returns. The last update was before Dawntrail launched which was API 9. Infi has contacted the original dev multiple times however the plugin still seems to be abandoned. Per the discussion in [#plugin-dev,](https://discord.com/channels/581875019861328007/653504487352303619/1311465930244493333) this seems to fit the rules for adoption. 

There has been no major changes since the last addition. All updates have been strict API related. Let me know if this should go to the testing branch first.