### PR TITLE
ChatTranslated v3.3.2.1

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,12 +1,10 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "f392de595e92775f6eac52eb7fc97e3d500aac46"
+commit = "8cff873725b39fe7e9abfce56b248fd5bea14e67"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
-Fix broken deepl translate.
-Google translate quality dropped. Use bing for backup for now.
-Bump GTranslate.
+Now uses backup options when translated text returned is the same as the original string.
 """
 [plugin.secrets]
 cfv5 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAwWjD3/KyJImP8dQmxaYopsnRrAzxTTyBXpjy8wD+\nukMwftTv2MvAmtpo4gs6XnvaiOwFbWGronS9JHxu6KX7VkYfqyoLBZNMdo+P\nqkCaSBuI0lgBYA7NBgG1qsc01OP7aWuQCwEsBTgBxUKHu3NXpJUA39789ZdG\nlijhq24gEee+H7e6TALiGvYh++jDhm7W07WnfBbuN8u/LmRlzXr9t+0ASIVv\niamGCfnX\n=iNor\n-----END PGP MESSAGE-----\n"


### PR DESCRIPTION
Uses backup options when translated text returned is the same as the original string.