### PR TITLE
BetterMountRoulette update

### DIFF
--- a/stable/BetterMountRoulette/manifest.toml
+++ b/stable/BetterMountRoulette/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "491501dc49fd857ae2ffb32aeb923475a809a162"
+commit = "5975309d6db1db8f2387b4fa8590f0a003786693"
 version = "1.7.2.27"
 owners = ["CMDRNuffin"]
 changelog = """Update for 7.3

--- a/stable/BetterMountRoulette/manifest.toml
+++ b/stable/BetterMountRoulette/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
-commit = "c001c27fd8e2fd9c7849ce8b00c4d3067b606fbd"
+commit = "491501dc49fd857ae2ffb32aeb923475a809a162"
 version = "1.7.2.27"
 owners = ["CMDRNuffin"]
-changelog = """Bugfix:
-- Properly update action list upon enabling and disabling the flying mount roulette action
-- Removed a racing condition that would very rarely crash the game on boot"""
+changelog = """Update for 7.3
+
+Also adds an option to override mount group size settings for frontline/rival wings."""

--- a/stable/BetterMountRoulette/manifest.toml
+++ b/stable/BetterMountRoulette/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/CMDRNuffin/BetterMountRoulette.git"
 commit = "5975309d6db1db8f2387b4fa8590f0a003786693"
-version = "1.7.2.27"
+version = "1.7.3.28"
 owners = ["CMDRNuffin"]
 changelog = """Update for 7.3
 


### PR DESCRIPTION
Also adds an option to override mount group size settings for frontline/rival wings.
