### PR TITLE
Waitingway 2.2.97

### DIFF
--- a/stable/Waitingway.Dalamud/manifest.toml
+++ b/stable/Waitingway.Dalamud/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Waitingway.git"
-commit = "c2a38392f96781806e011b67dfbb6dc5ce2c9f44"
+commit = "3da87dc6453493e4c90c87f91101cdf8a31a0a9a"
 owners = ["WorkingRobot"]
 project_path = "Waitingway"


### PR DESCRIPTION
Fixes a configuration bug that causes the plugin to fail to load.