### PR TITLE
Update manifest for CurrencySpender

### DIFF
--- a/stable/CurrencySpender/manifest.toml
+++ b/stable/CurrencySpender/manifest.toml
@@ -2,15 +2,15 @@
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
 owners = ["Blackcatz1911"]
 project_path = "CurrencySpender"
-commit = "41faa61f25f038de60dd63d86fac03a62184ab2c"
+commit = "eda7f945c615186f2408af2f44a4ef95f1ad138f"
 changelog = """
-## 1.2.2
+## 1.2.3
 ### Added
-- New NPC: Mesouaidonque on Sinus Ardorum and Phaenna.
-- New Currency: Cosmocredits.
-- Phaenna Credits as stub, because you cant buy anything of it yet.
+- A new setting to automatically open Currency Spender together with the Currency window.
+- A new button on the Currency window.
+### Fixed
+- Incorrect check for Framer's Kits has been resolved.
 ### Changed
-- Updated for 7.3
-- Updated ECommons.
+- ECommons is now used as a NuGet package.
 """
-version = "1.2.2"
+version = "1.2.3"


### PR DESCRIPTION
# Changelog

## 1.2.3
### Added
- A new setting to automatically open Currency Spender together with the Currency window.
- A new button on the Currency window.
### Fixed
- Incorrect check for Framer's Kits has been resolved.
### Changed
- ECommons is now used as a NuGet package.