### PR TITLE
Mappy v3.1.5.1

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "ea560d4a3dbf1f96b8bf306ed840e60e39b1a328"
+commit = "132f447f82d6d493986d8759e71dfe0eac14d418"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Significantly improve fog of war quality, and improve performance.

Potentially fix red alerts from showing when they shouldn't.