### PR TITLE
Wikilinx Rightclicks v0.0.0.6

### DIFF
--- a/stable/Wikilinx/manifest.toml
+++ b/stable/Wikilinx/manifest.toml
@@ -1,7 +1,8 @@
 [plugin]
 repository = "https://github.com/in1tiate/Wikilinx-Dalamud.git"
-commit = "e3bc186559cd90fb331999507421f3229575d328"
+commit = "77df7af015c3d6faae0e2bd7414e9cc70340c487"
 owners = ["in1tiate"]
 project_path = "WikilinxPlugin"
-changelog = "Update Lodestone IDs for 7.3"
+changelog = "Update Lodestone IDs for 7.31"
+
 


### PR DESCRIPTION
- Bump Lodestone IDs to 7.31

Diff from last version: https://github.com/in1tiate/Wikilinx-Dalamud/compare/v0.5...v0.6