### PR TITLE
XIVCombo v2.0.0.3 

### DIFF
--- a/testing/live/XIVCombo/manifest.toml
+++ b/testing/live/XIVCombo/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/MKhayle/XIVComboPlugin.git"
 
 # The commit to check out and build from the repository.
-commit = "d74183f033706fe2b7c7716615187166ceb45d58"
+commit = "12f47364163769f26f34bda69aa8a984dc6ab6de"
 
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
@@ -15,5 +15,5 @@ project_path = "XIVComboPlugin"
 
 # The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
 changelog = """\		
-- Added back BLM's Freeze/Flare to the Enochian feature. Apologies! 
+- Fixed MCH's Hypercharge not behaving like it used to. 
 		"""

--- a/testing/live/XIVCombo/manifest.toml
+++ b/testing/live/XIVCombo/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/MKhayle/XIVComboPlugin.git"
 
 # The commit to check out and build from the repository.
-commit = "12f47364163769f26f34bda69aa8a984dc6ab6de"
+commit = "f17911f9f770357c90b8e141b8ab4f1d8dee17b1"
 
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
@@ -15,5 +15,5 @@ project_path = "XIVComboPlugin"
 
 # The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
 changelog = """\		
-- Fixed MCH's Hypercharge not behaving like it used to. 
+- Fixed PCT's Substractive applying to both Fire in Red and Blizzard in Cyan, only applying to Fire in Red now as it used to.
 		"""


### PR DESCRIPTION
Fixed PCT's Substractive applying to both Fire in Red and Blizzard in Cyan, only applying to Fire in Red now as it used to.
