### PR TITLE
Tracky 1.5.9.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "758f6407baa5885baa6f6b57fa56949ae75a0e4b"
+commit = "98db2864c3f779fc6c504acb9a7b0fc556346c68"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Add loot uploads
  - Supports all kind of duties, alliances, trials ......
  - Does not work for solo clears
  - This is a test run, so only uploaded and not stored locally yet
- Add current desynth level to each upload for finding rare materials