### PR TITLE
PushyFinder 1.3.1.0

### DIFF
--- a/stable/PushyFinder/manifest.toml
+++ b/stable/PushyFinder/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = "https://github.com/snightshade/PushyFinder.git"
-commit = "c524570c72088fbd72bf7d18731caa445846a433"
+commit = "09bdd72e30d6de077da3d273928615af40d6c639"
 owners = ["snightshade"]
 project_path = "PushyFinder"
-version = "1.3.0.2"
+version = "1.3.1.0"
 changelog = """
-Minor fix for Ntfy.sh content formatting.
+API 12, XIV 7.2. Fix ntfy.sh topics not being taken into account (oops).
 """


### PR DESCRIPTION
- Dalamud API 12 support (FFXIV 7.2)
- Fix for ntfy.sh topic handling (it actually exists now)