### PR TITLE
Allagan Market 1.1.0.9

### DIFF
--- a/stable/AllaganMarket/manifest.toml
+++ b/stable/AllaganMarket/manifest.toml
@@ -1,12 +1,17 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/AllaganMarket.git"
-commit = "a7f1eefb1276f19a8c927acbe313e3520095f637"
+commit = "0fb994d717a2c2ae4d283356920be83e72190f36"
 owners = [
     "Critical-Impact",
 ]
 project_path = "AllaganMarket"
-version = "1.1.0.8"
+version = "1.1.0.9"
 changelog = """\
- - Fixed an issue with universalis dates not being converted into the user's time which would make them newer/older than they should be(unless you were in UTC)
- - Moved "Sourced From" into tooltip icon
+**Added**
+ - Undercut fallback setting added, this allows you to ignore NQ/HQ pricing if there are no listings available for NQ/HQ
+
+**Fixes**
+ - When listing an item and the only listings were your own, it was possible for the cache to not update(making all the listings still list as stale)
+ - When listing an item for the first and the only listings were your own the cache was not getting updated
+
 """


### PR DESCRIPTION
**Added**
 - Undercut fallback setting added, this allows you to ignore NQ/HQ pricing if there are no listings available for NQ/HQ

**Fixes**
 - When listing an item and the only listings were your own, it was possible for the cache to not update(making all the listings still list as stale)
 - When listing an item for the first and the only listings were your own the cache was not getting updated