### PR TITLE
[Testing] AcquisitionDate 0.1.1.3

### DIFF
--- a/testing/live/AcquisitionDate/manifest.toml
+++ b/testing/live/AcquisitionDate/manifest.toml
@@ -4,7 +4,7 @@ commit = "0d12448e1c4fdc691b06a711434f57d8878028f5"
 owners = ["Glyceri",]
 	changelog = """
 [0.1.1.3]
-- Outomatically adds the chocobo mount based on your achievement.
+- Automatically adds the Chocobo mount based on your achievement.
 - Will now pull data for legacy quests as well.
 - Fixed an issue (because I didn't think properly) that stops the whole queue from failing if a minion, mount or facewear had an invalid date or could for some reason not be parsed.
 """

--- a/testing/live/AcquisitionDate/manifest.toml
+++ b/testing/live/AcquisitionDate/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/Glyceri/AcquisitionDate.git"
-commit = "d58089c5009f1e99d8c14eb2422a8f2d0c83da41"
+commit = "0d12448e1c4fdc691b06a711434f57d8878028f5"
 owners = ["Glyceri",]
 	changelog = """
-    [0.1.1.2]
-    Fixes acquisition for users with ' in their name to not work (For real this time c:).
+[0.1.1.3]
+- Outomatically adds the chocobo mount based on your achievement.
+- Will now pull data for legacy quests as well.
+- Fixed an issue (because I didn't think properly) that stops the whole queue from failing if a minion, mount or facewear had an invalid date or could for some reason not be parsed.
 """


### PR DESCRIPTION
Automatically adds the Chocobo mount based on your achievement.
Will now pull data for legacy quests as well.
Fixed an issue (because I didn't think properly) that stops the whole queue from failing if a minion, mount or facewear had an invalid date or could for some reason not be parsed.