### PR TITLE
GatherBuddy 3.6.1.0

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "dd13b3b017b74aec1a67b88d55b6f640bb78d72b"
+commit = "c7802d90629c7a71f3dbdc1fd638d620fba4043e"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Added some handling for Lure timings to make records that are supposedly unaffected by Lures populate the timing tables, and show the duration in which you can not catch fish due to the lure cast. (thanks Keagdo!)
- Updated 7.2 fish info (thanks Caduceator!)