### PR TITLE
VanillaPlus

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "2436581b74541ac325f9a6ccbf160fcb5c1c2be3"
+commit = "318aee457104b7aa404a5481881d9ca6332e97c4"
 owners = [ "MidoriKami",]
 maintainers = [ "Haselnussbomber", "Zeffuro",]
 project_path = "VanillaPlus"


### PR DESCRIPTION
Duty Loot Preview - Fixed scrolling bug when changing tabs

Duty Loot Preview - Update Data

Party Finder Presets - Reworked Feature, old configs are incompatible, with 7.5 Square Enix broke how this worked, so this new approach won't let them break it again even if they change it in the future.