### PR TITLE
Dalamud.RichPresence 2.0.6.6

### DIFF
--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,11 +1,11 @@
 [plugin]
 repository = "https://github.com/reiichi001/Dalamud.RichPresence.git"
-commit = "13b153ca1cbbc1cad20cea84d501f11be95af940"
+commit = "490e4ec708142a2d8d1bc9910e9146efe07648ca"
 owners = [
     "goaaats",
     "reiichi001",
 ]
 project_path = "Dalamud.RichPresence"
 changelog = """
-Bump WineRPCBridge version. (Thankyou @blooym)
+Replace WineRPCBridge with a version that doesn't get flagged as a false positive by Windows AVs. (Windows users will never run this file btw. It's only for Linux users.)
 """


### PR DESCRIPTION
nofranz

changelog = """
Replace WineRPCBridge with a version that doesn't get flagged as a false positive by Windows AVs. (Windows users will never run this file btw. It's only for Linux users.)

Here's the scan for those interested
https://www.virustotal.com/gui/file/14668f1c815a421a7cc77da4d39659142b56292600db6cb004ce16218193ff0c