### PR TITLE
[Testing] QuestTracker v1.1.1.0

### DIFF
--- a/testing/live/QuestTracker/manifest.toml
+++ b/testing/live/QuestTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/isaiahcat/QuestTracker.git"
-commit = "8c48380c6ec7184cc08eac5c57a127c14fb3d97f"
+commit = "1b72605060079e4e6b954735f2c823335a3bff4b"
 owners = ["isaiahcat"]
 project_path = "QuestTracker"
 changelog = "Updated for 7.30 quests and Dalamud API13"

--- a/testing/live/QuestTracker/manifest.toml
+++ b/testing/live/QuestTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/isaiahcat/QuestTracker.git"
-commit = "e7bfa7fc0f2125389a70b1761fe2a72c751e501d"
+commit = "8c48380c6ec7184cc08eac5c57a127c14fb3d97f"
 owners = ["isaiahcat"]
 project_path = "QuestTracker"
-changelog = "Support for Dalamud 11.0.0 and 7.1"
+changelog = "Updated for 7.30 quests and Dalamud API13"


### PR DESCRIPTION
### Credits to [NebulousByte](https://github.com/isaiahcat/QuestTracker/commits?author=NebulousByte)!!

Updated for 7.30 quests and Dalamud API13 (https://github.com/isaiahcat/QuestTracker/pull/12)
* Add new quests and enhance quest title representation

Added:
* MSQ up to Seekers of Eternity
* Nitowikwe custom delivery quests
* Allied Society quests for Pelupelu and Mamool Ja
* Occult Crescent and Phantom Weapon quests
* and maybe other quests that I've lost track of

Apologies if the Level/Gc fields' order have been modified. That's just the way the parsing application I made did it and I couldn't be bothered to go through and unmodify entries since it's irrelevant (just doesn't look good for the diff).

* EOF

* Fixed some stuff

* Added  Post-Dawntrail sub-category

* Updated with latest MSQ and Alliance Raid quests

* Added remaining alliance raid and MSQ for patch 7.3

* Updated to Dalamud API13