### PR TITLE
Update PullToOBS to 0.3.0.0

### DIFF
--- a/testing/live/PullToOBS/manifest.toml
+++ b/testing/live/PullToOBS/manifest.toml
@@ -1,14 +1,10 @@
 [plugin]
 repository = "https://github.com/Miu-B/PullToOBS.git"
-commit = "1c7e1c459315134ac4a62da2b4a978b0622e5cad"
+commit = "cc713e66a6d08cfb0619992691acdc2a1701f4aa"
 owners = ["Miu-B"]
 maintainers = ["Miu-B"]
 project_path = "PullToOBS"
 changelog = """
-- Initial release to official repository
-- Automatically starts OBS recording when entering combat and stops after a 5-second grace period
-- Saves replay buffer 5 seconds into the encounter to capture the prepull
-- Visual on-screen indicator showing OBS state (recording, replay buffer active, connected, disconnected)
-- Configure via /pulltoobs or /pto command
-- Toggle OBS connection from chat with /pto obs
+- Improved setup documentation and Replay Buffer instructions
+- Toggle standby mode with /pto rec (suppresses combat-triggered recording while staying connected to OBS)
 """


### PR DESCRIPTION
## Update: PullToOBS 0.3.0.0

Bumps the commit SHA to [cc713e6](https://github.com/Miu-B/PullToOBS/commit/cc713e66a6d08cfb0619992691acdc2a1701f4aa).

**Changes since last submission (v0.2.4.0):**
- Improved setup documentation and Replay Buffer instructions (clarifies that OBS Replay Buffer must be enabled before connecting, with visual confirmation guide)
- Toggle standby mode with `/pto rec` (suppresses combat-triggered recording while staying connected to OBS) — this feature was present in 0.2.4.0 but missing from the changelog

No functional code changes.