### PR TITLE
Tracky 1.6.2.0

### DIFF
--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "44e0cffcdd8a888ff3b6b526df9859ba92f62717"
+commit = "3c6d100ce28e80b0f7e3aef242cd5f78b88a9644"
 owners = [
     "Infiziert90",
 ]

--- a/stable/TrackyTrack/manifest.toml
+++ b/stable/TrackyTrack/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/TrackyTrack.git"
-commit = "f919bc0533ea7b0e05a3a9bedce775fb0e97ac43"
+commit = "44e0cffcdd8a888ff3b6b526df9859ba92f62717"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Add occult pot tracking locally
- Improve memory usage
- Improve performance
- Show mount picture instead of the generic icon
- Show triad card picture instead of generic icon
- Session now includes occult pots