### PR TITLE
AbilityAnts 1.0.0.5

### DIFF
--- a/stable/AbilityAnts/manifest.toml
+++ b/stable/AbilityAnts/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/Zeffuro/AbilityAntsPlugin.git"
 
 # The commit to check out and build from the repository.
-commit = "a8802a6c98bb30fabd434f351e95be8f47d245f1"
+commit = "be101108372b1106de5988d338a5fd788e104033"
 
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
@@ -15,5 +15,6 @@ project_path = "AbilityAntsPlugin"
 
 # The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
 changelog = """\
-		Update to API12
+		#1.0.0.5
+		Add support for abilities that are also available without a job crystal (for example: Lance Charge, Life Surge for Dragoon | Mug and Trick Attack on Ninja) 
 		"""


### PR DESCRIPTION
# 1.0.0.5
Add support for abilities that are also available without a job crystal (for example: Lance Charge, Life Surge for Dragoon | Mug and Trick Attack on Ninja) 