### PR TITLE
Umbra 2.3.12

### DIFF
--- a/stable/Umbra/manifest.toml
+++ b/stable/Umbra/manifest.toml
@@ -1,19 +1,19 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "dc552877aae98ab2b09a94115989ef5dcdce882b"
+commit = "1b3cdc581145d0e8c9d6d4c267dcb6d4ba6b25ab"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 2.3.11
+# Umbra 2.3.12
 
-Updated for Patch 7.2.
+## New additions
 
-Thanks you for your contributions to this release: [Bloodsoul](https://github.com/Bloodsoul) and [LTS-FFXIV](https://github.com/LTS-FFXIV)!
+- Added a "Pick random job" to the gearset switcher. This button picks a random DoW/DoM job that is the highest level amongst your other gearsets. The button does nothing if there are no candidates to pick from (e.g. you only have one gearset). This was a request to "spice things up" when doing Daily Roulettes.
 
 ## Fixes & Improvements
 
-- Shorten the placeholder text of the empty button in the Dynamic Menu Widget + tooltip added for clarity (By [Bloodsoul](https://github.com/Bloodsoul)).
-- Fix German translation in Volume Widget (By [Bloodsoul](https://github.com/Bloodsoul)).
+- Removed the TextDecoder from Umbra that was responsible for some translations as this is now integrated into Dalamud itself (by [Haselnussbomber](https://github.com/Haselnussbomber)).
+- Updated Umbra to use Dalamud.NET.SDK (by [Haselnussbomber](https://github.com/Haselnussbomber)).
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 2.3.12

## New additions

- Added a "Pick random job" to the gearset switcher. This button picks a random DoW/DoM job that is the highest level amongst your other gearsets. The button does nothing if there are no candidates to pick from (e.g. you only have one gearset). This was a request to "spice things up" when doing Daily Roulettes.

## Fixes & Improvements

- Removed the TextDecoder from Umbra that was responsible for some translations as this is now integrated into Dalamud itself (by [Haselnussbomber](https://github.com/Haselnussbomber)).
- Updated Umbra to use Dalamud.NET.SDK (by [Haselnussbomber](https://github.com/Haselnussbomber)).
