### PR TITLE
DailyDuty v5.2.2.1

### DIFF
--- a/stable/DailyDuty/manifest.toml
+++ b/stable/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "57bc092ae4e2fb54510eda21305bdcdfc2f5d936"
+commit = "509cbb7db5f975982abef84da301e7db13f02090"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
Add force reload button to raids modules

It should automatically adjust to the new duties whenever they become available, but if not you can use this to fix it.