### PR TITLE
SubmarineTracker 1.9.5.0

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "3934a407731b478a4f7d80c511f6b3652362c320"
+commit = "e6ce0ea412b866f5e8129d7d70c76d8136a3ff02"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fix bug in Leveling that prevented SSSS from being valid
  - This should fix issues with never ending Leveling loops
- Update loot list with newest data