### PR TITLE
Wholist v1.8.2.1

### DIFF
--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "60a18e70a4ed6fccc33617185f5a1b5b62b6c4b5"
+commit = "0ad16f6cc613ea5de2380817ea21858d010b81b1"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
Fixes showing a broken "adventurer" player when disabling the minimum level filter.