### PR TITLE
AbilityAnts 1.0.2.0

### DIFF
--- a/stable/AbilityAnts/manifest.toml
+++ b/stable/AbilityAnts/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/Zeffuro/AbilityAntsPlugin.git"
 
 # The commit to check out and build from the repository.
-commit = "8169d5cecc26979b2079035d58a836b568f22363"
+commit = "e79950a00e7615031a03585da94d72dcdc8fde54"
 
 # The people authorised to update this manifest (e.g. who can deploy updates). These are GitHub usernames.
 owners = [
@@ -15,6 +15,7 @@ project_path = "AbilityAntsPlugin"
 
 # The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
 changelog = """\
-		#1.0.1.0
-		API13 Update
+		# 1.0.2.0
+		- Fix ants always showing up when "Charged abilities only get ants for the final charge" was unchecked.
+		- Internally reworked configuration window and should hopefully no longer tank your FPS.
 		"""


### PR DESCRIPTION
# 1.0.2.0
- Fix ants always showing up when "Charged abilities only get ants for the final charge" was unchecked.
- Internally reworked configuration window and should hopefully no longer tank your FPS.