### PR TITLE
CurrencySpender 1.0.5

### DIFF
--- a/testing/live/CurrencySpender/manifest.toml
+++ b/testing/live/CurrencySpender/manifest.toml
@@ -1,13 +1,13 @@
+
 [plugin]
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
-commit = "7e339e0ec37b27ec233cd715048b84f7ed968e71"
-owners = [ "Blackcatz1911" ]
+owners = ["Blackcatz1911"]
+project_path = "CurrencySpender"
+commit = "8a05067f07f3a29d4eed7a35c0dd4edd3dbe0c37"
 changelog = """\
-**1.0.4**
-- Added: Bicolor gemstone warnings now dynamically react to the current status of Shared Fates
-- Added: Made the tables a bit fancier
-- Added: Possibility to add items to an "Items of Interest" list
-- Fixed: Player login logic to trigger player updates automatically
-- Fixed: Some locations & aetherytes were incorrect
-- Changed: Rewrote GC Shop handling
+**1.0.5**
+- Fixed: Flame and Serpent NPCs were swapped
+- Fixed: Battlefield Etiquette tracking issues
+- Changed: Rephrased the punchline and description of the plugin
 """
+version = "1.0.5"


### PR DESCRIPTION
# Changelog

## 1.0.5
- Fixed: Flame and Serpent NPCs were swapped
- Fixed: Battlefield Etiquette tracking issues
- Changed: Rephrased the punchline and description of the plugin