### PR TITLE
Simple Tweaks 1.10.5.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "09ffbddd7a69c3b1dd0847ef0da50dd590859d50"
+commit = "68123392e91339008c2a0d3d596cc3feac5d4100"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "02abb1c3e4a140cbccded03af1e0637c3c5665ff"
+commit = "09ffbddd7a69c3b1dd0847ef0da50dd590859d50"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***General Changes***
- Fixed tweak preview images not loading correctly

***New Tweaks***
- **`Estate Access Command`** - Adds a command to open the estate access configuration for the current estate.


***Tweak Changes***
- **`House Lights Command`** - Fixed tweak not working.

- **`Improved Chat Font Sizes`** - Fixed tweak not working.

- **`Improved Crafting Action Tooltips`** - Fixed results preview not resetting.

- **`Screenshot File Name`** - Added option to use milliseconds in name template.

- **`Timer on Duty Waiting`** - Fixed display of text in french clients.