### PR TITLE
Update SimpleTriggers v1.0.1.1

### DIFF
--- a/stable/SimpleTriggers/manifest.toml
+++ b/stable/SimpleTriggers/manifest.toml
@@ -1,10 +1,8 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "a9b1cebfa4f4728faac6c0541b8eaabfb4889478"
+commit = "b8ae28c0ebd49ed074f4a9f7b1c5cc1a8d910ea4"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
 changelog = """
-* api15 bump
-* minor fixes to StopAudioPlayback
-* minor improvements to Triggers tab
+* tweaks to trigger structure
 """


### PR DESCRIPTION
squash one bug two more pop up in it's place
* Changes to how the triggers structure re-arranges itself. Doesn't search by category name when removing or sorting.