### PR TITLE
ChatTwo 1.29.18

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "5a78877abf47bcdeabf6a84e93097e7c578633ec"
+commit = "65d2cf7c639d078d4b5cd60d692ca810599a39ed"
 owners = [
     "Infiziert90",
     "lojewalo"

--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "65d2cf7c639d078d4b5cd60d692ca810599a39ed"
+commit = "8354db5b03c41a2ec1cd8cc4f8301c999c6166d8"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Set message length limit in the web implementation directly
- Fix weird line break that happens with ExtraChat channel names