### PR TITLE
ChatTwo 1.29.17

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "f6dd0359e72f52860e3ebc447019d6dd6d5b7c35"
+commit = "5a78877abf47bcdeabf6a84e93097e7c578633ec"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
**Chat2 DBViewer (/chat2Viewer)**
- Increase page count to 1000
- Now sorted by date

**Input Stuff**
- Echo everything that hasn't any channel set
- Tabs with fixed channel inputs are now enforced
- Added a warning for ECL channel mismatch

> ExtraChat Note:
If anyone with dev experience wants to take care of this feature, please speak up to me ... 
I do not use ExtraChat, i do not care about it, neither does the original dev seem to care.
No help from anyone else means that the support for ExtraChat stuff in ChatTwo will be removed.