### PR TITLE
ResLogger2 0.0.2.10 -> 0.0.3.0

### DIFF
--- a/stable/ResLogger2.Plugin/manifest.toml
+++ b/stable/ResLogger2.Plugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/perchbirdd/ResLogger2.git"
-commit = "7de5620e13905fe6a2674294065f77ab2c96f019"
+commit = "3f5c040c6825a84a404fdb9ac05d00481bd0dac5"
 owners = [
     "perchbirdd",
 ]

--- a/stable/ResLogger2.Plugin/manifest.toml
+++ b/stable/ResLogger2.Plugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/perchbirdd/ResLogger2.git"
-commit = "db7b1a58aa531df593149f358f94458025617c45"
+commit = "7de5620e13905fe6a2674294065f77ab2c96f019"
 owners = [
     "perchbirdd",
 ]


### PR DESCRIPTION
Adds support for .pap files as long as a certain conflicting custom-repo plugin is not detected. If it is detected, ResLogger2's pap handling is either not initialized in the first place, or unloaded if this plugin is loaded after ResLogger2.