### PR TITLE
Tracky 1.5.7.2

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "27aedf73fae7827bbc6237688ebbadbbe630bfde"
+commit = "9c7087b6f9e39860e8a3fb225efddfbb60662ec1"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Fix "Limited-time bonus activated" log message appearing for all loot