### PR TITLE
Glamaholic 1.10.15

### DIFF
--- a/stable/Glamaholic/manifest.toml
+++ b/stable/Glamaholic/manifest.toml
@@ -1,9 +1,12 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = 'cfd25e91c7836e5baa1eb2c029ad9293833085f0'
+commit = 'a5022b97607a0805993432a960e042a0f7f9efda'
 owners = [ 'caitlyn-gg' ]
 changelog = """
-- Updated for API 12
+- Fixed an issue where Neon Green dye was not importing from Eorez Collection
+- Fixed plate filters (job, level, etc.) not working correctly
+- Minor optimisation to timed message display (thanks @nebel)
+- Added left-click to copy item names in the Glamaholic plate view
 
 For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!
 """


### PR DESCRIPTION
- Fixed an issue where Neon Green dye was not importing from Eorez Collection
- Fixed plate filters (job, level, etc.) not working correctly
- Minor optimisation to timed message display (thanks @nebel)
- Added left-click to copy item names in the Glamaholic plate view

For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!