### PR TITLE
feat: Echooglossian v4.2600.x released!

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "2ab107015847e0276719eb9023bbc4ef6b6e6a66"
+commit = "88e6924f032abd7a474fa833972cef5dacc77368"
 owners = ["lokinmodar"]
 changelog = "v4.2600.x \n fixes:\n - Bump to API 15\n features: \n - Full internal logic refactor and countless new functions added and more to come"

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "fdb5d1f38760036269ded40bc4c60fae95420d2d"
+commit = "c460ff048f6983f7e90f57654e2cb117e6021721"
 owners = ["lokinmodar"]
 changelog = "v4.2600.x \n fixes:\n - Bump to API 15\n features: \n - Full internal logic refactor and countless new functions added and more to come"

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "f62882c5d4494acc6a6b9816dfe7c227575e91c3"
+commit = "fdb5d1f38760036269ded40bc4c60fae95420d2d"
 owners = ["lokinmodar"]
 changelog = "v4.2600.x \n fixes:\n - Bump to API 15\n features: \n - Full internal logic refactor and countless new functions added and more to come"
 project_path = "."

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,6 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "88e6924f032abd7a474fa833972cef5dacc77368"
+commit = "f62882c5d4494acc6a6b9816dfe7c227575e91c3"
 owners = ["lokinmodar"]
 changelog = "v4.2600.x \n fixes:\n - Bump to API 15\n features: \n - Full internal logic refactor and countless new functions added and more to come"
+project_path = "."

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -3,4 +3,3 @@ repository = "https://github.com/lokinmodar/Echoglossian.git"
 commit = "fdb5d1f38760036269ded40bc4c60fae95420d2d"
 owners = ["lokinmodar"]
 changelog = "v4.2600.x \n fixes:\n - Bump to API 15\n features: \n - Full internal logic refactor and countless new functions added and more to come"
-project_path = "."

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "bc3d31d48f448e87a6477fc81c123e74eb612d28"
+commit = "2ab107015847e0276719eb9023bbc4ef6b6e6a66"
 owners = ["lokinmodar"]
-changelog = "v3.25.x \n fixes:\n - Bump to API 14\n - It is Sdk not SDK"
+changelog = "v4.2600.x \n fixes:\n - Bump to API 15\n features: \n - Full internal logic refactor and countless new functions added and more to come"


### PR DESCRIPTION
## Summary

- bump Echoglossian to API15 and ship the current `v4-series` runtime line
- migrate major plugin surfaces to the newer addon-handler / DB-first architecture, including talk-family flows, toast-family flows, quest-family windows, character/game-window flows, and canonical action/item/trait/reference-text persistence
- add multiple translation engines and related engines/config plumbing
- harden release/runtime behavior with quieter logging, debug-only probe commands, config-upgrade notice, main UI callback registration, and overlay/tooltip font-sizing fixes
- keep structured tooltip translation disabled for this release while `ActionDetail` / `ItemDetail` stabilization continues

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] in-game verification was performed when runtime UI behavior changed

## AI Usage Disclosure

Required for submissions to the official Dalamud plugin repository when AI use
went beyond basic autocomplete or inline suggestions.

Select one when applicable:

- [ ] `Assist` — human-led work with AI used for specific tasks
- [x] `Pair` — active human/AI collaboration throughout
- [ ] `Copilot` — AI did most of the writing while the human planned and reviewed
- [ ] `Auto` — AI acted mostly autonomously with minimal human direction

```text
AI scope:
- tooling used: ChatGPT / Codex
- files or areas most affected: addon-handler/runtime refactor, quest-family flows, game-window and DB-first persistence, translation-engine/config UI work, diagnostics and release hardening
- how the result was reviewed/tested: manual diff review, multiple local Debug/Release builds, xUnit test suite, and targeted in-game verification on affected UI surfaces