### PR TITLE
NextUIPlugin v11.1.5.0 - Fixed crash in case of microplugin download error

### DIFF
--- a/stable/NextUIPlugin/manifest.toml
+++ b/stable/NextUIPlugin/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://gitlab.com/kaminariss/nextui-plugin.git"
-commit = "b17a6a6424dd3b4ff5876636128f4d38ae5f44c1"
+commit = "26020ae530862f9280b27aa220388037bd4cee63"
 owners = ["Kaminaris", "pwilkowski"]
 project_path = "NextUIPlugin"
-changelog = """Fixed linux permissions issue
+changelog = """Fixed crash in case of microplugin download error
+Fixed linux permissions issue
 Updated for patch 7.2 and new api
 Updated for patch 7.15
 Updated for patch 7 - pid and path fix


### PR DESCRIPTION
Fixed crash in case of microplugin download error

Also turns out gitlab overrides all pages files so it stops working after each release, fixed that in update script so versions stay consistent.