### PR TITLE
VanillaPlus v1.0.0.3

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,6 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "5b6aa30385f9143e79f49fac59e01a133c1fbb3b"
+commit = "83fb64a9e356b1867cf96a41ecef21860a883f24"
 owners = ["MidoriKami", "Haselnussbomber"]
 project_path = "VanillaPlus"
-


### PR DESCRIPTION
Fix windows growing in size with every reopen when using non-100% ui scaling

Target Castbar Countdown - Adjusted where the nodes get inserted into the ui, prevents time from showing when castbar is not visible

Recently Looted Items - When looting in quantities over 10,000, display count as ###k instead
