### PR TITLE
[Testing] PlayerTrack v3.4.10

### DIFF
--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/kalilistic/PlayerTrack.git"
-owners = [ "kalilistic" ]
+owners = ["kalilistic"]
 project_path = "PlayerTrack.Plugin"
-commit = "862079967b5f74e462b75da233b2498228748844"
+commit = "48d5135f31fe19edfb116fc5ddd83b1408839061"


### PR DESCRIPTION
_Minor bug fixes including avoiding adding players during replays._
### Changed
- Update chinese/spanish localization.
- Migrate to the dalamud nameplate service.
### Fixed
- Don't process player data during replays.
- Hide serilog version warnings.
- Handle error when with empty db on merge screen (thakyZ).
- Prevent database from being locked on crash (thakyZ).
- Fix compiler warning for player retrieval function (thakyZ).