### PR TITLE
ChatTwo 1.29.12

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "6144631b161d2eb83285f3b31f3b62113fdadafa"
+commit = "97a8b96326020459f5ea7ab306cc645a67626b75"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "cb8abc9ed60d28862da98e26ef04c59eedfc56c4"
+commit = "4c585f45bfd54dfec94ed1628201e677e69c87ef"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "f1fbe4d1ede0a8c1bccf9617f88fa1331e05486f"
+commit = "58a6020c8ba8b5c570831917285cf71a8d891340"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "4c585f45bfd54dfec94ed1628201e677e69c87ef"
+commit = "f1fbe4d1ede0a8c1bccf9617f88fa1331e05486f"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "97a8b96326020459f5ea7ab306cc645a67626b75"
+commit = "92d4a75ec46c2a9c80085eede9803afd3f3305b5"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "92d4a75ec46c2a9c80085eede9803afd3f3305b5"
+commit = "cb8abc9ed60d28862da98e26ef04c59eedfc56c4"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Display channel name even if invalid is selected
- Add no resize and no move for popouts
- Add independent hide condition for popouts
- Prevent item context menus being cut-off
- Add status linking
- Preview status links