### PR TITLE
Wholist v1.8.2.0

### DIFF
--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "f29c12a1d49f1262a6c698b5c66fd13b54924e97"
+commit = "60a18e70a4ed6fccc33617185f5a1b5b62b6c4b5"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
- Added the ability to disable the filtering of players under level 3 (not recommended as this hides most bots)
- Updated translations
- Removed the ability to disable window moving and resizing as this has become a base Dalamud feature (click the three lines on the nearby players window!)