### PR TITLE
BetterFriendList to 2.0.0.0 testing

### DIFF
--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "f13c7e25acc03ddf9fec59bb62f2fa2223476834"
+commit = "10b421b8b1574be71f5a8f7a7aaaa5bfb10f59a9"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """

--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "ca44966f6f48a478e1ab1e70a8540cfd57f390d8"
+commit = "6768dfbff0a8fea08ccb9f2f7973aa9edab8d1eb"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """

--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "10b421b8b1574be71f5a8f7a7aaaa5bfb10f59a9"
+commit = "ca44966f6f48a478e1ab1e70a8540cfd57f390d8"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """
@@ -11,6 +11,10 @@ add:
     option to show notes in native friend list
     option to use color in native friend list
     option to keep same keybind for both native and plugin friend list
+    restriction when requesting data (gpose, disconnected, offline, cutscene, afk, camera mode)
 fix:
-    fix refresh when used on specific player 
+    fix refresh when used on specific player
+    fix lodestone page with name with special chars
+    fix icons for crossworld party leader and memeber
+    fix condions for pf button
 """

--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "cc620f3c5ff0209109056925f62cb34cad9ba88e"
+commit = "26c9d50930c1e0531d6269d26c6cb9c250ae7453"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """

--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,12 +1,15 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "e1e0df1a4b5bc3b2d4e65a760bc10a3c2aad9299"
+commit = "3cadc2da29d4e084327f379714f04767bf43343c"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """
-fix :
-- pf retrieve data not getting world and private tab
-add :
-- option for column size
-- search pf info if playerId not present in data before trying to open it
+add:
+    refresh button in native friend list
+    collapse button on social (player search / friend list / party members)
+    option to prevent friendlist to refresh on open
+    option to show notes in native friend list
+    option to keep same keybind for both native and plugin friend list
+fix:
+    fix refresh when used on specific player 
 """

--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "26c9d50930c1e0531d6269d26c6cb9c250ae7453"
+commit = "f13c7e25acc03ddf9fec59bb62f2fa2223476834"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """

--- a/testing/live/BetterFriendList/manifest.toml
+++ b/testing/live/BetterFriendList/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/devckuw/BetterFriendList.git"
-commit = "3cadc2da29d4e084327f379714f04767bf43343c"
+commit = "cc620f3c5ff0209109056925f62cb34cad9ba88e"
 owners = ["devckuw"]
 project_path = "BetterFriendList"
 changelog = """
@@ -9,6 +9,7 @@ add:
     collapse button on social (player search / friend list / party members)
     option to prevent friendlist to refresh on open
     option to show notes in native friend list
+    option to use color in native friend list
     option to keep same keybind for both native and plugin friend list
 fix:
     fix refresh when used on specific player 


### PR DESCRIPTION
add:
    refresh button in native friend list
    collapse button on social (player search / friend list / party members)
    option to prevent friendlist to refresh on open but still keep other refresh (on log in / leaving duty / changing wolrd)
    option to show notes in native friend list (show note instead of the online statue)
    option to keep same keybind for both native and plugin friend list
fix:
    fix refresh when used on specific player 