### PR TITLE
Simple Tweaks 1.10.6

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "5681dacfc9c1f5b8c231bf46a53fc2d5def384e1"
+commit = "3bba4db1c3e5cc6636922c3dac3aae7713d7294d"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***New Tweaks***
- **`Disable Novice Network Auto-Switch`** - Disables automatically selecting novice network when logging in or transferring to another server.

- **`Ensure tooltips remain on screen`** - Prevents tooltips from extending below the bottom of the screen. Useful when using tweaks that make the tooltips longer.

- **`Logos Tooltips`** - Adds which kind of Logos Mnenes you can obtain from a Logogram in its tooltip. *(Khayle)*

- **`Special Character Input`** - Adds a window for adding special characters to text inputs.


***Tweak Changes***
- **`Item Level in Examine`** - Tweak now uses item level provided by the game, improving accuracy.

- **`Screenshot Improvements`** - Fixed 'Remove Copyright Text' option.

- **`Show Desynthesis Skill`** - Fixed tweak not working on french clients.

