### PR TITLE
RetainerSales api12 bump

### DIFF
--- a/stable/RetainerSales/manifest.toml
+++ b/stable/RetainerSales/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Populo/RetainerSales.git"
-commit = "f6c18f4f634ef1380c3cd22efe9def81da5082f4"
+commit = "ff75eb3c4d218d3ffe9392b0e169ece15a810215"
 owners = ["Populo"]
 project_path = "RetainerSales"
-changelog = "Leave testing"
+changelog = "api12 bump"

--- a/stable/RetainerSales/manifest.toml
+++ b/stable/RetainerSales/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Populo/RetainerSales.git"
-commit = "ff75eb3c4d218d3ffe9392b0e169ece15a810215"
+commit = "0aa6dca45318244b202cc75ff975b914de8c8969"
 owners = ["Populo"]
 project_path = "RetainerSales"
 changelog = "api12 bump"


### PR DESCRIPTION
api12 bump plus change some uints to bytes to save single digit bytes of ram. still more efficient than doge