### PR TITLE
Mappy v3.1.6.8

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,11 +1,5 @@
 [plugin]
 repository = "https://github.com/kotenuki/Mappy.git"
-commit = "acd7c480cfa9d42212d9e1a78d9d1868dd83f266"
+commit = "f2fb0bf59c9bc391465b927888ac5b7da1d788ac"
 owners = ["MidoriKami", "kotenuki"]
 project_path = "Mappy"
-
-
-
-
-
-


### PR DESCRIPTION
Fixes `Method Not Found` exception that prevents the map from opening.