### PR TITLE
Allagan Tools 1.11.1.3

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -10,6 +10,7 @@ changelog = """\
 **Fixes**
  - Fix duplicate craft list crash
  - Fix 'Filter items when in retainer' setting not being respected
+
 **Added**
  - Source/Use columns will output a summarized description when exporting to a CSV/json
  - Right clicking on a source/use icon will now give you the ability to "Copy Source/Use Information" making it easier to share source/use information with others

--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,16 +1,16 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "d70545f7a1428ecd45045afb48b936e9bd04545d"
+commit = "0290053b454e384df74f5983553d7f5b786c93b5"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.11.1.2"
+version = "1.11.1.3"
 changelog = """\
 **Fixes**
- - Market cache data is now saved in the background
- - Fixed an issue with the market tooltip causing lag
- - Retainer market items should parse properly again
- - The "Keep market prices for X hours" setting was not being respected
- - Teleporting to vendors via the buy menu would sometimes send you to the wrong zone
+ - Fix duplicate craft list crash
+ - Fix 'Filter items when in retainer' setting not being respected
+**Added**
+ - Source/Use columns will output a summarized description when exporting to a CSV/json
+ - Right clicking on a source/use icon will now give you the ability to "Copy Source/Use Information" making it easier to share source/use information with others
 """


### PR DESCRIPTION
**Fixes**
 - Fix duplicate craft list crash
 - Fix 'Filter items when in retainer' setting not being respected

**Added**
 - Source/Use columns will output a summarized description when exporting to a CSV/json
 - Right clicking on a source/use icon will now give you the ability to "Copy Source/Use Information" making it easier to share source/use information with others