### PR TITLE
Sightseeingway 1.2.0.0 (API 15)

### DIFF
--- a/stable/Sightseeingway/manifest.toml
+++ b/stable/Sightseeingway/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/gposingway/Sightseeingway.git"
-commit = "194fd18d0efe287d5fdc8fde4d5c5385ccdcd720"
+commit = "a8865dc22ce46bc23cd0712beba2545d7a05bcd3"
 owners = ["gposingway","LeonAquitaine"]
 project_path = "Sightseeingway"
-changelog = "API 13 update"
+changelog = "API 15 update (Dalamud SDK 15, .NET 10); thread-safe rename cache, Shadingway watcher fix, internal cleanup"

--- a/testing/live/Sightseeingway/manifest.toml
+++ b/testing/live/Sightseeingway/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/gposingway/Sightseeingway.git"
-commit = "0e63573f25940ca984ac0029fd9466844c180868"
+commit = "a8865dc22ce46bc23cd0712beba2545d7a05bcd3"
 owners = ["gposingway","LeonAquitaine"]
 project_path = "Sightseeingway"
-changelog = "Configurable name format, improved event handling, and some code housekeeping"
+changelog = "API 15 update (Dalamud SDK 15, .NET 10); thread-safe rename cache, Shadingway watcher fix, internal cleanup"


### PR DESCRIPTION
## Changed
- Updated to Dalamud API 15 (Dalamud .NET SDK 15, DalamudPackager 15, .NET 10).
- Migrated `IClientState.LocalPlayer` references to `IObjectTable.LocalPlayer`.
- Aligned the README license declaration with `LICENSE.md` and the csproj (AGPL-3.0-or-later).

## Fixes
- Shadingway state-file watcher was silently dropped whenever the screenshot directory changed, it now survives reinit.
- Rename cache is thread-safe and expires entries on read, so a TTL-expired entry can't shadow a legitimate later screenshot.
- Duplicate tooltip in the config window that was attaching the wrong help text to the Debug Mode checkbox.