### PR TITLE
[Testing] BisBuddy v0.1.5.0

### DIFF
--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,10 +1,16 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "e4178094ccead47677df84de4bd066233c462d7f"
+commit = "faf870bca70b2f358f338f6dbbde39090f5bdfcf"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
+**Added**
+ - Gearsets can now have unique highlight colors
+ - Refresh config menu visuals and rearrange setting locations
+ - Add "Bright List Items" toggle under General Settings to allow for more transparent list highlights.
 **Fixes**
-- Fix erroneous explanation in uncollected item materia help text
-- Fix prerequisite item melds not being recorded
+ - Fix an issue with some item name parsing in other languages
+ - Fix an issue with shop node highlights not disappearing when the list shortens
+ - Fix an issue with custom UIs where the list highlight isn't transparent ("Bright List Items")
+ - Fix an issue with custom UIs where the list highlight texture is wrong
 """


### PR DESCRIPTION
**Added**
 - Gearsets can now have unique highlight colors
 - Refresh config menu visuals and rearrange setting locations
 - Add "Bright List Items" toggle under General Settings to allow for more transparent list highlights.

**Fixes**
 - Fix an issue with some item name parsing in other languages
 - Fix an issue with shop node highlights not disappearing when the list shortens
 - Fix an issue with custom UIs where the list highlight isn't transparent ("Bright List Items")
 - Fix an issue with custom UIs where the list highlight texture is wrong