### PR TITLE
TargetLines 10.0.1.0

### DIFF
--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "07e94b9dc3c2e54d0dab1c6c1b702d4d49a5c18a"
+commit = "424876267f5bca8041ca0f631b8077f08facaf25"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
-- API15
+- Fix two reported crashes and make the surrounding code generally more safe
+- Fix an issue where switching from a newtworked object to a client-side object would skip playing the target switch animation
 """
 

--- a/stable/TargetLines/manifest.toml
+++ b/stable/TargetLines/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/Drahsid/TargetLines.git"
-commit = "424876267f5bca8041ca0f631b8077f08facaf25"
+commit = "d0c81c73bf2ea0efa84658ca5a7bab4d89452e4b"
 owners = ["Drahsid"]
 project_path = "TargetLines"
 changelog = """
 - Fix two reported crashes and make the surrounding code generally more safe
 - Fix an issue where switching from a newtworked object to a client-side object would skip playing the target switch animation
+- Fix an issue where the fallback line could consume a filter setting and cause line appearance to change or become invisible
 """
 


### PR DESCRIPTION
Fix the crash and error that was reported, one of which was caused by game object references going stale mid-frame; the other was from the faulty assumption that a game object of kind PC also had a PC game object.
There are also various other safety-related changes to ensure other similar issues don't crop up. Also a bugfix related to the target switching animation being skipped for client-only objects.