### PR TITLE
Mappy v3.1.6.10

### DIFF
--- a/testing/live/Mappy/manifest.toml
+++ b/testing/live/Mappy/manifest.toml
@@ -1,8 +1,9 @@
 [plugin]
 repository = "https://github.com/kotenuki/Mappy.git"
-commit = "acd7c480cfa9d42212d9e1a78d9d1868dd83f266"
+commit = "9e9e4a31d7943b55d5597b81604516119e0ea666"
 owners = ["MidoriKami", "kotenuki"]
 project_path = "Mappy"
+
 
 
 


### PR DESCRIPTION
1. Updated to use Dalamud's GetAddonByName<T> instead of the now deprecated internal KamiLib one.