### PR TITLE
Allagan Tools 1.12.0.9

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,17 +1,21 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "5954cb182fad5ab786d6423877cc0e177a77c24a"
+commit = "739d510faba8d0ce3ed329f14f2fb3e2918d0992"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.12.0.8"
+version = "1.12.0.9"
 changelog = """\
-### Added
-- Custom Button and Custom Link Button columns added
-- Troubleshooting section allowing you to tweak the acquisition tracker's timings
-- Holding down CTRL and scrolling while viewing a grouped source will let you scroll through each tooltip
+### Changed
+- Collectable items are now supported in craft lists
+- Retainer Retrieval can now be configured to only show NQ/Collectable items
+- The acquisition tracker now counts collectables when crafted
 
 ### Fixed
-- Improvements to the acquisition tracker
+- The market pricing column was not updating for items that were not specifically set to be bought off the market
+
+### Added
+- Added Is Collectable filter/column
+- Added Can Be HQ filter/column
 """


### PR DESCRIPTION
### Changed
- Collectable items are now supported in craft lists
- Retainer Retrieval can now be configured to only show NQ/Collectable items
- The acquisition tracker now counts collectables when crafted

### Fixed
- The market pricing column was not updating for items that were not specifically set to be bought off the market

### Added
- Added Is Collectable filter/column
- Added Can Be HQ filter/column