### PR TITLE
Glamaholic 1.10.12

### DIFF
--- a/stable/Glamaholic/manifest.toml
+++ b/stable/Glamaholic/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = '3d65cfe8877753199bc1ed3dd476f19a3bccc1d8'
+commit = '15b50a2757b6252656cc7cd3f78b3825676f8334'
 owners = [ 'caitlyn-gg' ]
 changelog = """
-Fixed a bug wherein the second dye slot would not be set when a plate was applied.
+- Eorzea Collection glamours with items containing NBSP characters should now import correctly.
+- Added a plugin interop command suggested by @subaruyashiro, see plugin help for more information.
 
 For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!
 """


### PR DESCRIPTION
- Eorzea Collection glamours with items containing alternative space characters should now import correctly.
- Added a plugin interop command suggested by @subaruyashiro, see plugin help for more information.

For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!