### PR TITLE
DailyDuty v5.3.1.4

### DIFF
--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "c6e93c38335593ac24e1dd2cde680b51e9406058"
+commit = "7e36a37318d15694fcfc3ce3f8a87c7ec005d288"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
Move location of Daily Reset timer in Duty Finder
Improved tooltip when hovering Daily Reset Timer in Duty Finder
Now automatically saves configuration when reloading plugin

Internal system changes, please report any crashes. (There shouldn't be any, but this is why this is a testing release)
