### PR TITLE
Goodfriend v3.5.0.0

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/GoodFriend.git"
-commit = "5f9261585043464bf82f0c8caada7587104ddfce"
+commit = "26dd9df738d036530d080ed4d335789082f94291"
 owners = [
     "Blooym",
 ]

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/Blooym/GoodFriend.git"
-commit = "ae5ac1654eddfd857e1282a58b944d1ccc4438d1"
+commit = "c55bb3b28c16d202b976adb67800ebfce59ecabc"
 owners = [
     "Blooym",
 ]
 project_path = "src/Plugin"
 
 [plugin.secrets]
-CLIENT_KEY = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdA7ZPmK0Ae203/dRAc/h83SB4WgBiGE/glMx2rmgXz\nj2cw5HafQU8mVXMJI+W3SIcKUYyB/Wsvxz4cumWvVb1Yr28cARVGi5FTfBub\nKEwhCV110pUBeCs6Zl1tUE5CDAQHE30BbHHUhbXSqRLilDwhX2gJyYB3DfI/\ne82ASXADE4jtTyQMlla4/GPyyzIGlIvTxziqt5VeZ4gnGJOPKbXTEeFD7aC9\nHwWhMDfFS1QY2/JON0JahJUO899hfDyjkbXVTCSidYWZMirjl3R+mBA13Uh0\ndtZUWovl1Ix0jKLRDbeadQy1wOmf1A==\n=1XVS\n-----END PGP MESSAGE-----\n"
+CLIENT_KEY = '-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAlS2I4ng4acFrB2CRoZfA0tKCehTrafjby7rjKhar\nnkMw82kGD7dPfUvht3dfExovec4caW/OyQAgVNyFvcTHFFohEkNYp5mDq2D3\niY4XMT7y0nEBEPRiAip1XVF23WFLwuPWUYsuXqZ7RrdfBDmbN0XeuImEckp8\naYeW3W83jlugK1J1OjkJiSGYAgbzEcjgUzHnBwerIMMBK1gAG4rxg5xL2mzB\n+lDnyAR6gBKo/9WxWjsypqFyMQAWw4nnJej6+HkltA==\n=MHrQ\n-----END PGP MESSAGE-----\n'

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/GoodFriend.git"
-commit = "c55bb3b28c16d202b976adb67800ebfce59ecabc"
+commit = "2bee50a99f4cf33c7fa70dd756aa4a0710fa86f6"
 owners = [
     "Blooym",
 ]

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -7,4 +7,4 @@ owners = [
 project_path = "src/Plugin"
 
 [plugin.secrets]
-CLIENT_KEY = '-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAlS2I4ng4acFrB2CRoZfA0tKCehTrafjby7rjKhar\nnkMw82kGD7dPfUvht3dfExovec4caW/OyQAgVNyFvcTHFFohEkNYp5mDq2D3\niY4XMT7y0nEBEPRiAip1XVF23WFLwuPWUYsuXqZ7RrdfBDmbN0XeuImEckp8\naYeW3W83jlugK1J1OjkJiSGYAgbzEcjgUzHnBwerIMMBK1gAG4rxg5xL2mzB\n+lDnyAR6gBKo/9WxWjsypqFyMQAWw4nnJej6+HkltA==\n=MHrQ\n-----END PGP MESSAGE-----\n'
+CLIENT_KEY = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdA8VKHN+sZChTGlmKqrkibgVSEfTZMhFje6W/OnrzH\nECUwOAHZBRv1Fh7hk9savI1t6r09LQsIAnsfBrpvtgoSFnm2gMvX0V6+iP4p\nYawBUZsR0nEBgn2Dx+8Rwr1tDZiAH8BCfH5TZeVV9DaIV3wlx8qb9GrW69+j\nDx+Lg5vcbP3N+0R+XRDszJOSn9q+WuWtD5Q7oBf9aDp4mVMjqrLqOxk2mjCy\nfitsi41QsRlJ/tExg0bWsd0Xt+qPvhk0nmWMf1Zxgg==\n=3Nyi\n-----END PGP MESSAGE-----\n"

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/GoodFriend.git"
-commit = "2bee50a99f4cf33c7fa70dd756aa4a0710fa86f6"
+commit = "5f9261585043464bf82f0c8caada7587104ddfce"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
Updated for Dawntrail with a first-pass cleanup on top.

## Developers note on using this plugin after 7.0
As of Patch 7.0, some of the data that GoodFriend uses to identify players during login/logout events is now visible to anyone nearby your character in-game (not just your friends or party members). GoodFriend itself will still only show notifications for people you've added to your in-game friends list - however, please use this plugin only if you're comfortable with your login/logout activity being theoretically visible to nearby players (note: GoodFriend never sends data for users who don't have the plugin installed).

If you ever want to stop sending login/logout events, simply disable or uninstall the plugin. The server does not store any data about you.

**For added privacy, you can now set a 'group key' in the plugin settings**. This allows events to be shared only with people using the same key (for example, everyone in your raid group). When a group key is active, your events are never visible to anyone outside your group no matter what.