### PR TITLE
BisBuddy v0.1.4.1

### DIFF
--- a/stable/BisBuddy/manifest.toml
+++ b/stable/BisBuddy/manifest.toml
@@ -1,9 +1,16 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "c1420389259f8685f66c849d14126ae59717c968"
+commit = "e4178094ccead47677df84de4bd066233c462d7f"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
-**Hotfix**
- - Temporarily partially disable materia attach highlighting while investigating crashing
+**Added**
+ - v0.1.2.0: Will attempt to highlight marketboard results needed to purchase
+ - v0.1.2.0: Item names in UI will now change with game language changes
+ - v0.1.2.0: Reduce size of exported gearset JSONs
+ - v0.1.4.1: Add (optional) feature to highlight a gearpiece's materia to meldable prerequisite items
+ - v0.1.4.1: Add (optional) feature to not highlight materia for gearpieces not yet collected
+**Fixes**
+ - v0.1.2.0 + v0.1.3.0: Rewrite to UI interfacing and backend to (hopefully) fix crashes
+ - v0.1.2.0 + v0.1.4.0: Fix new coffers not being highlighted or showing up as prerequisites
 """


### PR DESCRIPTION
Bring stable up to testing version. No changes from testing, below is changelog from v0.1.1.4

**Added**
 - v0.1.2.0: Will attempt to highlight marketboard results needed to purchase
 - v0.1.2.0: Item names in UI will now change with game language changes
 - v0.1.2.0: Reduce size of exported gearset JSONs
 - v0.1.4.1: Add (optional) feature to highlight a gearpiece's materia to meldable prerequisite items
 - v0.1.4.1: Add (optional) feature to not highlight materia for gearpieces not yet collected

**Fixes**
 - v0.1.2.0 + v0.1.3.0: Rewrite to UI interfacing and backend to (hopefully) fix crashes
 - v0.1.2.0 + v0.1.4.0: Fix new coffers not being highlighted or showing up as prerequisites

