### PR TITLE
Altoholic v1.9.9

### DIFF
--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,11 +1,9 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "1e5d45c1491396f20776933869a33eae6a2cc02d"
+commit = "89e124ef4ada71e4102f473dab84d23a6238c7bf"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\
-- **Progress**:
-    * Add missing bucket minion
-    * Add total required tomes for Moogle trove of Aphorism
-    * Change total tomestone a character has in total line to total required tomestone per character taking into account already owned rewards. Value of currently owned tomestone is now put on mousehover tooltip
+- **Character**: Add housing last entry tracking, enable in setting, set the number of days and an icon will show on character tab list if last entry was older
+- **Timer**: Add loot tracking for current normal raid tier (Arcadion Heavyweight).
 """

--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "89e124ef4ada71e4102f473dab84d23a6238c7bf"
+commit = "dda6b7d430c54d8675490a0dfd91d82fded0a3bc"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\


### PR DESCRIPTION
Version 1.9.9:

- **Character**: Add housing last entry tracking, enable in setting, set the number of days and an icon will show on character tab list if last entry was older
- **Timer**: Add loot tracking for current normal raid tier (Arcadion Heavyweight).