### PR TITLE
Fader 2.4.5.1

### DIFF
--- a/stable/FaderPlugin/manifest.toml
+++ b/stable/FaderPlugin/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Infiziert90/xivFaderPlugin.git"
-commit = "a89ef9ef335832f0a65322bc987b53a444fe9e4f"
+commit = "1427f83081b1292072c678449fe72bf682c1699e"
 owners = ["Infiziert90"]
 project_path = "FaderPlugin"


### PR DESCRIPTION
- Fixed an issue where the opacity sometimes finished animating faster than the specified duration
- Added “Relative Opacity” Option
  - When enabled, the plugin multiplies its own opacity setting by the HUD’s native opacity, preserving the original layout’s settings.
  - Example:
    - Native HUD hotbar opacity = 60%
    - Plugin opacity = 50% → Result = 0.6 × 0.5 = 30% visible
    - Plugin opacity = 100% → Result = 0.6 × 1.0 = 60% visible
    
thanks PhibrXIV

