### PR TITLE
CurrencyAlert v2.2.2.1

### DIFF
--- a/stable/CurrencyAlert/manifest.toml
+++ b/stable/CurrencyAlert/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/CurrencyAlert.git"
-commit = "debfa37cdec71ca8a8a037771f89c7154f60c724"
+commit = "2147cdd9f5bac4e9906939592088e9f78ffb8e5c"
 owners = [ "MidoriKami" ]
 project_path = "CurrencyAlert"


### PR DESCRIPTION
Fix warnings being invisible

Fixes the list not being able to be toggled off when "Hide in Duties" is enabled

Add option to disable main list click-ability/tooltip

It is intentional that the main list is interactable and shows a tooltip on hover. Additionally it is intentional that this update enables the background for the main list. This is so that people who have the overlay enabled don't have an invisible element that is interactable.

For those that like having the list in a corner of your screen and want quick access to the plugins settings this feature is intended for you. 

For those that want the list to be front and center in your face, you can use the "Disable Interactions" option in the settings.