### PR TITLE
BisBuddy v0.1.1.1

### DIFF
--- a/stable/BisBuddy/manifest.toml
+++ b/stable/BisBuddy/manifest.toml
@@ -1,5 +1,10 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "ab63af76b6b40ead7c9faa6cf1dde3cbaa7adc31"
+commit = "6c16a76abca0141cfc9ba59d0904e48627970042"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
+changelog = """\
+**Fixes**
+ - Fix issue with some german item names containing erroneous characters
+ - Fix materia abbreviations not working properly for other languages
+"""


### PR DESCRIPTION
-  Fix issue with some german item names containing erroneous characters
-  Fix materia abbreviations not working properly for other languages