### PR TITLE
StackSellPrice 4.4.0

### DIFF
--- a/stable/StackSellPrice/manifest.toml
+++ b/stable/StackSellPrice/manifest.toml
@@ -1,6 +1,5 @@
 [plugin]
-repository = "https://github.com/PrincessRTFM/StackSellPrice.git"
-owners = [ "PrincessRTFM",]
+repository = "https://github.com/Infiziert90/StackSellPrice.git"
+owners = [ "PrincessRTFM", "Infizier90"]
 project_path = ""
-commit = "811d8a6dd507f1426fd1ffe7c248adeb6fcbfd55"
-changelog = "Update for patch 6.58, no code changes."
+commit = "7743650780a74f8f2b257e4e3bdac7a95881349f"

--- a/stable/StackSellPrice/manifest.toml
+++ b/stable/StackSellPrice/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Infiziert90/StackSellPrice.git"
-owners = [ "PrincessRTFM", "Infizier90"]
+owners = [ "PrincessRTFM", "Infiziert90"]
 project_path = ""
 commit = "7743650780a74f8f2b257e4e3bdac7a95881349f"


### PR DESCRIPTION
- Update for API 11
- Removed all usage of XIVCommon~

Note: 
Adopting this from PrincessRTFM as they have no time to look into updating this, see <https://discord.com/channels/581875019861328007/684745859497590843/1319457062467670026>