### PR TITLE
Mappy v3.1.6.10

### DIFF
--- a/stable/Mappy/manifest.toml
+++ b/stable/Mappy/manifest.toml
@@ -1,6 +1,5 @@
 [plugin]
-repository = "https://github.com/MidoriKami/Mappy.git"
-commit = "e2d0161665bb69eebc1fdde98a0a7128ecd4d737"
+repository = "https://github.com/kotenuki/Mappy.git"
+commit = "9e9e4a31d7943b55d5597b81604516119e0ea666"
 owners = ["MidoriKami", "kotenuki"]
 project_path = "Mappy"
-


### PR DESCRIPTION
1. Corrected issue with CE map links not showing, by @harbingerftw
2. Updated to use Dalamud's GetAddonByName<T> instead of the deprecated internal KamiLib one.