### PR TITLE
[Testing] Umbra 3.0.8

### DIFF
--- a/testing/live/Umbra/manifest.toml
+++ b/testing/live/Umbra/manifest.toml
@@ -1,25 +1,15 @@
 [plugin]
 repository = "https://github.com/una-xiv/umbra.git"
-commit = "d554ae93718143144593110a1e33dcb0e1e89205"
+commit = "b1956ddaf0a2640de174ffdc790a561bf26d2e63"
 owners = ["haroldiedema"]
 project_path = "Umbra"
 changelog = """
-# Umbra 3.0.7 (Testing)
-
-## New additions
-
-- Added a script system for dynamic button labels, allowing for placeholders in custom button labels in widgets.
-- Added phantom job icons to the Game Icon Picker window.
+# Umbra 3.0.8 (Testing)
 
 ## Fixes & Improvements
 
-- Fixed popup flyout position on vertically aligned auxiliary bars.
-- Fixed a missing tooltip translation on the Import button of widgets (by [GayPotatoEmma](https://github.com/GayPotatoEmma)).
-- Fixed an issue where treasure world markers would remain visible after opening them.
-- Slight improvements in performance in the Dynamic & Collection button widgets.
-- Increased the URL character limit from 100 to 4096 characters in DynamicMenu entries.
-- Currencies Widget: Use overflow color in the progress bar when a currency is capped.
-- Currencies Widget: Use the weekly caps instead of global ones for the limited tomestones.
+- Fixed a crash when opening the Volume Widget after logging out and back in.
+- Added a "Disable Custom Plugins" button to the crash report dialog. Note that you still need to manually reload Umbra via Dalamud's plugins window.
 
 ---
 


### PR DESCRIPTION
# Umbra 3.0.8 (Testing)

## Fixes & Improvements

- Fixed a crash when opening the Volume Widget after logging out and back in.
- Added a "Disable Custom Plugins" button to the crash report dialog. Note that you still need to manually reload Umbra via Dalamud's plugins window.
