### PR TITLE
Tf2CriticalHitsPlugin 3.6.0.1

### DIFF
--- a/stable/Tf2CriticalHitsPlugin/manifest.toml
+++ b/stable/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/jkchen2/ffxiv-tf2-crit-plugin.git"
-commit = "c846943d0e9c9c8bec583e82c467a51041fd7d6c"
+commit = "eddc5307b6cdf51cf82df5eddd96a6dca4f68b57"
 owners = ["jkchen2"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-- Fix player/pet logic order
+- Update for 7.11
+- Add sound preloading
 """

--- a/testing/live/Tf2CriticalHitsPlugin/manifest.toml
+++ b/testing/live/Tf2CriticalHitsPlugin/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/jkchen2/ffxiv-tf2-crit-plugin.git"
-commit = "356dc4650aec5a39f6c9c4e8ea05513d1d866bc8"
+commit = "eddc5307b6cdf51cf82df5eddd96a6dca4f68b57"
 owners = ["jkchen2"]
 project_path = "Tf2CriticalHitsPlugin"
 changelog = """
-Updated for FFXIV 7.11
+- Update for 7.11
+- Add sound preloading
 """


### PR DESCRIPTION
Update both stable and testing versions. Adds a dumb fix for hitches when audio plays for the first time.