### PR TITLE
Pet Nicknames v2.4.0.5

### DIFF
--- a/stable/PetRenamer/manifest.toml
+++ b/stable/PetRenamer/manifest.toml
@@ -1,10 +1,8 @@
 [plugin]
 repository = "https://github.com/Glyceri/FFXIVPetRenamer.git"
-commit = "affcc108ac10e25dfe55af2ea2e82bf2ff8f8f74"
+commit = "d5bd0c355b7679a3fbb69e5b9abbe32460babe36"
 owners = ["Glyceri"]
 	changelog = """
-[2.4.0.4] 
-- Fixes Crashes on the staging branch. (Genuinely only 50% my fault this time c:)
-
-(Please restart your game for Pet Nicknames to function again).
+[2.4.0.5] 
+- Disabled the IPC watcher temporarily was it was causing many bugs.
 """


### PR DESCRIPTION
Disabled the IPC watcher temporarily because it was causing many bugs.