### PR TITLE
PennyPincher 1.8.0.5

### DIFF
--- a/stable/PennyPincher/manifest.toml
+++ b/stable/PennyPincher/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/tesu/PennyPincher.git"
-commit = "1c11275fc162e776b19e48a05810a0870990beda"
+commit = "1ca900389b4392557532aa612b5e879d6b1b4fe4"
 owners = [
     "tesu",
 ]
-changelog = "API 12"
+changelog = "Avoid network packet processing bug"


### PR DESCRIPTION
* stop using network packet processing because it's bugged (thanks @nebel)
* minor bugfix to stop copy garbage value upon `Please wait and try your search again` error