### PR TITLE
Add AetherFM plugin to testing/live

### DIFF
--- a/testing/live/AetherFM/manifest.toml
+++ b/testing/live/AetherFM/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/SalvatoreDevelopment/AetherFM.git"
+commit = "45b2bd37b69ad10f2f57b7a51a5274bacc05b006"
+owners = ["SalvatoreDevelopment"]
+project_path = ""
+changelog = "Initial release: listen to radio in FFXIV! Streams online radio stations in-game with a modern UI. No API key required, no usage limits." 


### PR DESCRIPTION
     Plugin Name: AetherFM
     Author: SalvatoreDevelopment

     - In-game radio streaming for FFXIV
     - Uses Radio Browser API for maximum station coverage per country
     - Initial testing release for Dalamud repository

     Repository: https://github.com/SalvatoreDevelopment/AetherFM
     Testing ZIP: https://github.com/SalvatoreDevelopment/AetherFM/releases/download/v1.0.0.0/AetherFM.zip

     Let me know if any changes are needed!