### PR TITLE
Snooper 1.5.0.0

### DIFF
--- a/stable/Snooper/manifest.toml
+++ b/stable/Snooper/manifest.toml
@@ -1,9 +1,12 @@
 [plugin]
 repository = "https://codeberg.org/Linneris/dalamud-snooper.git"
-commit = "08f8c5134187073fa196d0a4d07b77e8a6f304b7"
+commit = "1396a1b2c3dc3977947c8957564a83289c8d81e7"
 owners = ["Maia-Everett"]
 project_path = "Snooper"
-version = "1.4.0.3"
+version = "1.5.0.0"
 changelog = """
-Update to Dalamud API 13. Thanks pallascat!
+* Enhancement: Added a hover delay option. (#9)
+* Enhancement: Added the ability to lock windows in place. (#19)
+* Bugfix: Fixed one's own messages in party chat not displaying when class/job abbreviations are enabled. (#27)
+* Bugfix: Fixed log files for persistent windows writing messages from players not in the window's player list. (#29)
 """


### PR DESCRIPTION
* Enhancement: Added a hover delay option.
* Enhancement: Added the ability to lock windows in place.
* Bugfix: Fixed one's own messages in party chat not displaying when class/job abbreviations are enabled.
* Bugfix: Fixed log files for persistent windows writing messages from players not in the window's player list.