### PR TITLE
ShopItemRevealer 1.1.3

### DIFF
--- a/stable/ShopItemRevealer/manifest.toml
+++ b/stable/ShopItemRevealer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Era-FFXIV/ShopItemRevealer.git"
 owners = ["nathanctech"]
-commit = "65c85a8af16b576e37274ebe0d541f1af10e8770"
+commit = "d154f0d02a2beeef244ecf51b8e2d23b912cf804"
 version = "1.1.3"


### PR DESCRIPTION
1.1.3 - The "I Totally Tested This Thoroughly" Edition

- Fixes an issue where reputations weren't scanned on character login.