### PR TITLE
Who's Talking 0.8.7.0

### DIFF
--- a/stable/WhosTalking/manifest.toml
+++ b/stable/WhosTalking/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
-repository = "https://github.com/keysmashes/WhosTalking.git"
-commit = "c402e8e63b7259083c2e787a6209fb13f3f01ecc"
+repository = "https://codeberg.org/keysmashes/WhosTalking.git"
+commit = "becebe1784b1762152ec7d4e31bde5489bd40162"
 owners = ["keysmashes"]
 project_path = "WhosTalking"
 changelog = """\
-**Version 0.8.6.0**
+**Version 0.8.7.0**
 
-Updated for patch 7.3 (API 13) and improved error handling.
+Improved compatibility with other UI-editing plugins.
 """

--- a/testing/live/WhosTalking/manifest.toml
+++ b/testing/live/WhosTalking/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
-repository = "https://github.com/keysmashes/WhosTalking.git"
-commit = "c402e8e63b7259083c2e787a6209fb13f3f01ecc"
+repository = "https://codeberg.org/keysmashes/WhosTalking.git"
+commit = "becebe1784b1762152ec7d4e31bde5489bd40162"
 owners = ["keysmashes"]
 project_path = "WhosTalking"
 changelog = """\
-**Version 0.8.6.0**
+**Version 0.8.7.0**
 
-Updated for patch 7.3 (API 13) and improved error handling.
+Improved compatibility with other UI-editing plugins.
 """


### PR DESCRIPTION
apparently indexing `NodeList` is more likely to explode than whatever i just changed it to, though i don't think there's any other plugin that actually modifies the alliance lists