### PR TITLE
Allagan Tools 1.13.0.1

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,13 +1,25 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "f82ed181610cc0f8de38b101c118b0a37ebc907a"
+commit = "ebd730b7d49ee01250df4b948385f50e428698e5"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.13.0.0"
+version = "1.13.0.1"
 changelog = """\
+### Added
+- Added debug windows available for end-users when debugging specific issues
+
 ### Fixed
-- API13 support
+- Fixed a silent crash when trying to duplicate a list
+- The Gather column will show a button for spearfishing
+- Removed bad mob data causing the mob window to crash
+- Hotkeys now work even if you continue to down a modifier key(shift, ctrl, alt)
+
+### Updated
+- Data refresh of data collected from various sources for 7.3
+
+### Removed
+- Tetris has been removed as Allagan Tetris supersedes it
 
 """


### PR DESCRIPTION
### Added
- Added debug windows available for end-users when debugging specific issues

### Fixed
- Fixed a silent crash when trying to duplicate a list
- The Gather column will show a button for spearfishing
- Removed bad mob data causing the mob window to crash
- Hotkeys now work even if you continue to down a modifier key(shift, ctrl, alt)

### Updated
- Data refresh of data collected from various sources for 7.3

### Removed
- Tetris has been removed as Allagan Tetris supersedes it