### PR TITLE
Shop Item Revealer v1.1.1

### DIFF
--- a/stable/ShopItemRevealer/manifest.toml
+++ b/stable/ShopItemRevealer/manifest.toml
@@ -1,14 +1,4 @@
 [plugin]
 repository = "https://github.com/Era-FFXIV/ShopItemRevealer.git"
-commit = "b82169e2a58ec2e07aafd69dbb2844cdb334e10f"
+commit = "53e40a7e15edb24484be6cdc422c3eda289707c7"
 owners = ["nathanctech"]
-changelog = """
-1.1.0
- - Adds gemstone vendor support with FATE rank requirement tracking.
- - Added some help desk at the bottom of the window.
- - Showing/hiding unrevealed items now re-sorts the table correctly.
- - Some code cleanup
-1.0.2
-- Adds sorting the table by item name (default) or quantity required.
-- Fixes another imgui assert.
-"""


### PR DESCRIPTION
## Version 1.1.1
- Changes fate item names the data json to IDs, allowing for game sheet lookup for localized names.
- Table now has its header frozen while scrolling.
- Adjustments to handling player shared FATE data. This will require regenerating them on update.
- A button to open the Shared FATEs window appears if needed.