### PR TITLE
SettingsEnhanced 0.1.3.2

### DIFF
--- a/testing/live/SettingsEnhanced/manifest.toml
+++ b/testing/live/SettingsEnhanced/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/Blooym/Dalamud.SettingsEnhanced.git"
 owners = [ "Blooym" ]
 project_path = "SettingsEnhanced"
-commit = "309952006988b9460f7cb6978df1ab3516c393de"
+commit = "f40d7523b6bb013a4a3420cd136aae2ee567e66d"


### PR DESCRIPTION
nofranz

Temporarily disables character configuration overwrites while I work on a fix for cases where the plugin reads values too early on login leading to some settings being temporarily applied incorrectly until zone change or plugin reload.