### PR TITLE
CollectableCalculator 4.2

### DIFF
--- a/stable/CollectableCalculator/manifest.toml
+++ b/stable/CollectableCalculator/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/mabako/CollectableCalculator.git"
-commit = "4c0e9df9d75b06fdc6eb4ba1aa41885339617b03"
+commit = "449c33a8d9f6c437f32bb34e8bbf550e5e1ca4dc"
 owners = ["carvelli", "mabako"]
 project_path = "CollectableCalculator"


### PR DESCRIPTION
- Update for Patch 7.2
- Show orange/purple scrip rewards for weekly delivery NPCs such as Zhloe, M'naago etc., according to your remaining allowances and current bonuses (requires you to have opened the weekly delivery window once)