### PR TITLE
BetterFriendList 1.0.2.0

### DIFF
--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,12 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "ea6f657d67b9d65d172c21eb6fb29bce9e62918c"
+commit = "cf0251f4f144102f8a0f9dac176c2b6f33e04791"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
-changelog = "adding keybind to open it"
+changelog = """
+fix :
+- checking nulls in sorting for colors dict
+add :
+- import colors from simple tweaks chat colors
+- open lodestone page for players
+"""


### PR DESCRIPTION
fix :
- checking nulls in sorting for colors dict
add :
- import colors from simple tweaks chat colors
- open lodestone page for players