### PR TITLE
[Testing] Racingway v0.1.0.0

### DIFF
--- a/testing/live/Racingway/manifest.toml
+++ b/testing/live/Racingway/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Abyeon/Racingway.git"
-commit = "9fc5089be70e9b4699695d322cf7079e34a8a0bb"
+commit = "8637d69ea672e7d7582dec23713c9023eb9029c2"
 owners = ["Abyeon"]
 project_path = "Racingway"
 changelog = """

--- a/testing/live/Racingway/manifest.toml
+++ b/testing/live/Racingway/manifest.toml
@@ -4,17 +4,21 @@ commit = "9fc5089be70e9b4699695d322cf7079e34a8a0bb"
 owners = ["Abyeon"]
 project_path = "Racingway"
 changelog = """
-v0.0.6.9 [TESTING] - HUGE thanks to TrainerHol
-+ Add toggles for requiring ground checks
-+ Add toggle for timer window buttons
-+ Show trigger type names in dropdown
-+ Created a new Loop trigger type
-  - Loop trigger starts the race when the player exits and ends when they enter again
-+ Added timer buttons for opening main window and clearing lines
-+ Filter fields for:
-  - Date range (start and end dates)
-  - Player name (case-insensitive contains filter)
-  - Time (minimum and maximum in seconds)
-  - Distance (minimum and maximum values)
-+ CSV export uses filtered records
+v0.1.0.0 [TESTING]
++ Add new Gizmo for transforming triggers.
+  + Hold ctrl to edit scale.
++ Cleanup Routes tab
+  + Moved behavior options to dropdown
+  + Trigger settings now get their own scrollbar
+  + Move trigger type dropdown to a popup
+  + Add buttons for moving triggers up/down
+  + Highlight triggers in game when hovered
+  + Add snapping options for gizmo
++ Add loop trigger type info to About tab
++ Add customizable trigger colors
++ Move to ZLinq queries for a marginal performance boost
+
+Fixes:
++ Disallow negative trigger scales to avoid unwanted behavior
++ Fix errors popping up when entering a trigger
 """


### PR DESCRIPTION
v0.1.0.0 [TESTING]
+ Add new Gizmo for transforming triggers.
  + Hold ctrl to edit scale.
+ Cleanup Routes tab
  + Moved behavior options to dropdown
  + Trigger settings now get their own scrollbar
  + Move trigger type dropdown to a popup
  + Add buttons for moving triggers up/down
  + Highlight triggers in game when hovered
  + Add snapping options for gizmo
+ Add loop trigger type info to About tab
+ Add customizable trigger colors
+ Move to ZLinq queries for a marginal performance boost

Fixes:
+ Disallow negative trigger scales to avoid unwanted behavior
+ Fix errors popping up when entering a trigger