### PR TITLE
Update Tidy Chat 2.0.10

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "d1e85bb7c64fadf33702a1a1f4f3090f2c924783"
+commit = "79401d1d9282c513c3c753ee295f2229d72c79c3"
 owners = [
     "NadyaNayme",
 ]
 project_path = "TidyChat"
-changelog = "Only log to XLLog when Debug Mode / Dry Run Mode is enabled ; fixes Custom Emotes used by Player"
+changelog = "Disable Tidy Chat for combat-related channels ; fix S Rank Hunts and Experience Gain filters"


### PR DESCRIPTION
Last PR accidentally said 2.0.9 but was really 2.0.8 -- skipping actual 2.0.9 due to that and bumping to 2.0.10. 

Tidy Chat now returns immediately for Battle-related channels to prevent unnecessary filtering. I am not able to investigate until Monday if this is the cause of framerate issues but I have a strong hunch it is the problem for Frontlines & Hunts so am pushing this change now while I can. 