### PR TITLE
[Testing] CustomResolution v1.1.6.0

### DIFF
--- a/testing/live/CustomResolution2782/manifest.toml
+++ b/testing/live/CustomResolution2782/manifest.toml
@@ -1,8 +1,11 @@
 [plugin]
 repository = "https://git.0x0a.de/0x0ade/DP-CustomResolution.git"
-commit = "096692c4be94f0959635836d693d72e4cf49dd4f"
+commit = "1fbcb652bb67175d0b0aeb8dec920903d6c3aebf"
 owners = ["0x0ade"]
 project_path = "CustomResolution2782"
 changelog = """
+Since last testing:
+- Fix game freezing on exit with async interface.
+Since last stable:
 - Low-level change: Use new Dalamud API15 interface for async plugins.
 """


### PR DESCRIPTION
Changes the FloppyUtils delayed execution context (basically fancy `RunOnFrameworkUpdateThread` which can also be used for other threads and other contexts, used in conjunction with my threaded detour helpers) for the framework update thread to match Dalamud's `RunOnFrameworkUpdateThread` regarding framework unloading. Fixes a deadlock with fully async CustomResolution on framework unload.

https://git.0x0a.de/0x0ade/DP-CustomResolution/compare/096692c4be94f0959635836d693d72e4cf49dd4f...1fbcb652bb67175d0b0aeb8dec920903d6c3aebf

https://git.0x0a.de/0x0ade/DP-FloppyUtils/compare/e167947dbf4dc3345024630bd6d7c2ba708dcdfa...feace87ff133068b53d36109e1aaed09c5b4bda8
