### PR TITLE
Mappy v3.1.1.3

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "6a4df9708ac83e99883f95c4fec8fac1f774af65"
+commit = "054513e0ba60ae8f69ec6b8fb27c2299be8ad1bc"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Remove "Ignore Escape Key" setting, instead respects the vanilla map's lock setting.

You may need to disable Mappy temporarily to change this setting in the vanilla map window.
(Sorry I don't know a good way to toggle that setting via code, this is the best I can do right now.)