### PR TITLE
Update SimpleTriggers v0.3.5.2 (testing)

### DIFF
--- a/testing/live/SimpleTriggers/manifest.toml
+++ b/testing/live/SimpleTriggers/manifest.toml
@@ -1,10 +1,16 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "4951de870d67e3ef73c8bd6aec4b1a21e7b6ccec"
+commit = "83f4a75153ef7f6e8b661dc1a39b0fef6d8dba44"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
 changelog = """
-## Simple Triggers v0.3.4.2
-* New command `/strig toggle`
-* Improvements to audio device scanning. Now operates in the background.
+## Simple Triggers v0.3.5.2
+* New settings for filtering chat messages based on XivChatType.
+  * Added setting to ignore messages from Damage and Healing sources.
+  * Added a debug setting for the chat log history to include XivChatType information.
+  * You can manually select what channels the trigger system reads from, however note that documented types are missing several, if not most, of the game's actual list of combat related message types. It is suggested to leave the channel settings as default.
+* Chat history now shows the size of the log next to it.
+* Disabling chat logging does not clear the log anymore. Log is now only cleared when the user clicks "Clear Log"
+* Fix for audio device scanning: Devices are scanned when the plugin initializes the window. This fixes devices not being cached if the plugin is restarted and opens on the settings tab first.
+* Various little clean ups inside MainWindow.cs
 """


### PR DESCRIPTION
## Simple Triggers v0.3.5.2
* New settings for filtering chat messages based on XivChatType.
  * Added setting to ignore messages from Damage and Healing sources.
  * Added a debug setting for the chat log history to include XivChatType information.
  * You can manually select what channels the trigger system reads from, however note that documented types are missing several, if not most, of the game's actual list of combat related message types. It is suggested to leave the channel settings as default.
* Chat history now shows the size of the log next to it.
* Disabling chat logging does not clear the log anymore. Log is now only cleared when the user clicks "Clear Log"
* Fix for audio device scanning: Devices are scanned when the plugin initializes the window. This fixes devices not being cached if the plugin is restarted and opens on the settings tab first.
* Various little clean ups inside MainWindow.cs

Assuming I don't get any extra ideas or breaking bug reports, my next PR after this will probably be to migrate to stable next month. Many thanks to all those in the Dalamud server who assisted or gave advice.