### PR TITLE
Update SimpleTriggers v0.3.6.0 (testing)

### DIFF
--- a/testing/live/SimpleTriggers/manifest.toml
+++ b/testing/live/SimpleTriggers/manifest.toml
@@ -1,16 +1,5 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "83f4a75153ef7f6e8b661dc1a39b0fef6d8dba44"
+commit = "03ad9c54fb708abf476a5fa0d7536486856bb48d"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
-changelog = """
-## Simple Triggers v0.3.5.2
-* New settings for filtering chat messages based on XivChatType.
-  * Added setting to ignore messages from Damage and Healing sources.
-  * Added a debug setting for the chat log history to include XivChatType information.
-  * You can manually select what channels the trigger system reads from, however note that documented types are missing several, if not most, of the game's actual list of combat related message types. It is suggested to leave the channel settings as default.
-* Chat history now shows the size of the log next to it.
-* Disabling chat logging does not clear the log anymore. Log is now only cleared when the user clicks "Clear Log"
-* Fix for audio device scanning: Devices are scanned when the plugin initializes the window. This fixes devices not being cached if the plugin is restarted and opens on the settings tab first.
-* Various little clean ups inside MainWindow.cs
-"""


### PR DESCRIPTION
nofranz

* Rewrote AudioPlayer.cs (again) to allow switching audio backends between Wasapi, DirectSound, and WaveOut (as a last resort).
* Device enumeration in the settings window will prefer Wasapi if it can, otherwise it will fallback to DirectSound enumeration (less preferable, 32 char limit on device names).
* Updated channel settings using LogKind for the filters. (Thanks Midori and Infi)
* Added RepoUrl and IconUrl to the json