### PR TITLE
Currency Watchdog 1.0.3.0

### DIFF
--- a/stable/CurrencyWatchdog/manifest.toml
+++ b/stable/CurrencyWatchdog/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/nebel/CurrencyWatchdog.git"
-commit = "911652dfe262b874b2e4eb9f2b01e6d710fa46ca"
+commit = "ddb80bb444d066b89cc3ee843a6e2a807e701ca8"
 owners = ["nebel"]
 project_path = "CurrencyWatchdog"


### PR DESCRIPTION
- Add jurisdictions
  - Jurisdictions can be created in the "Advanced" drop-down header when selecting a burden
  - Jurisdictions can be used to override overlay panel visibility settings when in certain zones or when doing certain types of content