### PR TITLE
[Testing] CustomResolution v0.4.1.0

### DIFF
--- a/testing/live/CustomResolution2782/manifest.toml
+++ b/testing/live/CustomResolution2782/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://git.0x0a.de/0x0ade/DP-CustomResolution.git"
-commit = "78ff318397a3917b0c02063756b449a1d2cdc3d1"
+commit = "d2d517c43228b3fc14702945701a79728a0b5ce8"
 owners = ["0x0ade"]
 project_path = "CustomResolution2782"
 changelog = """
-- Improved config window user experience
-- Improved compatibility with Simple Tweaks screenshot tweak
+- Implement separate display vs gameplay scaling.
+    - Thanks to NotNite for getting me into the RTM rabbit hole!
+- Fix some hotkey configurations not working properly.
+- Add "Game hang protection" (auto-disable on 1s+ hangs).
 """


### PR DESCRIPTION
Getting close to a v1.0.0.0 release once this survives testing without any huge hiccups!

**v0.4.0.0 changelog:**

- Implement separate display vs gameplay scaling.
    - Thanks to NotNite for getting me into the RTM rabbit hole!
    - This is explained in more detail in-game, but TL;DR:
        - Display scaling is better for high-res screenshots / manual DPI scaling, and affects everything: HUD and gameplay.
        - Gameplay scaling doesn't affect screenshot or HUD resolution, and acts as supersampling AA for gameplay only.
- Fix some hotkey configurations not working properly.
- Add "Game hang protection" (auto-disable on 1s+ hangs).

**v0.4.1.0 changelog:**

- Now featuring even more funny hook stunts to generate mipmaps and add allow for a fully pixelated scaling mode!
    - This improves the feature added in v0.4.0.0, thus it's not listed in the manifest.