### PR TITLE
ChatTwo 1.29.20

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "14cb3af13a13e866571d022fe6cf93d39e25b73a"
+commit = "a6b71f50e66dca5b0decc5c77fe9d859fedefe56"
 owners = [
     "Infiziert90",
     "lojewalo"


### PR DESCRIPTION
- Both item and action tooltips are now checked for clipping, if "Next To Cursor" is enabled