### PR TITLE
Update The Great Controller HUD Switcher to 1.2

### DIFF
--- a/stable/XIVControllerToggle/manifest.toml
+++ b/stable/XIVControllerToggle/manifest.toml
@@ -1,26 +1,29 @@
   [plugin]
   repository = "https://github.com/CallumCarmicheal/XIVControllerToggle.git"
-  commit = "1a98c9e841806d0ff14598a5fd88e0b4c9359ca4"
+  commit = "b40d8e26989b03954096d2cc45618474eb19bb34"
   owners = ["CallumCarmicheal", "Aida-Enna"]
   project_path = ""
   changelog = """
-  # The Great Controller Hud Switcher 1.1
+  # The Great Controller HUD Switcher 1.2
+  - Added UI Scaling option to change scaling when swapping between KBM / PAD.
+
+  # The Great Controller HUD Switcher 1.1
   - Updated to DT 7.2
   - Added collection enabling / disabling upon switching
 
-  # The Great Controller Hud Switcher 1.0.1.3
+  # The Great Controller HUD Switcher 1.0.1.3
   - Updated to DT 7.1
   - Added hide chat on switch when changing hud layout
 
-  # The Great Controller Hud Switcher 1.0.1.2
+  # The Great Controller HUD Switcher 1.0.1.2
   - Fixed issue with configuration UI not changing HUD selection
 
-  # The Great Controller Hud Switcher 1.0.1.1
+  # The Great Controller HUD Switcher 1.0.1.1
   - Updated to Dawntrial (7.X) by Aida-Enna
 
-  # The Great Controller Hud Switcher 1.0.1.0
+  # The Great Controller HUD Switcher 1.0.1.0
   - Attempted to fix display scaling on larger DPI monitors
   - Fixed issue where main plugin command was registered twice
   
-  # The Great Controller Hud Switcher 1.0.0.0
+  # The Great Controller HUD Switcher 1.0.0.0
   - Made it work(tm)"""


### PR DESCRIPTION
Update XIVController to 1.2

- Added an option to change the UI scaling amount.
![image](https://github.com/user-attachments/assets/b84c5afb-9dfe-4f50-a614-ea43d45953f8)
