### PR TITLE
Currency Watchdog 1.0.2.3

### DIFF
--- a/testing/live/CurrencyWatchdog/manifest.toml
+++ b/testing/live/CurrencyWatchdog/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/nebel/CurrencyWatchdog.git"
-commit = "bfe0f951d4a01bc362e361d1adebeef696b664fe"
+commit = "911652dfe262b874b2e4eb9f2b01e6d710fa46ca"
 owners = ["nebel"]
 project_path = "CurrencyWatchdog"


### PR DESCRIPTION
- Update for API 15
- Fix an issue where a burden's advanced limit settings would be cleared when using Revert or Clone.