### PR TITLE
[Testing] Altoholic v0.0.0.51

### DIFF
--- a/testing/live/Altoholic/manifest.toml
+++ b/testing/live/Altoholic/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "11edc39110d3fc91c1c009e53a1639e27384651f"
+commit = "517c08e282b625d783fc9e4631f87c3c3fa357b5"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\
-- **General**: Add plugin version in titlebar. Migrate way to detect beast tribe/societal relations
-- **Progress**: Add Hildibrand 7.25. Add mamool ja reward up to trusted.
+- **General**: Auto scan collection items every minutes.
+- **Database**: Fix mistake that reset tribes every time the plugin load.
+- **Progress**: Add Mamool'ja's minion reward.
 """


### PR DESCRIPTION
Version 0.0.0.51:

- **General**: Auto scan collection items every minutes.
- **Database**: Fix mistake that reset tribes every time the plugin load.
- **Progress**: Add Mamool'ja's minion reward.