### PR TITLE
EurekaLinker 1.5.6.0

### DIFF
--- a/stable/EurekaTrackerAutoPopper/manifest.toml
+++ b/stable/EurekaTrackerAutoPopper/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/EurekaTrackerAutoPopper.git"
-commit = "8cf2ec249d1e849d03a1b1f2a82d5b4666e93c2e"
+commit = "b23115d1cf76d1af1eed387d48bdaf8a0c071179"
 owners = [
     "Infiziert90",
     "electr0sheep",


### PR DESCRIPTION
[New]
- CE/Forked Tower tracker with shared history
  - Uploads anonymized data about your current instance [Opt-Out, Chat Warning]
  - May take 1-2 FATEs before tracking history appears
  - /eloccult -> Tracker, to see the history of your instance
  - Results are automatically feed into "Engagements" and "Forked Tower" tabs
  - **Work in Progress**, may fail to produce correct data
  - Feedback welcome

[Fixes]
- Start pot fate timer correctly

[Loc]
- Update french loc, thanks humbibi

