### PR TITLE
XIVDeck 0.4.0

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "7099405bb42aabf213e4b492337a1dd4f3514c01"
+commit = "a31c7fde556dcc1593c22aa0a16b640e1067fe6f"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
It's time for another maintenance release! I was hoping that 0.4.0 would finally be a version with significantly cleaner and better code, but unfortunately life keeps getting in the way of doing that. My kingdom for free time and motivation...

* Add support for Patch 7.3 and Dalamud API 13
* Change icon loading behavior for hotbars to more properly follow the standard request flow.
  * NOTE: This is an API breaking change. Users will need to update both sides of the plugin.
* Minor code cleanup.


Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.4.0).