### PR TITLE
TextToTalk v1.37.1

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "253d0a1ae5cc7820f10a6f97dc031474c0fb74ac"
+commit = "27779a07618288ae090d8562d88505e64034bcdf"
 project_path = "src/TextToTalk"
 owners = ["karashiiro"]
 changelog = """\
-- **General**: Updated for 7.5 (Thanks aniachan!)
+- **System**: Fixed crashes when using the Characters and Locations lexicon.
 """


### PR DESCRIPTION
- **System**: Fixed crashes when using the Characters and Locations lexicon.