### PR TITLE
[Testing] Who's Talking 0.8.4.0

### DIFF
--- a/testing/live/WhosTalking/manifest.toml
+++ b/testing/live/WhosTalking/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/sersorrel/WhosTalking.git"
-commit = "c84979998561420e7ed3e5915b5bdcdf303fb5ff"
+commit = "6b9edf1cd47dc4fb1f539534ad650668dc1b25f5"
 owners = ["sersorrel"]
 project_path = "WhosTalking"
 changelog = """\
-**Version 0.8.3.0**
+**Version 0.8.4.0**
 
-Fixed a bug where a rare Discord API error could crash the game.
+You can now configure which port Who's Talking uses to communicate with the Discord client. This is primarily useful if you have multiple Discord clients open at the same time.
+
+Many thanks to SayuShira for implementing this feature!
 """


### PR DESCRIPTION
discord clients can expose the RPC API on one of ten ports, previously we only tried the lowest port, now we let the user select any port

@SayuShira thanks again for the pull request – the port configuration option will be available on the testing branch once this PR is merged.