### PR TITLE
FlyTextFilter 4.3.0.0

### DIFF
--- a/stable/FlyTextFilter/manifest.toml
+++ b/stable/FlyTextFilter/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Aireil/FlyTextFilter.git"
-commit = "0ac607d086713f0f5c8b59c832a1cceb03d3c4f2"
+commit = "62a1fad83b9f3659d635e1f11873486390db4041"
 owners = [
     "Aireil",
 ]


### PR DESCRIPTION
- 7.2 related fixes.
- SE added 3 new fly text types with unknown usage, if you have `Help to find unknown types` enabled in the misc tab of the settings, you will be notified when you encounter one (likely for Occult Crescent).