### PR TITLE
CustomResolution v1.1.4.0

### DIFF
--- a/stable/CustomResolution2782/manifest.toml
+++ b/stable/CustomResolution2782/manifest.toml
@@ -1,15 +1,10 @@
 [plugin]
 repository = "https://git.0x0a.de/0x0ade/DP-CustomResolution.git"
-commit = "f152a693c861528c281b0685f2f35f9a4c203b49"
+commit = "70420406b6f16fc327fab6e141f37c7ec7e48fa6"
 owners = ["0x0ade"]
 project_path = "CustomResolution2782"
 changelog = """
-Since 1.1.2.0:
-- Work around a Dalamud plugin install bug which breaks the manifest .json
-Since last working stable:
-- Move internal utilities to new shared utility
-- API14 compat, migrate from SharpDX to TerraFX (except compiler)
-- Fix Dalamud UI cursor positioning (apparently broken since late API13)
-- Implement scaling via new internal mode to work around GPU driver bugs and crashes
-- Improve exclusive fullscreen mode support
+- API15 compat
+- Fix compatibility with some Linux environments
+- Fix performance regression, mostly noticeable on Linux
 """


### PR DESCRIPTION
The IAsyncDalamudPlugin update and https://github.com/goatcorp/Dalamud/pull/2726 cleanup will have to wait for another day, as those don't hold up the plugin from being usable in general.

Same FloppyUtils target version as https://github.com/goatcorp/DalamudPluginsD17/pull/8482

https://git.0x0a.de/0x0ade/DP-CustomResolution/compare/f152a693c861528c281b0685f2f35f9a4c203b49...70420406b6f16fc327fab6e141f37c7ec7e48fa6

https://git.0x0a.de/0x0ade/DP-FloppyUtils/compare/68cdad478f0f4bb4c9a2372f4e7eb88afbe9f098...455c88760689dac42070aac9b652baee483f39e0
