### PR TITLE
[Testing] BisBuddy v0.1.4.0

### DIFF
--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "dbcd8e63955f7f0c4503460fa9cf26e254e36562"
+commit = "942b4ab461e734039fcda423f96577688e68289e"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
+**Added**
+- Add (optional) feature to highlight a gearpiece's materia to meldable prerequisite items
+- Add (optional) feature to not highlight materia for gearpieces not yet collected
 **Fixes**
-- Fix issue where auto inventory updates wasn't working
-- Fix issue where highlights would stay visible while melding window wasn't visible while melding
+- Fix issue where recent coffer prerequisites wouldn't populate when game language is not english
 """


### PR DESCRIPTION
**Added**
- Add (optional) feature to highlight a gearpiece's materia to meldable prerequisite items
- Add (optional) feature to not highlight materia for gearpieces not yet collected
**Fixes**
- Fix issue where recent coffer prerequisites wouldn't populate when game language is not english