### PR TITLE
Honorific 1.6.0.0

### DIFF
--- a/stable/Honorific/manifest.toml
+++ b/stable/Honorific/manifest.toml
@@ -1,4 +1,4 @@
 [plugin]
 repository = "https://github.com/Caraxi/Honorific.git"
 owners = [ "Caraxi" ]
-commit = "7fe995c326424562e22515e225965c4b60f87058"
+commit = "b0dc7a0cf328ec458c84f70b86da695f56a04e42"


### PR DESCRIPTION
Added *Custom Identity* system
- Users can choose another configured character to get titles from
- This will, of course, not change the name of the character, just which list of titles the character uses
- `/honorific identity set Name | Server` to change
- `/honorific identity reset` to reset to original character
- Right click a character in the honorific config window and select **`Identity as`**