### PR TITLE
[Testing] BisBuddy v0.1.1.2

### DIFF
--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "3de501aa2f45035e9d335b71f62ad76e8ff2e6d4"
+commit = "bcf270996950e02e60d4c39c7d4854b728115f12"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\

--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,17 +1,13 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "ab63af76b6b40ead7c9faa6cf1dde3cbaa7adc31"
+commit = "3de501aa2f45035e9d335b71f62ad76e8ff2e6d4"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
 **Changes**
- - Updated importing UI (and backend)
- - Added import support for Teamcraft plaintext gearsets
- - Added option "Next Materia Only" to only show next materia to meld, disabled by default
- - Added color to individual materia in meld plan window to convey meld status
+ - Updated to 7.2 / API 12
+ - Completed meld plans no longer appear when melding
+ - Remove opinionated sorting on materia display order, show original
 **Fixes**
- - Fix importing from etro for HQ items with materia
- - Fix prerequisite assignment logic not working, like at all
- - Fix item tooltip gearset names truncating too aggressively with low gearset counts
- - Fix bug with highlights not getting updated immediately with some inventory changes
+ - Fix various errors with item assignment edge cases
 """

--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "bcf270996950e02e60d4c39c7d4854b728115f12"
+commit = "b03d6b74d12ab39be8d0a838ee2796c1888ea977"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\


### PR DESCRIPTION
- Updated to 7.2 / API 12
- Completed meld plans no longer appear when melding
- Remove opinionated sorting on materia display order, show original
- Fix various errors with item assignment edge cases