### PR TITLE
Allagan Item Search 1.0.0.5

### DIFF
--- a/stable/AllaganItemSearch/manifest.toml
+++ b/stable/AllaganItemSearch/manifest.toml
@@ -1,11 +1,14 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/AllaganItemSearch.git"
-commit = "514a83c024f0841d9f96ac5e2cffeed246a7fc52"
+commit = "8f66fd402af4cffa323b553af2daaab49d3cabfe"
 owners = [
     "Critical-Impact",
 ]
 project_path = "AllaganItemSearch"
-version = "1.0.0.4"
+version = "1.0.0.5"
 changelog = """\
-- Added filters/sources for battle/company/gathering leves, gardening crossbreeds, quests and triple triad
+-Added hotkey to open main window
+- Added setting to clear search filters when closing the main window
+- Clicking an item with no modifiers held will try to open the More Information window for the item in AT
+- Added sources/use filters for Card Packs, PoTD, HoH, Orthos, Anemos, Pagos, Pyros, Hydatos, Bozja, Logograms, Occult, PvP Series and Collectable Shops
 """

--- a/stable/AllaganItemSearch/manifest.toml
+++ b/stable/AllaganItemSearch/manifest.toml
@@ -7,7 +7,7 @@ owners = [
 project_path = "AllaganItemSearch"
 version = "1.0.0.5"
 changelog = """\
--Added hotkey to open main window
+- Added hotkey to open main window
 - Added setting to clear search filters when closing the main window
 - Clicking an item with no modifiers held will try to open the More Information window for the item in AT
 - Added sources/use filters for Card Packs, PoTD, HoH, Orthos, Anemos, Pagos, Pyros, Hydatos, Bozja, Logograms, Occult, PvP Series and Collectable Shops


### PR DESCRIPTION
- Added hotkey to open main window
- Added setting to clear search filters when closing the main window
- Clicking an item with no modifiers held will try to open the More Information window for the item in AT
- Added sources/use filters for Card Packs, PoTD, HoH, Orthos, Anemos, Pagos, Pyros, Hydatos, Bozja, Logograms, Occult, PvP Series and Collectable Shops