### PR TITLE
Tracky 1.5.6.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "50075d4a6e687e78754ba1d9e3b012fee8f2f425"
+commit = "137a6d7635e75254fa1395340eb0768c054d4a05"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- **Retainer venture results are now uploaded**
  - Results are soon to be published on the gacha spreadsheet :)
- Read the expansions max level from game files
  - This affects the stats page, all ventures after DT weren't counted as "venture coffer valid" if your retainer was above 90
- Overhaul Retainer tab
- Fix tracking of Firmament tickets