### PR TITLE
[Testing] Racingway v0.0.4.3

### DIFF
--- a/testing/live/Racingway/manifest.toml
+++ b/testing/live/Racingway/manifest.toml
@@ -1,6 +1,13 @@
 [plugin]
 repository = "https://github.com/Abyeon/Racingway.git"
-commit = "07910f47d0ec9e5c5f700fff2ff8277f6dae72c8"
+commit = "0d0c8d1cd992a080423d5dd11e24988f657c50b8"
 owners = ["Abyeon"]
 project_path = "Racingway"
-changelog = "Fix crash that happened when TrackOthers was enabled."
+changelog = """
+v0.0.4.3 [TESTING]
+- Fixed crash when Track Others was enabled
+
+Known Issues:
+- Need to refresh when importing routes from clipboard
+- Triggers displaying incorrectly when a portion is behind the camera
+"""


### PR DESCRIPTION
Previous fix for crash relating to Track Others being enabled did not seem to work. This should work now.