### PR TITLE
Pet Nicknames v2.4.0.3 (Shame.... again)

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "9231761f09ce9d7e5f38fbbfb6154f3b9cc8c0d5"
+commit = "ab9f0c8a77564e22765c185d128417db2adacbb9"
 owners = ["Glyceri"]
 	changelog = """
-[2.4.0.2] 
-- Tentative fix for afk lag issue. (I'm quite confident this is the actual fix).
+[2.4.0.3] 
+- Fixes 2749273439827 bugs that have to do with database entries not existing anymore.
 """


### PR DESCRIPTION
- Fixes 2749273439827 bugs that have to do with database entries not existing anymore.