### PR TITLE
ZodiacBuddy 1.13.0.2

### DIFF
--- a/stable/ZodiacBuddy/manifest.toml
+++ b/stable/ZodiacBuddy/manifest.toml
@@ -2,4 +2,4 @@
 repository = "https://github.com/foophoof/ZodiacBuddy.git"
 owners = [ "foophoof" ]
 project_path = "ZodiacBuddy"
-commit = "08929a6fff56f752161225b05c5a2f6f7358d5a1"
+commit = "ad3ef1342bf378b771896aecce7923c7d3acbd31"


### PR DESCRIPTION
### Fixed
- Fixed duty finder link to Cutter's Cry in Trial of the Braves book.
- Fixed bonus light window times being incorrect if you were in a timezone not an even number of hours away from UTC (e.g. UTC+1, UTC+8:45, UTC+9:30, etc.). The plugin now shows both local and server time for clarity.
- Fixed bonus light window times being incorrect if there is a leap second in the upcoming two hours.
### Changed
- Some new debug helpers to detect issues with Trial of the Braves links in the future, thanks to Hiroa for the contribution.