### PR TITLE
[Testing] Racingway v0.0.6.5

### DIFF
--- a/testing/live/Racingway/manifest.toml
+++ b/testing/live/Racingway/manifest.toml
@@ -1,9 +1,14 @@
 [plugin]
 repository = "https://github.com/Abyeon/Racingway.git"
-commit = "aa8cf0d17e600a35a6a568c13a133bfd6e3e3a60"
+commit = "f3d9828eec44ab1ea48a4319d546920a7e90ca7a"
 owners = ["Abyeon"]
 project_path = "Racingway"
 changelog = """
-v0.0.6.4 [TESTING]
-- Fix lag in routes tab
+v0.0.6.5 [TESTING]
+- Fix records tab
+- Add importing records (they're very large at the moment)
+- Make right-click to display records work for loaded routes
+
+Known Issues:
+- Highlighted record loses it's color when you start a race
 """


### PR DESCRIPTION
- Fix records tab
- Add importing records (they're very large at the moment)
- Make right-click to display records work for loaded routes

I swore I submitted this earlier, but it seems to have disappeared into the void. ¯\_(ツ)_/¯