### PR TITLE
WondrousTailsSolver 3.2.2.3

### DIFF
--- a/stable/WondrousTailsSolver/manifest.toml
+++ b/stable/WondrousTailsSolver/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/MidoriKami/WondrousTailsSolver.git"
 owners = ["daemitus", "MidoriKami", "nathanctech"]
 project_path = "WondrousTailsSolver"
-commit = "4f6d04fe34060bc186e4693932a018c5c9839c51"
-version = "3.2.2.2"
+commit = "872b336d3d076a9b2dfaac6a53a370d89ccfe08b"
+version = "3.2.2.3"


### PR DESCRIPTION
3.2.2.3

- Fixes text overlapping on non-English clients. This removes the "applicable duty" reminder text added with 7.3.