### PR TITLE
Wholist v1.9.5.0

### DIFF
--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "d9497580d565d92be0ca8bdd5a891bde19806832"
+commit = "3c8f57ef8df4033572a1a9939ca40fd6c2af0cc9"
 owners = [
     "Blooym",
 ]

--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "28ee6c4a02093452c6b55f386ebf2b464d6d2f30"
+commit = "d9497580d565d92be0ca8bdd5a891bde19806832"
 owners = [
     "Blooym",
 ]

--- a/stable/Wholist/manifest.toml
+++ b/stable/Wholist/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Wholist.git"
-commit = "a3e15148e13f748ebbf59cd58f7d3e8758e08aa2"
+commit = "28ee6c4a02093452c6b55f386ebf2b464d6d2f30"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
nofranz

This version adds support for highlighting MareSync pairs in the players list. All functionality relating to this is only shown to the user if they have Mare installed and IPC is available, otherwise there is nothing detailing this feature exists.