### PR TITLE
Update plugin CreateXIV - 1.0.6.4

### DIFF
--- a/testing/live/CreateXIV/manifest.toml
+++ b/testing/live/CreateXIV/manifest.toml
@@ -1,7 +1,10 @@
 [plugin]
 repository = "https://github.com/seventity7/CreateXIV.git"
-commit = "3a6b392087bd018a9d9eb986afa6c59954e080e1"
+commit = "d1b294b966f9609a8c6cc52cc19b04543e3e6f56"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
-changelog = "Update Native Commands Support"
+changelog = """
+- Added support for shared macros in **Macro Alias** command field
+  - Existing macro aliases continue to work normally
+"""


### PR DESCRIPTION
Added support for shared macros in **Macro Alias** command field

### Changed

- Updated `Plugin.cs` to recognize both `macro:<number>` and `shared:<number>`
- Updated `Windows/MainWindow.cs` so the UI/help text shows the new `shared:` format as well
  - Existing macro aliases continue to work normally.
