### PR TITLE
MacroMate 1.0.24.0

### DIFF
--- a/stable/MacroMate/manifest.toml
+++ b/stable/MacroMate/manifest.toml
@@ -1,9 +1,19 @@
 [plugin]
 repository = "https://github.com/grittyfrog/MacroMate.git"
-commit = "ac5fe5b3d52dde8ca5f8331bad3bb76268de7d0e" 
+commit = "29ba922ac0fdae572a0ac6c288318add9fee430b" 
 owners = ["grittyfrog"]
 project_path = "MacroMate"
-version = "1.0.23.1"
+version = "1.0.24.0"
 changelog = """
-- Add 'Use Macro Chain By Default' setting (for new macros)
+Rewritten Edit Mode / Bulk Edit.
+
+Bulk edits are now done via a list of actions, supported actions are:
+
+- Set Icon
+- Set Link
+- Set 'Use Macro Chain'
+- Set 'Always Linked'
+- Add Condition
+- Remove Condition
+- Remove All Conditions
 """


### PR DESCRIPTION
Rewritten Edit Mode / Bulk Edit.

Bulk edits are now done via a list of actions, supported actions are:

- Set Icon
- Set Link
- Set 'Use Macro Chain'
- Set 'Always Linked'
- Add Condition
- Remove Condition
- Remove All Conditions