### PR TITLE
ChatTwo 1.34.5

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "9f7a6267f6cc05326d4639d15081d1ed1c26a12a"
+commit = "df0773ac650e9927832a873a6469750ede8ffcec"
 owners = [
     "Infiziert90"
 ]


### PR DESCRIPTION
### History export
- Simple text file export has been added
  - A more advanced and styled HTML version is planned for the near future
  - HowTo: https://discord.com/channels/581875019861328007/1224865018789761126/1492258414980763798

### Auto translate commands
- As wished by many users, these are now executed similar to how vanilla chat handles them

### Other
- Empty auto translate entries are now excluded from the list
- Plugin commands also appear in the command helper window
- Early 7.5 prep, all SeString payloads got replaced with ROSS


**Important**
The database implementation will be switched to ROSS for **7.5**, after this point for 2 month an export period will be granted until all support for the old database format will be dropped!
