### PR TITLE
Mappy v3.1.5.0

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "31da9fa81366bcc811c3812deac5cf8dae070625"
+commit = "ea560d4a3dbf1f96b8bf306ed840e60e39b1a328"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Adds Fog of War to obscure parts of the map you don't have unlocked yet.

It looks a bit blotchy, I did the best I can.

On by default for now, toggleable in the settings.