### PR TITLE
Photobooth v1.0.1.0

### DIFF
--- a/stable/Photobooth/manifest.toml
+++ b/stable/Photobooth/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/iri-impulse/PhotoboothPlugin.git"
-commit = "d02e32e3649fe2ce9c19b1b6ffd010ffc42223a6"
+commit = "5042d22592e6cb498101cea9a31b8cf6120e7eb2"
 owners = ["iri-impulse"]
 project_path = "Photobooth"
 changelog = """\
-1.0.0:
-- Initial stable release. Enjoy!
+1.0.1:
+- Update for patch 7.5
+- Fix diagram title flicker when right-dragging
 """


### PR DESCRIPTION
- Dalamud API bump
- One-line fix for the camera diagram header disappearing when right-dragging