### PR TITLE
GatherBuddy 3.8.0.0

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "ea19e85d4ba1a9ee41413de7eb7a37f269b862e4"
+commit = "31dcb0d0b0b4182477f1267d5c16c8dabc997799"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Added a lot of improvements and data updates, mostly done by keagdo, thanks!
- Better support for Cosmic Exploration
- Option to display fishing timestamps in local time.
- Option to display non-integral seconds up to accuracy in the bottom row of the fish timer window.
- Fixed some bugs with the recorded hookset.
- Added some known data for double/triple hooks and point values for fish.
- Added a flag for legendary fish.
- Updated the filter selection for fish status flags in records and added Large Fish to it.
- Added a very WIP and disabled-by-default tab to display Fishing Spot statistics, keagdo is working on this. It can already be used to export reports for sports.