### PR TITLE
[Testing] Gauge-O-Matic 0.8.1.4

### DIFF
--- a/testing/live/GaugeOMatic/manifest.toml
+++ b/testing/live/GaugeOMatic/manifest.toml
@@ -1,13 +1,13 @@
 [plugin]
 repository = "https://github.com/itsbexy/gaugeomatic.git"
-commit = "ae4c3659afadb3552fb32f6257c2b4b20d934bfc"
+commit = "7509ffce1dfd4ef9e4a812a48f1ce0af587a432e"
 owners = [
     "ItsBexy",
 ]
 changelog = """
-## TRACKERS
-- Added multiple song trackers for BRD. These can be used to track song time remaining, stacks of Repertoire, and/or Minstrel's Coda status.
+## WIDGETS
+- Added an Icon option to bar & timer widgets. You can now display the icon for an action or status effect next to its widget. (Also works dynamically with castbar widgets!)
+- Added the missing "Behavior" tab to more widgets. Whoops!
 
-## MISC
-- Added the missing `Behavior` tab to the `Simple Timer` widget.
+Currently only bar & timer widgets have sound and icon options, but these settings will be added to other widget types in the (hopefully near) future.
 """


### PR DESCRIPTION
## WIDGETS
- Added an Icon option to bar & timer widgets. You can now display the icon for an action or status effect next to its widget. (Also works dynamically with castbar widgets!)
- Added the missing "Behavior" tab to more widgets. Whoops!

Currently only bar & timer widgets have sound and icon options, but these settings will be added to other widget types in the (hopefully near) future.