### PR TITLE
Simple Tweaks 1.10.9.0

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "47c41c9adaee12b77e34fda3d0d32adaeb7e64e2"
+commit = "db3e2c765f4d30211a6492a3534beaaafa62a797"
 owners = [
     "Caraxi",
 ]

--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "db3e2c765f4d30211a6492a3534beaaafa62a797"
+commit = "7c0f389d6743e635e262dcd6f18014ccfe447e72"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
Simple Tweaks has been updated for 7.2

***New Tweaks***
- **`Sort World Visit List`** - Removes the randomization from the data center visit world list.

***Tweak Changes***
- **`Add Number Separators`** - Fixed flytext number separator not working.

- **`Limit Break Adjustments`** - Added preview for when not in a party

- **`House Lights Command`** - Added ability to toggle SSAO with 'ssao-on' and 'ssao-off' parameters

- **`Expanded Currency Display`** - Added option to Grand Company seals to display current grand company.

*Other various changes to accommodate updates to Dalamud and FFXIV*
