### PR TITLE
[Testing]  BetterShadows 1.4.5

### DIFF
--- a/syncfork.cmd
+++ b/syncfork.cmd
@@ -1,1 +1,0 @@
-git push --force

--- a/testing/live/BetterShadows/manifest.toml
+++ b/testing/live/BetterShadows/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/Drahsid/BetterShadows.git"
-commit = "e09614012a9585fbaadbd93d8b18aca915e65c33"
+commit = "8a2da61c4a3bb4638a692d4529d410a6fefddbcc"
 owners = ["Drahsid"]
 project_path = "BetterShadows"
 changelog = """
-- Adjust dynamic cascade formula to be less conservative, and to have more significant changes at 4096p shadows.
-- Add option to use a separate shadowmap for combat, with the intent of allowing users to improve their performance when it matters.
+- Updated for most recent patch
+- Reimplemented combat shadowmaps
 """
 


### PR DESCRIPTION
This update adds support for the most recent patch and also reimplements the combat shadowmap option to be more holistic. Putting this in testing so that I can get feedback on the stability of the combat shadowmap rehaul.

I also removed `syncfork.cmd` from the tree. This file was in my exclude but seemed to end up in the tree during a HybridCamera update, and seemingly nobody noticed lol. My mistake!