### PR TITLE
ChatTwo 1.29.16

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "70971d7b8a02011821de75ae47b35a5d2ad55c4d"
+commit = "f6dd0359e72f52860e3ebc447019d6dd6d5b7c35"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Potential fix for tells getting stuck
- Allow debugger use outside of debug builds