### PR TITLE
Update SimpleTriggers v1.0.2.4

### DIFF
--- a/stable/SimpleTriggers/manifest.toml
+++ b/stable/SimpleTriggers/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "b8ae28c0ebd49ed074f4a9f7b1c5cc1a8d910ea4"
+commit = "6276375678edae7208f4717401d3865be8fdad16"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
 changelog = """
-* tweaks to trigger structure
+## SimpleTriggers v1.0.2.3
+* Minor improvements.
+* Disabled dectalk (was in testing)
 """

--- a/testing/live/SimpleTriggers/manifest.toml
+++ b/testing/live/SimpleTriggers/manifest.toml
@@ -1,10 +1,5 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "8541a6f99a80626b69fa994a2795ea4806a6bc04"
+commit = "6276375678edae7208f4717401d3865be8fdad16"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
-changelog = """
-## SimpleTriggers v1.0.2.0
-* Added new TTS option: DECtalk
-* Library loads from latest release on dectalk/dectalk and validates hashes before loading into memory.
-"""


### PR DESCRIPTION
## SimpleTriggers v1.0.2.4
* Minor improvements.
* Disabled dectalk (was in testing)
* Reduced artifact size ~7 MB. (Removed linux binaries from the output build, they aren't needed in Wine)