### PR TITLE
[Testing] CustomResolution v0.3.2.0

### DIFF
--- a/testing/live/CustomResolution2782/manifest.toml
+++ b/testing/live/CustomResolution2782/manifest.toml
@@ -1,10 +1,9 @@
 [plugin]
 repository = "https://git.0x0a.de/0x0ade/DP-CustomResolution.git"
-commit = "ada9113b37d41a4e834bdf9b4df19fcf19a46ecd"
+commit = "78ff318397a3917b0c02063756b449a1d2cdc3d1"
 owners = ["0x0ade"]
 project_path = "CustomResolution2782"
 changelog = """
-- Fix mis-sized windowed mode windows on startup.
-- Update to API 12
-- Update offsets for 7.2
+- Improved config window user experience
+- Improved compatibility with Simple Tweaks screenshot tweak
 """


### PR DESCRIPTION
- Improved config window user experience
- Improved compatibility with Simple Tweaks screenshot tweak

Besides that, some smaller internal changes:
- `WM_WINDOWPOSCHANGED` is now logged
- The `/cres debugsizeold` and `/cres debugsizenew` commands now no longer switch between old and new *window size* behaviors (which seems to work well from ongoing testing), but between *device size update behaviors* (tried to fix DLSS, ended up fixing cross plugin compatibility and finding out that DLSS is broken in vanilla XIV).