### PR TITLE
TwitchXIV 1.0.0.4, the oauth update

### DIFF
--- a/stable/TwitchXIV/manifest.toml
+++ b/stable/TwitchXIV/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Aida-Enna/TwitchXIV.git"
-commit = "7afed804f9449769cade4a2cfb002845b3936d4b"
+commit = "d3adf9f43e85e783b809341627b845f1ce745a2a"
 owners = ["Aida-Enna"]
 project_path = ""
-changelog = "- Updated for patch 7.1"
+changelog = "- Fixed the issue with getting an oauth token\n- Fixed a small bug that could display text twice instead of once. It did not actually send two messages."


### PR DESCRIPTION
- Completely redid the oauth process internally to use a new backend on my website since the website we were using is now offline.
- Fixed a bug that could cause chat to appear twice
- Version bump