### PR TITLE
Wholist v1.9.0.0

### DIFF
--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "0ad16f6cc613ea5de2380817ea21858d010b81b1"
+commit = "7e2ded404f24a07b92efdc257086eee9c734b3bc"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
- New feature: show the number of nearby players in the server info bar, click to open the main UI. This is enabled by default, but can be disabled by navigating to the "Server Info" tab in Dalamud Settings and unchecking "Nearby Player Count". Thanks Gwen for doing the German translations for this feature ahead of time <3
- Bug fix: the "add to blacklist" context menu item will be disabled if the player in question is on your friends list. 