### PR TITLE
Hyperfocus 0.1.0.0

### DIFF
--- a/testing/live/Hyperfocus/manifest.toml
+++ b/testing/live/Hyperfocus/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Exter-N/Hyperfocus.git"
-commit = "66dd5f549d994adf876f382792ebb27b1e24dd78"
+commit = "f504cd054fc20f54e2e05da54bb123cb1227c474"
 owners = ["Exter-N"]
 project_path = "Hyperfocus"
-changelog = "Initial version"
+changelog = "Allow use in PvE"


### PR DESCRIPTION
Re: https://discord.com/channels/581875019861328007/653504487352303619/1420171739022753934, the use of `if (!target.IsTargetable) return;` makes it so, according to my own testing, it doesn't seem to draw the cursor towards the focus target when the game wouldn't have drawn it in these duties. As for secondary actors that are specific to mechanics, you cannot acquire them as targets or focus targets to begin with (unless using a CRP probably, but I don't think I should account for that), making them a non-issue.

Given perchbird's complete lack of reply to my further inquiries (or did I miss something?), I have no idea if this is fine by him, or by you in general, as it now is.