### PR TITLE
[Testing] PlayerTrack v3.4.14

### DIFF
--- a/testing/live/PlayerTrack/manifest.toml
+++ b/testing/live/PlayerTrack/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/kalilistic/PlayerTrack.git"
 owners = ["kalilistic"]
 project_path = "PlayerTrack.Plugin"
-commit = "84ce6229559c2b91f104a0e2557fd9bd53c2927d"
+commit = "1884b096128a0cc2c521b25c219b6a419b697032"


### PR DESCRIPTION
_Examine players and a new player history screen._
### Added
- Add player history screen with past name/worlds and appearance.
  - As a note, very old migrated data may have missing data ("N/As") and timestamps will be the migration date.
- Add examine player for current players (gone since 6.2!).
### Changed
- Increase search box input size limit so you can type longer queries.