### PR TITLE
[Testing] Umbra 3.0.5

### DIFF
--- a/testing/live/Umbra/manifest.toml
+++ b/testing/live/Umbra/manifest.toml
@@ -1,24 +1,17 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "922a2ba4423ece78afda439ef5642af9bf53c211"
+commit = "db5617448d3b28b1dae8e56cbbf6eb81fb974a30"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 3.0.4 (Testing)
-
-## New Additions
-
-- Added a settings & shutdown/logout button to the Unified Main Menu (for that extra Windows XP flavour)
+# Umbra 3.0.5 (Testing)
 
 ## Fixes & Improvements
 
-- Fixed categories in the Game Icon Picker not showing in the correct language after changing it (by [Haselnussbomber](https://github.com/Haselnussbomber)).
-- Fixed the Ko-Fi support link (by [GayPotatoEmma](https://github.com/GayPotatoEmma)).
-- Fixed the shown Umbra version in the Settings Window (by [Haselnussbomber](https://github.com/Haselnussbomber)).
-- Fixed broken icons in the Game Icon Picker window.
-- Fixed a crash caused by the Volume Widget.
-- Fixed the Grand Company seal cap in the Currencies Widget.
-- Show a crash-logger window when a widget fails to instantiate for easier reporting.
+- Fix missing translation in the tooltip of the unread mail indicator widget (by [GayPotatoEmma](https://github.com/GayPotatoEmma)).
+- Hide completed Aether Current world markers after collecting one.
+- Removed a left-over debug message when toggling auxiliary bars using the `/umbra-aux` chat-command.
+- Added an option to show map names in the condensed layout of the Teleporter Widget.
 
 Join [Umbra's Discord server](https://discord.gg/xaEnsuAhmm) for the latest updates and information.
 Visit the [website](https://una-xiv.github.io/umbra-docs/) for more information and guides on how to make the most out of Umbra.


### PR DESCRIPTION
# Umbra 3.0.5 (Testing)

## Fixes & Improvements

- Fix missing translation in the tooltip of the unread mail indicator widget (by [GayPotatoEmma](https://github.com/GayPotatoEmma)).
- Hide completed Aether Current world markers after collecting one.
- Removed a left-over debug message when toggling auxiliary bars using the `/umbra-aux` chat-command.
- Added an option to show map names in the condensed layout of the Teleporter Widget.