### PR TITLE
Market Board 1.12.0

### DIFF
--- a/stable/MarketBoardPlugin/manifest.toml
+++ b/stable/MarketBoardPlugin/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/fmauNeko/MarketBoardPlugin.git"
-commit = "6ee22ef827f88e08ba03cf4434dd79ade54dcdb4"
+commit = "46d3f49fca27c78fb410ba196a3e4feaa28de871"
 owners = ["fmauNeko"]
 project_path = "MarketBoardPlugin"
-changelog = """\
-- Patch 7.3 / API 13 compatibility\
+changelog = """
+- Patch 7.4 / API 14 compatibility
+- Allow including Oceania in Cross-DC searches (added a checkbox in settings)
+- Added support for China Cross-DC
 """


### PR DESCRIPTION
- Patch 7.4 / API 14 compatibility
- Allow including Oceania in Cross-DC searches (added a checkbox in settings)
- Added support for China Cross-DC