### PR TITLE
Mappy v3.1.6.4

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "957630a81df1da5f940e0a189582a6c8b520b450"
+commit = "5c47d32fe038a990247d4ef9c03196351df8c48b"
 owners = ["MidoriKami"]
 project_path = "Mappy"

--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "90c0d5d26caad5e07da3efba6de55606b7c4d48a"
+commit = "957630a81df1da5f940e0a189582a6c8b520b450"
 owners = ["MidoriKami"]
 project_path = "Mappy"


### PR DESCRIPTION
Fix exception in OC when reading tooltips

Add option to show radar in duties (helps to indicate the range at which treasure becomes visible)

Unlock range limit for treasure detection, used to be 50y, now is radar range

Add Center on Marker functionality for Bozja / Eureka / OC event markers such as CE's