### PR TITLE
Browsingway 1.6.7.0

### DIFF
--- a/stable/Browsingway/manifest.toml
+++ b/stable/Browsingway/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/Styr1x/Browsingway.git"
-commit = "2e8e7ce04c188c023bc49ea8f0864bcd9e74a53b"
+commit = "546edf222004ddc5c38a072d373a357eb620ce27"
 owners = ["Styr1x"]
 project_path = "Browsingway"
 changelog = """\
-- Bump Chromium to 138.0.7204.184
-- Api 13 support
-- Add HideInPvP setting (by SheepGoMeh)
+- Bump Chromium to 139.0.7258.139
+- Improve renderer crash handling
+- Fix CEF not loading when game runs as a privileged process (please don't..)
 """


### PR DESCRIPTION
- Bump Chromium to 139.0.7258.139
- Improve renderer crash handling
- Fix CEF not loading when game runs as a privileged process (please don't..)