### PR TITLE
Plugin CreateXIV Update 1.0.6.5

### DIFF
--- a/testing/live/CreateXIV/manifest.toml
+++ b/testing/live/CreateXIV/manifest.toml
@@ -1,10 +1,15 @@
 [plugin]
 repository = "https://github.com/seventity7/CreateXIV.git"
-commit = "d1b294b966f9609a8c6cc52cc19b04543e3e6f56"
+commit = "dcee257b67c2acfcfb8496e376ef565bee9d6dce"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
 changelog = """
-- Added support for shared macros in **Macro Alias** command field
-  - Existing macro aliases continue to work normally
+- Added command suggestions while creating command aliases
+- Added macro suggestions while creating macro aliases, including shared macros
+  - Suggestions can be clicked to fill the command field automatically
+- Improved validation of command fields
+- Commands now automatically receive `/` when needed
+- Cleaner alias list and no longer shows the `N°` column
+- Saved aliases can now be sorted by clicking on column titles
 """


### PR DESCRIPTION
### Changes

- Added autocomplete popups for the `Command` fields in both Command/Macro creation
  - Macro Alias suggestions list only non-empty user-created macros and distinguish between regular and shared macros.
  - Selecting an item from the suggestion list fills the command field directly
- Command Alias suggestions are populated from available command handlers, including active plugin commands and native game commands
- Native game commands are labeled as `#FFXIV`, while plugin commands show their source plugin/assembly
  - **Does not rely on custom repo plugins and does not function with intent of having it either**

### Validation Improvements

- Reworked alias validation states to better reflect input state:
  - `Idle` for empty fields
  - `Waiting..` while fields are still being dited or incomplete
  - `OK` only when the target command or macro can be resolved
  - `Invalid` when the input is complete but cannot be resolved
- Improved prevention system for invalid command aliases
- Command Alias entries now automatically add a leading `/` on save when the command is missing it

_(typed 1.0.6.4 while commiting, mb)_