### PR TITLE
VFXEditor v1.9.3.6

### DIFF
--- a/stable/VFXEditor/manifest.toml
+++ b/stable/VFXEditor/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/0ceal0t/Dalamud-VFXEditor.git"
-commit = "0ecb77c4afa282dbb2c502a1927ec4bee5c11791"
+commit = "b5af057dc3e21fec9659e51c2b2c8a6499a739e3"
 owners = [
     "0ceal0t",
 ]


### PR DESCRIPTION
- Added missing common `pap` paths
- Small `.tmb` updates
- General cleanup
- Fixed occasional issue with rendering skeleton previews
- Added button to import emitter vertexes
- Adjusted emitter item checkbox to use `Create Probability` parameter
- Added `.pbd` extended data