### PR TITLE
Who's Talking 0.8.2.0

### DIFF
--- a/stable/WhosTalking/manifest.toml
+++ b/stable/WhosTalking/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/sersorrel/WhosTalking.git"
-commit = "ae6bfc5b9c7776b09abb2a51e16e755f9025608f"
+commit = "fc3ff36fe2430efa410a3948101d6bd20767e579"
 owners = ["sersorrel"]
 project_path = "WhosTalking"
 changelog = """\
-**Version 0.8.1.0**
+**Version 0.8.2.0**
 
-Updated for patch 7.1.
+Fixed a bug where Discord users would be displayed on top of your chocobo if you didn't have a pet summoned.
 """

--- a/testing/live/WhosTalking/manifest.toml
+++ b/testing/live/WhosTalking/manifest.toml
@@ -1,12 +1,10 @@
 [plugin]
 repository = "https://github.com/sersorrel/WhosTalking.git"
-commit = "ae6bfc5b9c7776b09abb2a51e16e755f9025608f"
+commit = "fc3ff36fe2430efa410a3948101d6bd20767e579"
 owners = ["sersorrel"]
 project_path = "WhosTalking"
 changelog = """\
-**Version 0.8.1.0**
+**Version 0.8.2.0**
 
-Updated for patch 7.1.
-
-**Request for testing:** please enable ImGui indicators in the Who's Talking settings, then try Who's Talking in an alliance raid, and check whether indicators are drawn correctly for the other alliances (they should be drawn around the entire job icon). Ping @sersorrel or report in https://discord.com/channels/581875019861328007/1260701371846365246 with results! (Screenshots are ideal.)
+Fixed a bug where Discord users would be displayed on top of your chocobo if you didn't have a pet summoned.
 """


### PR DESCRIPTION
- migrate to dalamud.net.sdk
- add some debug ui
- fix a bug where the list of non-xiv users would display on top of a summoned chocobo (unless a pet was summoned as well)