### PR TITLE
AetherDraw v2.3.0.5

### DIFF
--- a/stable/AetherDraw/manifest.toml
+++ b/stable/AetherDraw/manifest.toml
@@ -1,7 +1,7 @@
 # stable/live/AetherDraw/manifest.toml
 [plugin]
 repository = "https://github.com/rail2025/AetherDraw.git"
-commit = "891d128acde31524df59cc5e9ded31477c19da62" 
+commit = "6de05a2cf53802bcd1a7ef8f4a703982d6d48248" 
 owners = ["rail2025"]
 # project_path = "AetherDraw" # Only uncomment and use if your .csproj is NOT at the root of your AetherDraw repo
-changelog = "v2.3.0.4: Transform handle visibility fix.\nv2.3.0.3: API 13."
+changelog = "v2.3.0.5:live session initial sync fix(duped waymarks).\nv2.3.0.4: Transform handle visibility fix.\nv2.3.0.3: API 13."


### PR DESCRIPTION
initial sync state fixed by sending replacepage command on server connect, server expects that message and was updated as well.