### PR TITLE
ChatTwo 1.35.5

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "f640fdcb38c830ceba5679c0e1453ab84a4104aa"
+commit = "ff899ffe54ef76bcdf9c13b5690957c5b5e17637"
 owners = [
     "Infiziert90"
 ]


### PR DESCRIPTION
- Fix emote cache regression
- Update DBViewer UI, also decrease space between the newly added buttons 