### PR TITLE
OfDungeonsDeep v1.0.4.3

### DIFF
--- a/stable/OfDungeonsDeep/manifest.toml
+++ b/stable/OfDungeonsDeep/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/NotNite/OfDungeonsDeep.git"
-commit = "086debc8f56aa751195fb1840e6c34b16a44740a"
+commit = "da98688e334d4852ce3cd7cb7f43a0bb60ceb26c"
 owners = ["NotNite", "MidoriKami", "MKhayle"]
 project_path = "OfDungeonsDeep"
 changelog = """
-- API 12 update
+- Data update (thanks compendium)
+- Fixed an issue with EO's boss data on floor 30 and 40 not being displayed (thanks Seitoun for the report)
 """


### PR DESCRIPTION
- Data update (thanks compendium)
- Fixed an issue with EO's boss data on floor 30 and 40 not being displayed (thanks Seitoun for the report)