### PR TITLE
[Testing] Allagan Tools 1.13.1.0

### DIFF
--- a/testing/live/InventoryTools/manifest.toml
+++ b/testing/live/InventoryTools/manifest.toml
@@ -1,15 +1,25 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "94ca133440b5d23b84c678c8d301e8d637791c7a"
+commit = "41859cfe7fe5c700ed4578cf5fd822bb6703e820"
 owners = [
     "Critical-Impact",
 ]
 project_path = "InventoryTools"
-version = "1.7.0.3"
+version = "1.13.1.0"
 changelog = """\
-**Allagan Tools 1.7.0.3**
-- This will be the last testing release before this gets released fully
+**[Testing] Allagan Tools 1.13.1.0**
 
-**Fixes:**
-- The sort parser would sometimes not fire on client login/logout causing no inventory updates to occur
+### List Source/Destination Changes
+- The way that sources and destinations work has changed, the individual dropdowns have been removed and replaced with a new scope picker.
+- From the scope picker you can define a set of inventories, characters, categories or worlds you want to match against.
+- Craft lists have received the same upgrade and also include a "Staging Area" scope that lets you pick which items are considered to be in your inventory
+- Your previous settings will be migrated
+
+The other following additions were made:
+
+### Added
+- Preconfigured/sample lists were added to the lists menu in the lists window
+- A import/export menu item was added to the lists menu
+
+Please hit up the Allagan Tools #plugin-help-forum topic on the XIVLauncher/Dalamud discord if you run into any issues!
 """


### PR DESCRIPTION
**[Testing] Allagan Tools 1.13.1.0**

### List Source/Destination Changes
- The way that sources and destinations work has changed, the individual dropdowns have been removed and replaced with a new scope picker.
- From the scope picker you can define a set of inventories, characters, categories or worlds you want to match against.
- Craft lists have received the same upgrade and also include a "Staging Area" scope that lets you pick which items are considered to be in your inventory
- Your previous settings will be migrated

The other following additions were made:

### Added
- Preconfigured/sample lists were added to the lists menu in the lists window
- A import/export menu item was added to the lists menu

Please hit up the Allagan Tools #plugin-help-forum topic on the XIVLauncher/Dalamud discord if you run into any issues!