### PR TITLE
Target Lines 1.8.0.0 (API12)

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,11 +1,13 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "ace8a361a49c219f6cd70cdc82b4ec77040c8182"
+commit = "ecefc1c77052cf316b0b62ccf7d8650b95a167b7"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
 Bug fixes:
-- Fixed issue where focus target lines would repeatedly play dying animation when the player died
-- Fixed issue where resetting to default wouldn't always update the filters
+- Fixed an issue where the plugin would output an error in regards to the focus target when logging out with a focus target. Additionally, fixed an issue with the focus target line respawning on a dead entity.
+- Added some LOD options which may improve performance at no visual cost: "Use ScreenSpace LOD" and "View Angle Sampling".
+Known Issues:
+- After logging into a character, returning to the title screen may cause target lines to not appear on all entities. This can be fixed by restarting the plugin.
 """
 


### PR DESCRIPTION
This updates the plugin for API12, and additionally adds some LOD related options, as well as resolves some focus-target quirks.