### PR TITLE
Simple Tweaks 1.10.11.4

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "6e5ceee9fc661ebfdfebb7ae7af6a8067e5d335f"
+commit = "967479b8dca01a514a79853aadcdc095c0f224a8"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
- Fixes crash when using `Open Estate Access` command without parameters.
- Fixes incorrect estate being selected when using `Open Estate Access` command.
- Fixes positioning of search bar for `Searchable Friend List`