### PR TITLE
[Testing] Racingway v0.1.1.2

### DIFF
--- a/testing/live/Racingway/manifest.toml
+++ b/testing/live/Racingway/manifest.toml
@@ -1,12 +1,10 @@
 [plugin]
 repository = "https://github.com/Abyeon/Racingway.git"
-commit = "fa110bf3f589c4d1286169d88ab02640462c033f"
+commit = "abb83e7a858febce550215dba7e325be7db40813"
 owners = ["Abyeon"]
 project_path = "Racingway"
 changelog = """
-v0.1.1.1 [TESTING]
-+ Added laps
-+ Slight adjustments to wording
-+ Fixed splits not being cleared when hitting a fail
-- Removed the Line Quality setting
+v0.1.1.2 [TESTING]
++ Version bump for API 13
 """
+


### PR DESCRIPTION
Version bump for API 13. Removed unnecessary references.