### PR TITLE
SubmarineTracker 1.9.6.0

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "3be779a2b0dd7f03fac0e9339bb023890001ea49"
+commit = "d53fb53785f00851a9b537b366dbf24a32dc0a7a"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Switch away from Supabase as upload receiver
  - Uploads now go to a VPS fully managed by me