### PR TITLE
Better Mount Roulette 1.7.2.27

### DIFF
--- a/stable/BetterMountRoulette/manifest.toml
+++ b/stable/BetterMountRoulette/manifest.toml
@@ -1,6 +1,8 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "7fe6538480358c0d9113def55c7f8a1798c91b97"
-version = "1.7.1.26"
+commit = "c001c27fd8e2fd9c7849ce8b00c4d3067b606fbd"
+version = "1.7.2.27"
 owners = ["CMDRNuffin"]
-changelog = """Bugfix: remove error spam in log after closing any plugin window."""
+changelog = """Bugfix:
+- Properly update action list upon enabling and disabling the flying mount roulette action
+- Removed a racing condition that would very rarely crash the game on boot"""


### PR DESCRIPTION
Bugfix:
- Properly update action list upon enabling and disabling the flying mount roulette action
- Removed a racing condition that would very rarely crash the game on boot
