### PR TITLE
VanillaPlus v1.0.2.0

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "47382942a6b213610ae918e1d06678f8ec4fe19b"
+commit = "e5b7d0ef55da28d6414f737c80f504daf144d666"
 owners = ["MidoriKami", "Haselnussbomber"]
 project_path = "VanillaPlus"


### PR DESCRIPTION
Add Gearset Redirect - [PR](https://github.com/MidoriKami/VanillaPlus/pull/47) - Allows you redirect which gearset actually gets equipped, depending on which zone you are in.

Add Skip Teleport Confirm - [PR](https://github.com/MidoriKami/VanillaPlus/pull/46) - Skips the "Teleport to wherever for whatever gil" popup when using the map to teleport to an aetheryte.

(Important note, this is allowable automation because this prompt does not interact with Square Enix Servers in any way)

Add Better Interruptable Castbars - [PR](https://github.com/MidoriKami/VanillaPlus/pull/45) - Modifies the pulsing indicator for interruptable castbars to be much more noticeable, additionally will enable ants for interject/head graze when the target is using an interruptable skill
