### PR TITLE
GoodFriend v3.7.2.3

### DIFF
--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Dalamud.GoodFriend.git"
-commit = "074521b2d355c1261122da032ec99f8975267a92"
+commit = "f230e3ad42ae63670f4622c47387c9fb5d31502d"
 owners = [
     "Blooym",
 ]

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Dalamud.GoodFriend.git"
-commit = "f9d18951e45fff0968aba7387113e7145576805e"
+commit = "074521b2d355c1261122da032ec99f8975267a92"
 owners = [
     "Blooym",
 ]

--- a/stable/GoodFriend/manifest.toml
+++ b/stable/GoodFriend/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Blooym/Dalamud.GoodFriend.git"
-commit = "f230e3ad42ae63670f4622c47387c9fb5d31502d"
+commit = "e6306c4083057e84c489ddc39d4afa91beb1b30e"
 owners = [
     "Blooym",
 ]


### PR DESCRIPTION
nofranz

Changes the default API url to point to an updated location. No other major functionality adjustments. The old URL will remain working for a while.