### PR TITLE
Pet Nicknames v2.3.0.10

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "6c6f6a22716c4f21bacc21ddbc38e92e153d88c0"
+commit = "d3159038a1b06a55f98d733f5a864bf655c7f246"
 owners = ["Glyceri"]
 	changelog = """
-    [2.3.0.9]
-    Fixes profile pictures not downloading for people with ' and - in their name.
+    [2.3.0.10]
+    Now shows version number on windows.
+    Uses BNpcName name instead of Pet name fixing some display names not renaming properly.
 """


### PR DESCRIPTION
Now shows version number on windows.
Uses BNpcName name instead of Pet name fixing some display names not renaming properly.