### PR TITLE
[Testing] BisBuddy v0.1.0.0

### DIFF
--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,13 +1,15 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "1c9f70eadc092ed9c9b6265af65300931207d523"
+commit = "49fa67b3fd48557688475ee6b4e229fad0a681ff"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
-##Initial testing release##
- - Added ability to customize highlight color in config
- - Added search for gearpiece items in inventory
- - Added configurable behavior for matching behavior of auto-assignment
- - resx localization (en impl. only)
- - bugfixes
+**Version 0.1.0.0**
+ - Complete rewrite of item prerequisite system to support more sources
+ - Use LuminaSupplemental for coffer contents
+ - Indent gearpieces in UI for increased readability
+ - Increase initial main window size
+ - Fix bug where changes would not save if no gearset changes were applied
+ - Fix assignment handling for gearpieces with empty materia slots
+ - Fix incorrect gearpiece display color when unobtainable
 """


### PR DESCRIPTION
**Version 0.1.0.0**
 - Complete rewrite of item prerequisite system to support more sources
 - Use LuminaSupplemental for coffer contents
 - Indent gearpieces in UI for increased readability
 - Increase initial main window size
 - Fix bug where changes would not save if no gearset changes were applied
 - Fix assignment handling for gearpieces with empty materia slots
 - Fix incorrect gearpiece display color when unobtainable