### PR TITLE
Tracky 1.5.6.2

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "137a6d7635e75254fa1395340eb0768c054d4a05"
+commit = "52bcf324a7c896d5ec14a7dffedda05320ea021e"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Massively improve retainer task tracking
  - This also fixes an issue that ventures would end up a different type
- Implement Session tab
  - Currently only supports eureka bunny coffers
- Fix wrong indent in Stats