### PR TITLE
EurekaLinker 1.5.4.2

### DIFF
--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "48c32e470c81b7ddbdab7f4e3d7c11c78d6b6f03"
+commit = "1294a6030bdc94f99ecb449cf9cc9e8b55a352ec"
 owners = [
     "Infiziert90",
     "electr0sheep",


### PR DESCRIPTION
- Proximity notification can now be enabled/disabled for occult itself
- Show correct marker set on refresh
  - You can switch between 3 sets, one for treasure, one for pot locations and one for bunny carrots 
  - just /el and go to the occult tab