### PR TITLE
VanillaPlus v1.0.0.11

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "270e8d17808f0d2068ff7ceacac13ddccd415a43"
+commit = "528ebdcc12a996aa79044bc8b425bc1f68d05de5"
 owners = ["MidoriKami", "Haselnussbomber"]
 project_path = "VanillaPlus"


### PR DESCRIPTION
`Hide MP Bars` - [PR](https://github.com/MidoriKami/VanillaPlus/pull/26) - Hides the MP Bars of party members, who are on jobs that don't use MP

 `Resource Bar Percentages` - [PR](https://github.com/MidoriKami/VanillaPlus/pull/25) - Adds options to display your HP and MP as percentages, and to show all partymembers HP as percentages

`Missing Job Stone Lockout` - [PR](https://github.com/MidoriKami/VanillaPlus/pull/27) - Displays a warning in the duty finder when you try to queue for a duty, while on a job that you could be using a job stone for.