### PR TITLE
Umbra 2.3.6

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,14 +1,16 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "4ca0ef3a01dd128c66c1ad4ea8c0377f8eb664ec"
+commit = "a21544f78560d377c2af59f81f688e074eedeaa8"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.3.5
+# Umbra 2.3.6
 
 ## Fixes & Improvements
 
-- Fixed a crash in the Party Member World Markers due to the missing "Max Visible Distance" configuration variable (by [mustafakalash](https://github.com/mustafakalash)).
+- Fix MainCommandShortcut disabled status (by [Haselnussbomber](https://github.com/Haselnussbomber)).
+- Switch to ProcessChatBoxEntry from ClientStructs (by [Haselnussbomber](https://github.com/Haselnussbomber)).
+- Make ReadOnlySeString.ReplaceText replace all occurrences (by [Haselnussbomber](https://github.com/Haselnussbomber)).
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 2.3.6

## Fixes & Improvements

- Fix MainCommandShortcut disabled status (by [Haselnussbomber](https://github.com/Haselnussbomber)).
- Switch to ProcessChatBoxEntry from ClientStructs (by [Haselnussbomber](https://github.com/Haselnussbomber)).
- Make ReadOnlySeString.ReplaceText replace all occurrences (by [Haselnussbomber](https://github.com/Haselnussbomber)).
