### PR TITLE
[Testing] CurrencySpender 1.0.4

### DIFF
--- a/testing/live/CurrencySpender/manifest.toml
+++ b/testing/live/CurrencySpender/manifest.toml
@@ -1,5 +1,13 @@
 [plugin]
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
-commit = "5f4244918e43b5dcd69748d95684f3ab472d1f4f"
+commit = "7e339e0ec37b27ec233cd715048b84f7ed968e71"
 owners = [ "Blackcatz1911" ]
-changelog = "1.0.2"
+changelog = """\
+**1.0.4**
+- Added: Bicolor gemstone warnings now dynamically react to the current status of Shared Fates
+- Added: Made the tables a bit fancier
+- Added: Possibility to add items to an "Items of Interest" list
+- Fixed: Player login logic to trigger player updates automatically
+- Fixed: Some locations & aetherytes were incorrect
+- Changed: Rewrote GC Shop handling
+"""


### PR DESCRIPTION
## 1.0.4
- Added: Bicolor gemstone warnings now dynamically react to the current status of Shared Fates
- Added: Made the tables a bit fancier
- Added: Possibility to add items to an "Items of Interest" list
- Fixed: Player login logic to trigger player updates automatically
- Fixed: Some locations & aetherytes were incorrect
- Changed: Rewrote GC Shop handling