### PR TITLE
WTSync 0.14.0.0

### DIFF
--- a/stable/WTSync/manifest.toml
+++ b/stable/WTSync/manifest.toml
@@ -1,14 +1,13 @@
 [plugin]
 repository = "https://github.com/KhloeLeclair/WTSync.git"
-commit = "311d125a90085a5cd1142f0ae62b6dbb827b9782"
+commit = "bad99025cde42e0e6ee93eb3ea0353bfc49c8bc0"
 owners = [ 
 	"KhloeLeclair"
 ]
 project_path = ""
 changelog = """
-* Added: Share links. Got a friend who can't or doesn't use plugins? You can now generate a link and they can view WTSync in their browser. For privacy, these links expire after 30 minutes and only show characters' initials.
-* Added: Wondrous Tails statistics. What duties are people doing? Are people finishing their Wondrous Tails? How many stickers do people have? Find out now with our new weekly reports.
+* Added: Ability to open the Duty Finder to a relevant duty when clicking a Wondrous Tails entry directly in the Wondrous Tails UI.
 
-* Added option to opt out from statistics. The data is fully anonymous, but I understand some people aren't cool with that sort of thing so, for those of you who aren't, just opt out and you won't be included.
-* Added links to the WTSync website to its settings window.
+* Fixed: Bug where we would attempt to open the Duty Finder to a roulette while in an instance.
+* Maintenance: Update the various API endpoints to new URLs.
 """


### PR DESCRIPTION
* Added: Ability to open the Duty Finder to a relevant duty when clicking a Wondrous Tails entry directly in the Wondrous Tails UI.

* Fixed: Bug where we would attempt to open the Duty Finder to a roulette while in an instance.
* Maintenance: Update the various API endpoints to new URLs.