### PR TITLE
Update SimpleTriggers v0.3.3.4 (testing)

### DIFF
--- a/testing/live/SimpleTriggers/manifest.toml
+++ b/testing/live/SimpleTriggers/manifest.toml
@@ -1,11 +1,9 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "3d0997525249ea8c64f25dcd8ac6270c05a7828a"
+commit = "5e226cbddf55c90f890101d9f555058cd1f09121"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
 changelog = """
-## Simple Triggers v0.3.3.3
-* TTS audio playback is now handled by a dedicated AudioPlayer class. Need feedback if it causes any issues but should be fine.
-* You can now specify the output device in the Settings tab. Keep in mind it'll still show as the game in your OS's volume mixer.
-* Volume is now more customizable, allowing values above 100%. For safety, by default only goes up to 200%, but there's a checkbox directly under the volume setting which will allow you to go up to 3000% if you *really* feel like you need it. Since TTS volume is tied to the game's volume in your OS audio settings, this might give you the boost you need if you keep the game volume really, really low.
+## Simple Triggers v0.3.3.4
+* Addresses a COM conflict error when accessing audio device information in Windows.
 """


### PR DESCRIPTION
Addresses a COM access error in Windows when attempting to query the audio device list.
Hardware queries now only occur when the user opens the settings tab or clicks on the dropdown box for the audio devices list. If it can't, it'll capture the error without breaking the window. (Then I'll have something else to investigate).