### PR TITLE
[Testing] MogMogCheck v3.2.0

### DIFF
--- a/testing/live/MogMogCheck/manifest.toml
+++ b/testing/live/MogMogCheck/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Haselnussbomber/MogMogCheck.git"
-commit = "646305291a012d8434543f998c711e9733a2ead8"
+commit = "6a9bf1b035bd1b16b88f13f3be6db452c54b37a3"
 owners = [ "Haselnussbomber" ]
 project_path = "MogMogCheck"


### PR DESCRIPTION
- **Added:** The MogMogCheck window now automatically opens when the Item Exchange Shop is opened (only for the current event). This can be disabled with the new config option "Open/Close with Shop window" (default on).
- **Added:** An option to "Automatically turn off tracking for purchased rewards" (default on). This requires the Checkbox-Mode to be enabled.
- **Added:** An option to "Gray out collected items" (default off).
- **Fixed:** The checkmark for collected equippable items for "All Classes" will also show when the data is not fresh.
- **Fixed:** To get an accurate collected status the item quantity cache is now cleared when logged in and when opening the MogMogCheck window.
- **Fixed:** The MogMogCheck window is no longer focused when opened with the Mogpendium.