### PR TITLE
[Plugin submission] Random Job

### DIFF
--- a/testing/live/RandomJob/manifest.toml
+++ b/testing/live/RandomJob/manifest.toml
@@ -1,0 +1,6 @@
+[plugin]
+repository = "https://github.com/micfiygd/RandomJob.git"
+commit = "74f546541a221abc52a7ce1af0a7bbe038cb4c04"
+owners = ["micfiygd"]
+project_path = "RandomJob"
+changelog = "Initial release. Equip a random job from a configurable pool with an optional custom command on job change."

--- a/testing/live/RandomJob/manifest.toml
+++ b/testing/live/RandomJob/manifest.toml
@@ -3,4 +3,4 @@ repository = "https://github.com/micfiygd/RandomJob.git"
 commit = "74f546541a221abc52a7ce1af0a7bbe038cb4c04"
 owners = ["micfiygd"]
 project_path = "RandomJob"
-changelog = "Initial release. Equip a random job from a configurable pool with an optional custom command on job change."
+changelog = "V1.0 release. Equip a random job from a configurable pool with an optional custom command on job change."


### PR DESCRIPTION
This plugin  lets you equip a random job from a configurable pool of gear sets. 
Supports an optional custom command that fires after each job change (e.g. /ac "Minion Roulette").

Commands:
/randomjob - Equips a random job from your enabled pool
/randomjobui - Opens the configuration window