### PR TITLE
Waitingway 2.2.95

### DIFF
--- a/stable/Waitingway.Dalamud/manifest.toml
+++ b/stable/Waitingway.Dalamud/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Waitingway.git"
-commit = "6e76ff49f12042a99288f38dc6ad89e98322941d"
+commit = "c2a38392f96781806e011b67dfbb6dc5ce2c9f44"
 owners = ["WorkingRobot"]
 project_path = "Waitingway"


### PR DESCRIPTION
- Changed around some settings
- Added configuration for duty queue notifications
- Fixed crashing when queuing into some non-standard duties
- Waitingway no longer requires you to stay in the support server to receive notifications