### PR TITLE
SubmarineTracker 1.9.9.10

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "c5817fd346733a4da08e77c34d8f38f34f2c0535"
+commit = "d9575ea54c50077a3f17df23459cd2afd18e5773"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Attempt to fix crash in all tab by limiting table to 1 column minimum