### PR TITLE
SubmarineTracker 1.9.7.1

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "9ffb01bf5a4e066267055030f8015e885efb9ec3"
+commit = "b7f0899e89ea05d22adbea2b84c41a8196647d8e"
 owners = [
     "Infiziert90",
 ]

--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "b7f0899e89ea05d22adbea2b84c41a8196647d8e"
+commit = "05f0f389e3ca64b2290adb8f465bd4e2376f9eb9"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Prevent error on load if migration already happened
  - This should only happen if user had some form of corruption ...
- Fix submarine list gettig cut-off if window is too small
- Add role mentions to offline mode notification