### PR TITLE
TextToTalk v1.38.0

### DIFF
--- a/stable/TextToTalk/manifest.toml
+++ b/stable/TextToTalk/manifest.toml
@@ -1,8 +1,11 @@
 [plugin]
 repository = "https://github.com/karashiiro/TextToTalk.git"
-commit = "27779a07618288ae090d8562d88505e64034bcdf"
+commit = "11c76717a88b38781433297c3c53bf2ced19d344"
 project_path = "src/TextToTalk"
 owners = ["karashiiro"]
 changelog = """\
-- **System**: Fixed crashes when using the Characters and Locations lexicon.
+- **General**: Added global volume setting under the General settings
+- **General**: Added `/tttvolume` command to change the global volume setting
+- **General**: Added `/tttpreset <name>` command to change the Chat Channel preset configuration
+- **ElevenLabs**: Fixed missing model selector, which also fixes voice styles
 """


### PR DESCRIPTION
- **General**: Added global volume setting under the General settings
- **General**: Added `/tttvolume` command to change the global volume setting
- **General**: Added `/tttpreset <name>` command to change the Chat Channel preset configuration
- **ElevenLabs**: Fixed missing model selector, which also fixes voice styles