### PR TITLE
QuestShare 1.2.0.0

### DIFF
--- a/stable/QuestShare/manifest.toml
+++ b/stable/QuestShare/manifest.toml
@@ -2,5 +2,5 @@
 repository = "https://github.com/Era-FFXIV/QuestShare.Plugin.git"
 owners = ["nathanctech"]
 project_path = "QuestShare.Plugin"
-commit = "fe6535e3e1ed09f719a2c53f26e0599bf1e7240f"
-version = "1.1.1.0"
+commit = "28e3cc238c72477fb827e92f7b9585ff2e32c6e0"
+version = "1.2.0.0"


### PR DESCRIPTION
## 1.2.0.0

- Adds the `/qsnext` command which will print the next step of the current quest the selected player is on (selected by opening the mini window) along with a clickable marker that will open the map.
- Some code refactoring for more sane code (surely).