### PR TITLE
Party Icons 1.2.3.0

### DIFF
--- a/stable/PartyIcons/manifest.toml
+++ b/stable/PartyIcons/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/nebel/xivPartyIcons.git"
-commit = "fe52bd22ac4c61484d617a59c20f82948ae7a926"
+commit = "31b67dcb41644f462ef393e4eb7f915f17718705"
 owners = [
     "shdwp",
     "avafloww",


### PR DESCRIPTION
- Re-enable the option to view role indicators in the party list
- Add support for Chaotic Alliance Raids (thanks @hmm-norah!)