### PR TITLE
[Testing] Bisbuddy v0.1.6.0

### DIFF
--- a/testing/live/BisBuddy/manifest.toml
+++ b/testing/live/BisBuddy/manifest.toml
@@ -1,10 +1,13 @@
 [plugin]
 repository = "https://github.com/RajahOmen/BisBuddy.git"
-commit = "d06538352252ca7572f79e8e6f82a88a4e3d962a"
+commit = "4abbce0b77e5a44ec128de32b1a31ca2ffe28638"
 owners = ["RajahOmen"]
 project_path = "BisBuddy"
 changelog = """\
+**Added**
+ - Added a "Include Collected" option to toggle highlighting collected gearpieces in inventories (default: true)
 **Fixes**
- - Fix issue where gearsets are wiped on switching characters
- - Fix race condition upon quitting game potentially causing crash
+ - Fix an issue with generating duplicate prerequisite entries
+ - Fix gearset active status not being saved
+ - Fix some issues with meld selector windows and materia highlighting
 """


### PR DESCRIPTION
**Added**
 - Added a "Include Collected" option to toggle highlighting collected gearpieces in inventories (default: true)

**Fixes**
 - Fix an issue with generating duplicate prerequisite entries
 - Fix gearset active status not being saved
 - Fix some issues with meld selector windows and materia highlighting