### PR TITLE
Glamaholic 1.15.2

### DIFF
--- a/stable/Glamaholic/manifest.toml
+++ b/stable/Glamaholic/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = 'https://github.com/caitlyn-gg/Glamaholic.git'
-commit = 'e9e8de7141242c1d99aa6e80c24a32b0371fbbcb'
+commit = '7ba1ae37416b30252c89cdcd019a3cf2f5b87e88'
 owners = [ 'caitlyn-gg' ]
 changelog = """
-- Updated "Hover to Preview / Copy Stains" to support the new categorized stain items
+- Fixed DyeCount check for HQ items:
+  - Since 7.5, applying plates with dyed HQ items would cause the dye to be temporarily removed from the plate for safety
 
 For troubleshooting, please enable Troubleshooting mode (Settings -> Troubleshooting mode), reproduce the issue, then post any log line from `/xllog` starting with `[Troubleshooting]`. Thanks!
 """


### PR DESCRIPTION
- Fixed DyeCount check for HQ items:
  - Since 7.5, applying plates with dyed HQ items would cause the dye to be temporarily removed from the plate for safety