### PR TITLE
Allagan Tools 1.11.0.8

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,12 +1,26 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "131e70032ecee15fc655e0f81d074ad52ba5c4a0"
+commit = "9e68e4d9c78e8d8c63c87f69e9e956c514049596"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.11.0.7"
+version = "1.11.0.8"
 changelog = """\
 ### Added
-- Added a new craft list mode, stock mode allows you to enter how much of an item you want in total in your inventory, rather than how much you want to gather/craft/buy
+- The craft overlay has arrived, this collapsable overlay will show you the next steps in your current craft project.
+  - Has a menu for each item for buying/gathering/crafting
+  - Is retainer aware, so it'll only show you what you need to extract from each retainer while it's open
+  - Provides quick switching between active craft list
+- Item icons within the AT interface can now be hovered and a tooltip will show, this can be configured to show never/on icon hover/row hover
+- Right clicking on any item within AT will now provide a Gather/Buy/Craft menu with the ability to teleport to specific nodes/shops
+- New filter called "Glamour Ready Combined", shows if an item is part of a set that gets combined in the glamour chest
+- Extra vendors have been included
+- The item window will show if an item has been combined into a glamour ready set
+- Initial 7.11 data
+
+### Fixed
+- Fishing/Spearfishing items should show more accurate locations
+- Certain vendors were not showing due to having no name will now show their NPCs name instead
+- Housing vendors have been de-deduplicated
 """


### PR DESCRIPTION
### Added
- The craft overlay has arrived, this collapsable overlay will show you the next steps in your current craft project.
  - Has a menu for each item for buying/gathering/crafting
  - Is retainer aware, so it'll only show you what you need to extract from each retainer while it's open
  - Provides quick switching between active craft list
- Item icons within the AT interface can now be hovered and a tooltip will show, this can be configured to show never/on icon hover/row hover
- Right clicking on any item within AT will now provide a Gather/Buy/Craft menu with the ability to teleport to specific nodes/shops
- New filter called "Glamour Ready Combined", shows if an item is part of a set that gets combined in the glamour chest
- Extra vendors have been included
- The item window will show if an item has been combined into a glamour ready set
- Initial 7.11 data

### Fixed
- Fishing/Spearfishing items should show more accurate locations
- Certain vendors were not showing due to having no name will now show their NPCs name instead
- Housing vendors have been de-deduplicated