### PR TITLE
SubmarineTracker 2.0.1.0

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "ebbc1fafddf5a40b74e838a8a80c4ebf8faa0d16"
+commit = "cb661e300553eea4ed0a0c2d8bb88444eb0a280e"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Swap SQLite backend dependencies to reduce the risk of install timeouts
  - This should also provide a small boost in performance