### PR TITLE
Allagan Tools 1.15.0.1

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "a3d9479b6b9911fa66b397373ecf90c085be9564"
+commit = "057c10316395899a5ebdc2d4fd3129fe3f994370"
 owners = [ "Critical-Impact",]
 project_path = "InventoryTools"
-version = "1.15.0.0"
-changelog = "### Changed\n- API15 update\n- Data update for 7.5\n- Now parses the extra items from the armoire + housing"
+version = "1.15.0.1"
+changelog = "### Fixed\n- Fix an issue that occurs when trying to open the \"Open Map\" menu for certain spearfishing items."


### PR DESCRIPTION
### Fixed
- Fix an issue that occurs when trying to open the "Open Map" menu for certain spearfishing items.