### PR TITLE
DamageInfoPlugin 2.4.1.4 -> 2.4.1.5

### DIFF
--- a/stable/DamageInfoPlugin/manifest.toml
+++ b/stable/DamageInfoPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/perchbirdd/DamageInfoPlugin.git"
-commit = "3624ce0eb101a5f3afa1a1fcc3609b8413245f8e"
+commit = "4dd93e396a8d7474aabb3c64f359330da022db7f"
 owners = [
     "perchbirdd",
 ]


### PR DESCRIPTION
Fix castbar coloring in the situation where an additional node is present in the addons that DamageInfo uses. Thanks to @/MidoriKami for this one!