### PR TITLE
EurekaTracker 1.5.4.8

### DIFF
--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "f0559447469a8959482d3a3791bc1f08dadee583"
+commit = "c7526dd89d418d95b969ccd5464a4829cc78902b"
 owners = [
     "Infiziert90",
     "electr0sheep",


### PR DESCRIPTION
- Add option to show fast switch overlay below the map [default false]
- Add option to place flag marker for fairy, treasure and bunny carrots [default false]
- Make clear memory time configurable [default 60s, min-max 60-600s]
- Fix eureka bunny marker not appearing

Internal:
- Switch to resx loc