### PR TITLE
Simple Tweaks 1.11.12

### DIFF
--- a/stable/SimpleTweaksPlugin/manifest.toml
+++ b/stable/SimpleTweaksPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Caraxi/SimpleTweaksPlugin.git"
-commit = "967479b8dca01a514a79853aadcdc095c0f224a8"
+commit = "26ca79eb2804d748f3b55e2a2ebe1ec3a70d6460"
 owners = [
     "Caraxi",
 ]


### PR DESCRIPTION
***Fixes***
- Fixes some potential crashes with other plugins that edit native UI layouts

***General Changes***
- Disabled error messages in chat when using a tweak command in a macro after using '/macroerror off'.

***New Tweaks***
- **`Enable chat bubbles in combat`** - Allow chat bubbles to be displayed while in combat.