### PR TITLE
[Testing] DeviceChangeFix v3.1.1

### DIFF
--- a/testing/live/DeviceChangeFix/manifest.toml
+++ b/testing/live/DeviceChangeFix/manifest.toml
@@ -1,10 +1,10 @@
 [plugin]
 repository = "https://github.com/nopjmp/DeviceChangeFix.git"
-commit = "0d6bbb7e9fdbcdf5ca650b838e9ddb750e1846a0"
+commit = "a3f97d0afdc000c77c932a2fbccf5ccd91b07ca4"
 owners = ["Jessidhia", "MKhayle", "nopjmp"]
 project_path = "DeviceChangeFix"
 changelog = """\
-		# 3.1.0
+		# 3.1.1
 		- Updated for API15
         - This is now filtering WM_DEVICECHANGE messages to only controller events
 		"""


### PR DESCRIPTION
Further testing on Windows showed that filtering on the device name is required so it is actually only controllers.

Tested with Sony Dualsense and Xbox Controllers that I had lying around.