### PR TITLE
[Testing] TextToTalk v1.32.0

### DIFF
--- a/testing/live/TextToTalk/manifest.toml
+++ b/testing/live/TextToTalk/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "539246385d73480d15a48defd45ce86876cc7079"
+commit = "f1b1b2efe80f68d96c4e416a1aca711cda1feca3"
 project_path = "src/TextToTalk"
 owners = ["karashiiro"]
 changelog = """\

--- a/testing/live/TextToTalk/manifest.toml
+++ b/testing/live/TextToTalk/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "f1b1b2efe80f68d96c4e416a1aca711cda1feca3"
+commit = "95f37c651db6fd8f769c2bc5b338a530580387ac"
 project_path = "src/TextToTalk"
 owners = ["karashiiro"]
 changelog = """\

--- a/testing/live/TextToTalk/manifest.toml
+++ b/testing/live/TextToTalk/manifest.toml
@@ -1,12 +1,12 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "b98853af56a02876022cda6ab3fd3dd0a3c453d5"
+commit = "539246385d73480d15a48defd45ce86876cc7079"
 project_path = "src/TextToTalk"
 owners = ["karashiiro"]
 changelog = """\
-- **General**: Reduces internal plugin log level for most TTS events
-- **General**: Potential fix for rare and unreproducible crash when reading from dialogue windows (please DM me logs if this happens to you!)
-- **WebSocket**: Fixes configuration errors only showing up in the UI for one frame
-- **WebSocket**: Potential fix for speaker gender always being "None" for some plugin users
-- **OpenAI**: Updated supported voice list
+- **Kokoro**: Adds a new Kokoro-based voice backend for high-quality TTS without any API subscriptions or fees. You may encounter performance issues on older hardware - please report any issues you find.
+- **General**: Fixes an error when reading text from certain speakers (e.g. the Research Note after the first boss of Yuweyawata Field Station).
+- **General**: Adds help tooltips on several settings.
+
+Thanks to PhilippNaused for all of the improvements in this release!
 """


### PR DESCRIPTION
- **Kokoro**: Adds a new Kokoro-based voice backend for high-quality TTS without any API subscriptions or fees. You may encounter performance issues on older hardware - please report any issues you find.
- **General**: Fixes an error when reading text from certain speakers (e.g. the Research Note after the first boss of Yuweyawata Field Station).
- **General**: Adds help tooltips on several settings.

Thanks to PhilippNaused for all of the improvements in this release!