### PR TITLE
PvP Tracker v2.6.0.1

### DIFF
--- a/stable/PvpStats/manifest.toml
+++ b/stable/PvpStats/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/wrath16/PvpStats.git"
-commit = "7bbae5f9199c525ff4919034a159136b3c43486d"
+commit = "8b3e368ee7b51791957b19736dc87e253183e44a"
 owners = ["wrath16"]
 project_path = "PvpStats"
 changelog = """
-* Fixes for patch 7.3.
-* Rival Wings tracker temporarily disabled.
+* Fixed some text formatting issues.
+* Fixed Frontline team points graph not showing last point.
+* Fixed a leaky hook.
 """


### PR DESCRIPTION
* Fixed some text formatting issues.
* Fixed Frontline team points graph not showing last point.
* Fixed a leaky hook.