### PR TITLE
Photobooth v1.0.2.0

### DIFF
--- a/stable/Photobooth/manifest.toml
+++ b/stable/Photobooth/manifest.toml
@@ -1,9 +1,12 @@
 [plugin]
 repository = "https://github.com/iri-impulse/PhotoboothPlugin.git"
-commit = "5042d22592e6cb498101cea9a31b8cf6120e7eb2"
+commit = "fc063100b5687dadea9422d4d15e672fc374c428"
 owners = ["iri-impulse"]
 project_path = "Photobooth"
 changelog = """\
+1.0.2:
+- Fix to left-dragging
+
 1.0.1:
 - Update for patch 7.5
 - Fix diagram title flicker when right-dragging


### PR DESCRIPTION
Fixes a just-introduced bug that slipped through with the update for 7.5.