### PR TITLE
Namingway v1.1.18.0

### DIFF
--- a/stable/Namingway/manifest.toml
+++ b/stable/Namingway/manifest.toml
@@ -1,5 +1,9 @@
 [plugin]
 repository = 'https://github.com/MKhayle/Namingway.git'
-commit = 'fbd153abb62550fefb84d3d79d2422878d77eb7d'
+commit = '0072b3b435d45a14e8e71a52056613a88b2b97ad'
 owners = [ 'anna-is-cute', 'MKhayle' ]
-changelog = 'Fixing status/actions not being displayed in the edit mode if they lack an icon in the game data.'
+changelog = '- Added Occult Crescent actions to the Player Actions filter
+- Added commands (/namingway <enable|disable> <GUID>)
+- Added a GUID field to copy/paste them for macros use
+- Added the ID of actions in the edit window to differentiate actions with the same name
+- Fixed an issue with names not being updated at some times'

--- a/stable/Namingway/manifest.toml
+++ b/stable/Namingway/manifest.toml
@@ -1,9 +1,9 @@
 [plugin]
 repository = 'https://github.com/MKhayle/Namingway.git'
-commit = '0072b3b435d45a14e8e71a52056613a88b2b97ad'
+commit = '609f7b487551f650e3cbbee3ca727059c4881f74'
 owners = [ 'anna-is-cute', 'MKhayle' ]
-changelog = '- Added Occult Crescent actions to the Player Actions filter
-- Added commands (/namingway <enable|disable> <GUID>)
+changelog = """- Added Occult Crescent actions to the Player Actions filter
+- Added commands (/namingway <enable|disable|toggle> <GUID>)
 - Added a GUID field to copy/paste them for macros use
 - Added the ID of actions in the edit window to differentiate actions with the same name
-- Fixed an issue with names not being updated at some times'
+- Fixed an issue with names not being updated at some times"""


### PR DESCRIPTION
- Added Occult Crescent actions to the Player Actions filter
- Added commands (/namingway <enable|disable|toggle> \<GUID\>)
- Added a GUID field to copy/paste them for macros use
- Added the ID of actions in the edit window to differentiate actions with the same name
- Fixed an issue with names not being updated at some times