### PR TITLE
VanillaPlus v1.0.1.8

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "9b52722d5762a2e5d538a87e79fff487aa0ed3b7"
+commit = "47382942a6b213610ae918e1d06678f8ec4fe19b"
 owners = ["MidoriKami", "Haselnussbomber"]
 project_path = "VanillaPlus"


### PR DESCRIPTION
Add FadeLootButton Feature - [PR](https://github.com/MidoriKami/VanillaPlus/pull/44) - Fades the Loot Button (_NotificationLoot) when you've already rolled on all available items.

Acts as a handy reminder to roll on things if it isn't faded yet ;)