### PR TITLE
XIVDeck 0.4.4

### DIFF
--- a/stable/XIVDeck.FFXIVPlugin/manifest.toml
+++ b/stable/XIVDeck.FFXIVPlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/KazWolfe/XIVDeck.git"
-commit = "c7406e3baac566990cc881d278366bb76a110a93"
+commit = "ed1a2d92a257c7fbcb997aaa26db0edf6f198fd6"
 owners = [
     "KazWolfe",
 ]


### PR DESCRIPTION
With keys being so important for this patch, let's get your control keys working again!

* Update for Patch 7.5 and Dalamud 15.0

Full release notes and downloads are available [on the plugin GitHub](https://github.com/KazWolfe/XIVDeck/releases/tag/v0.4.4).