### PR TITLE
Acquisition Date 0.1.0.1

### DIFF
--- a/testing/live/AcquisitionDate/manifest.toml
+++ b/testing/live/AcquisitionDate/manifest.toml
@@ -1,31 +1,9 @@
 [plugin]
 repository = "https://github.com/Glyceri/AcquisitionDate.git"
-commit = "9d48f6a4abe792fd367c545d7289a037f36879ee"
+commit = "e2c8629cf1aaef98ed89fbc1d0007da9ca1dcd74"
 owners = ["Glyceri",]
 	changelog = """
-    [0.1.0.0]
-    Initial commit of Acquired Date!
-
-    This plugin tracks and shows you the date you acquired/got the following:
-    - Achievements
-    - Quests
-    - Duties
-    - Levels (For any Job)
-    - Fish
-    - Sightseeing Log Entries
-    - Glasses
-    - Minions
-    - Mouts
-    - Orchestrion Rolls
-    - Fashion Accessories
-    And more!
-
-    Using the lodestone you can import a backlog of the following dates:
-    - Achievements
-    - Quests
-    - Glasses
-    - Minions
-    - Mounts
-
-    Expect a UI rework and more ways of importing data soon after release!
+    [0.1.0.1]
+    Shows a couple more warnings and tutorials in the UI for the session token.
+    Fixed a bug where disabling the Show Placeholder Dates option would prevent any date from showing up. 
 """


### PR DESCRIPTION
Shows a couple more warnings and tutorials in the UI for the session token.
Fixed a bug where disabling the Show Placeholder Dates option would prevent any date from showing up. 
Shows the version number of the plugin in the header bar.