### PR TITLE
XIVDeck 0.3.23

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "fb65aaeba12e5027b3785fd609fac48d73771fde"
+commit = "7099405bb42aabf213e4b492337a1dd4f3514c01"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
Mmmmm, new API version. New Sphene memes. And new 🌽.

- Still no feature changes. This plugin is perfect as is.
- ~~LOL FIRST WOOOOO~~ No longer first thanks to the plugin builder being angy :(

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.3.23).