### PR TITLE
Quest Share 0.0.0.4

### DIFF
--- a/testing/live/QuestShare/manifest.toml
+++ b/testing/live/QuestShare/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Era-FFXIV/QuestShare.Plugin.git"
-commit = "3d3ee3d2837c13c40d0f7e028bc29a48a9b365de"
+commit = "d6556d32411282cfeced145fa2018729fd3b3656"
 owners = ["nathanctech"]
 project_path = "QuestShare.Plugin"
-version = "0.0.0.3"
+version = "0.0.0.4"


### PR DESCRIPTION
New:
- Implemented auto sharing quests on acceptance with the associated setting. This is a separate feature from MSQ sharing.

Changed:
- Moved the "Auto Share" settings from Settings tab to Host tab to reduce confusion
- Reduced the initial size of the main window.