### PR TITLE
PvP Tracker v2.3.0.2

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "2daf3a10cfb90dd4866201dc351d3dc7378c4c86"
+commit = "6b672469abac2a16258ce1664996fafdc48533ca"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Removed ContentId and AccountId recording.
+* Added 7.2X periods to time filter.
+* Fixed a bug with blacklisted player names on match intro.
 """


### PR DESCRIPTION
* Added 7.2X periods to time filter.
* Fixed a bug with blacklisted player names on match intro.