### PR TITLE
Update FCNameColor to 5.1.3.0

### DIFF
--- a/stable/FCNameColor/manifest.toml
+++ b/stable/FCNameColor/manifest.toml
@@ -7,6 +7,6 @@ changelog = """
 - Rewrite config menu entirely to use tabs instead of various windows
 - Rewrite the way the ignore list works, it now picks from members in every tracked FC, not just your own. You can now search within the list and add and remove multiple players at once as well as the currently targeted player.
 
-Feedback and suggestions on the previous nameplate hightlight feature as well as the new config and ignore feature would be appreciated!
+Feedback and suggestions on the previous nameplate highlight feature as well as the new config and ignore feature would be appreciated!
 Special thanks to MidoriKami for answering my questions when working on this
 """

--- a/stable/FCNameColor/manifest.toml
+++ b/stable/FCNameColor/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "a2795c6da72d72bd783b2f10487155bfb5e3939a"
+commit = "56de4542a9381d0aa3ab7b1c7d0423371b948cfc"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
-- Add nameplate hiding feature
+- Rewrite config menu entirely to use tabs instead of various windows
+- Rewrite the way the ignore list works, it now picks from members in every tracked FC, not just your own. You can now search within the list and add and remove multiple players at once as well as the currently targeted player.
 
-Feedback and suggestions on this feature would be appreciated!
+Feedback and suggestions on the previous nameplate hightlight feature as well as the new config and ignore feature would be appreciated!
+Special thanks to MidoriKami for answering my questions when working on this
 """

--- a/stable/FCNameColor/manifest.toml
+++ b/stable/FCNameColor/manifest.toml
@@ -1,11 +1,12 @@
 [plugin]
 repository = "https://github.com/WesselKuipers/FCNameColor.git"
-commit = "56de4542a9381d0aa3ab7b1c7d0423371b948cfc"
+commit = "2175e00d3faf49d26f8926e430b31cb055a3e9ee"
 owners = ["WesselKuipers"]
 project_path = "FCNameColor"
 changelog = """
 - Rewrite config menu entirely to use tabs instead of various windows
 - Rewrite the way the ignore list works, it now picks from members in every tracked FC, not just your own. You can now search within the list and add and remove multiple players at once as well as the currently targeted player.
+- Add color preview when assigning groups to FCs
 
 Feedback and suggestions on the previous nameplate highlight feature as well as the new config and ignore feature would be appreciated!
 Special thanks to MidoriKami for answering my questions when working on this


### PR DESCRIPTION
- Rewrite config menu entirely to use tabs instead of various windows
- Rewrite the way the ignore list works, it now picks from members in every tracked FC, not just your own. You can now search within the list and add and remove multiple players at once as well as the currently targeted player.

Feedback and suggestions on the previous nameplate highlight feature as well as the new config and ignore feature would be appreciated!

Special thanks to MidoriKami for answering my questions when working on this