### PR TITLE
NoTankYou v7.2.2.5

### DIFF
--- a/stable/NoTankYou/manifest.toml
+++ b/stable/NoTankYou/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/NoTankYou.git"
-commit = "36fe28e96db2e3039a9101c96eb54fe2eb9cbda1"
+commit = "c652397bcd2226a364f077679776891dec5a3eea"
 owners = ["MidoriKami"]
 project_path = "NoTankYou"


### PR DESCRIPTION
Due to various issues, the PartyListOverlay is being significantly reduced in functionality.
The required tech to make this feature work as desired is not yet ready.

This will reduce the warning to a single image that animates over the job icon, if you mouse over the warning image a tooltip will show you the warning message.

It is intentional that this warning appears *over top* the emnity display.