### PR TITLE
[Testing] BisBuddy v0.1.5.7

### DIFF
--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "36910279e886c5dff361128828393cfc561f4dcb"
+commit = "e492416b98826665bcd93f954d22a67a080aa0f7"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
 **Fixes**
- - Fix to writing files causing crashes in some situations
+ - Fix error being thrown when disabling plugin
+ - Fix adding and removing gearsets not triggering inventory updates
+ - Fix changing a gearsets highlight color changing the default color
 """


### PR DESCRIPTION
 - Fix error being thrown when disabling plugin
 - Fix adding and removing gearsets not triggering inventory updates
 - Fix changing a gearsets highlight color changing the default color