### PR TITLE
MacroMate 1.0.23.0

### DIFF
--- a/stable/MacroMate/manifest.toml
+++ b/stable/MacroMate/manifest.toml
@@ -1,11 +1,11 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "6cdcda460039fc799e300d1bd9115fcfba85ab9e"
+commit = "5b9e377dda18553cf12637a28f4fceab891ecc7d" 
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.22.0"
+version = "1.0.23.0"
 changelog = """
-- Add 'Player Status' condition (Well Fed / Medicated)
-- Fix issue when loading obsolete Player Conditions
-- Fix issue where Player Conditions would show using an old name
+- Add 'World' condition (DC/World)
+- Fix game crash when using Macro Chain + Run from Macro Mate UI (thanks mokocup!)
+- Fix corrupt macro line writing - may fix the other Macro Chain issue (thanks Haselnussbomber!)
 """


### PR DESCRIPTION
- Add 'World' condition (DC/World)
- Fix game crash when using Macro Chain + Run from Macro Mate UI (thanks mokocup!)
- Fix corrupt macro line writing - may fix the other Macro Chain issue (thanks Haselnussbomber!)