### PR TITLE
GoodFriend v3.7.2.0

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/GoodFriend.git"
-commit = "c2d803858240d9735dbcb183e657eb0698deb66f"
+commit = "0f62e79c874c158212f9fa1b74e6a3947aa06467"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
Events for friends will now show up even while the in-game friends list is unavailable (for example, inside of Occult Crescent)