### PR TITLE
DailyDuty v5.3.1.9

### DIFF
--- a/testing/live/DailyDuty/manifest.toml
+++ b/testing/live/DailyDuty/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/DailyDuty.git"
-commit = "964c98e8389ebde65b023c28f1185ac2e2dc751a"
+commit = "591bef94d4460f85e7f6bed102ee329ec81e6240"
 owners = ["MidoriKami"]
 project_path = "DailyDuty"


### PR DESCRIPTION
Add Timer Node, Simple Mode Option, for setting module name alignment, old configs use a different alignment value, this will let you change it more easily. Recommended alignment is "Left"