### PR TITLE
MacroMate 1.0.21.2

### DIFF
--- a/stable/MacroMate/manifest.toml
+++ b/stable/MacroMate/manifest.toml
@@ -1,12 +1,10 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "f1f03c02993c7a66d61370dc2eb1a270cfa00173"
+commit = "5e7e18799dc49985421aa18de427b59c24a34776"
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.21.1"
+version = "1.0.21.2"
 changelog = """
-- Patch 7.2 support
-- Added HUD Layout condition
-- Added `/mm run` command
-- Rewritten MacroChain support, hopefully preventing crashes this time
+- Fix crash when editing empty macros
+- 'Duplicate Macro' now copies Use Macro Chain flag
 """


### PR DESCRIPTION
- Fix crash when editing empty macros
- 'Duplicate Macro' now copies Use Macro Chain flag