### PR TITLE
Tracky 1.5.7.1

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "c05f3e5cd7a09377274978e349bce62dbb4c7f5a"
+commit = "27aedf73fae7827bbc6237688ebbadbbe630bfde"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fix upload error if HQ items are encountered
  - This affected mainly PotD sacks
- Fix general issues with HQ items
- Small performance improvements
- Data update
  - Desynthesis records reached 5.7 mil
 