### PR TITLE
TextToTalk v1.31.1

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,13 +1,12 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "de63a703c3b6296c01fd474200220c77dfbc3cca"
+commit = "471de21fcebeff79e1fabbc117da70b68f1837dd"
 project_path = "src/TextToTalk"
 owners = ["karashiiro"]
 changelog = """\
-- **General**: Updates for latest Dalamud API
-- **General**: Reduces internal plugin log level for most TTS events
-- **General**: Potential fix for rare and unreproducible crash when reading from dialogue windows (please DM me logs if this happens to you!)
-- **WebSocket**: Fixes configuration errors only showing up in the UI for one frame
-- **WebSocket**: Potential fix for speaker gender always being "None" for some plugin users
-- **OpenAI**: Updated supported voice list
+- **General**: Possible fix for crashes when reading the dialogue window
+- **OpenAI**: Fixed TTS not respecting model choice for OpenAI
+- **OpenAI**: Added support for gpt-4o-mini-tts, including new voices and support for instructions
+
+Thanks to PassiveModding for all of the OpenAI-related improvements!
 """


### PR DESCRIPTION
- **General**: Possible fix for crashes when reading the dialogue window
- **OpenAI**: Fixed TTS not respecting model choice for OpenAI
- **OpenAI**: Added support for gpt-4o-mini-tts, including new voices and support for instructions

Thanks to PassiveModding for all of the OpenAI-related improvements!