### PR TITLE
ChatTranslated 3.3.1.0

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "e110caa573ed55b77cc4ec233f7a4761c59135ab"
+commit = "b925b1e402b0ec0e1e44c46abfdbb68361e2dccd"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
@@ -9,6 +9,7 @@ Integrated OpenAI compatible class to keep things simple.
 Removed RAG since it doesn't seem to help.
 Rotate secret for LLM proxy.
 Actually get active chatlog when getting chat context, instead of always getting the first chat tab.
+Update localization strings.
 """
 [plugin.secrets]
 cfv5 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAwWjD3/KyJImP8dQmxaYopsnRrAzxTTyBXpjy8wD+\nukMwftTv2MvAmtpo4gs6XnvaiOwFbWGronS9JHxu6KX7VkYfqyoLBZNMdo+P\nqkCaSBuI0lgBYA7NBgG1qsc01OP7aWuQCwEsBTgBxUKHu3NXpJUA39789ZdG\nlijhq24gEee+H7e6TALiGvYh++jDhm7W07WnfBbuN8u/LmRlzXr9t+0ASIVv\niamGCfnX\n=iNor\n-----END PGP MESSAGE-----\n"

--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,10 +1,14 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "cc1cbab8afd343b91405a7b395363711efbf3ddf"
+commit = "e110caa573ed55b77cc4ec233f7a4761c59135ab"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
-api11
+Twisted chat cleaning a bit.
+Integrated OpenAI compatible class to keep things simple.
+Removed RAG since it doesn't seem to help.
+Rotate secret for LLM proxy.
+Actually get active chatlog when getting chat context, instead of always getting the first chat tab.
 """
 [plugin.secrets]
-cfv4 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdA6pJhuSH6dczvaYeD63zu9acSslPwCOL07H3Y/I9U\nSXEwniIxuJhNXosTsVRTjAuMsJkf2H7+hqecwkWKmgz+VZZMxjDZbOdbqlgn\n6JGaH5zw0lgBjaBo5SyBVnczrQjwcGcf4m/iPKneI2SBxCZ2o7doT3TsVLZ2\nEW7s+tFBVwq4zPikZwAHya561/n3qPFfch+Hh+GwdLCs3B3+xTUhvMD/J+02\npwAOqraG\n=ytna\n-----END PGP MESSAGE-----\n"
+cfv5 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAwWjD3/KyJImP8dQmxaYopsnRrAzxTTyBXpjy8wD+\nukMwftTv2MvAmtpo4gs6XnvaiOwFbWGronS9JHxu6KX7VkYfqyoLBZNMdo+P\nqkCaSBuI0lgBYA7NBgG1qsc01OP7aWuQCwEsBTgBxUKHu3NXpJUA39789ZdG\nlijhq24gEee+H7e6TALiGvYh++jDhm7W07WnfBbuN8u/LmRlzXr9t+0ASIVv\niamGCfnX\n=iNor\n-----END PGP MESSAGE-----\n"

--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "b925b1e402b0ec0e1e44c46abfdbb68361e2dccd"
+commit = "ce9ea6065ea386a65e8cb835effdd86c8fee1d04"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """


### PR DESCRIPTION
Twisted chat cleaning a bit.
Integrated OpenAI compatible class to keep things simple.
Removed RAG since it doesn't seem to help.
Rotate secret for LLM proxy.
Actually get active chatlog when getting chat context, instead of always getting the first chat tab.