### PR TITLE
Waitingway 2.3.0

### DIFF
--- a/stable/Waitingway.Dalamud/manifest.toml
+++ b/stable/Waitingway.Dalamud/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Waitingway.git"
-commit = "3da87dc6453493e4c90c87f91101cdf8a31a0a9a"
+commit = "5b97266c2f68f8a6f38d19e1d9a0337973254264"
 owners = ["WorkingRobot"]
 project_path = "Waitingway"


### PR DESCRIPTION
- Updated for API12 (7.2)
- Added duty support! The ability to view crowdsourced data will come in a later update.
- Fixed some bugs causing erroneous errors to display.