### PR TITLE
VanillaPlus

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "d2428229198088f247b1f5b501bc14f6c28438f3"
+commit = "904d99f885b8db577e37863ca93f092a23f500ca"
 owners = [ "MidoriKami",]
 maintainers = [ "Haselnussbomber", "Zeffuro",]
 project_path = "VanillaPlus"


### PR DESCRIPTION
Fixes duplicate flag marker on map when using map overlay features.

(Note this feature comes from a shared code library that other plugins may also be using, if you see duplicate flags reach out to us in the XIVLauncher & Dalamud discord)