### PR TITLE
Update plugin CreateXIV 1.0.6.6

### DIFF
--- a/testing/live/CreateXIV/manifest.toml
+++ b/testing/live/CreateXIV/manifest.toml
@@ -1,15 +1,13 @@
 [plugin]
 repository = "https://github.com/seventity7/CreateXIV.git"
-commit = "dcee257b67c2acfcfb8496e376ef565bee9d6dce"
+commit = "2c4f251d01a34a7660e65e4fe198dbf8a61ffd0d"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
 changelog = """
-- Added command suggestions while creating command aliases
-- Added macro suggestions while creating macro aliases, including shared macros
-  - Suggestions can be clicked to fill the command field automatically
-- Improved validation of command fields
-- Commands now automatically receive `/` when needed
-- Cleaner alias list and no longer shows the `N°` column
-- Saved aliases can now be sorted by clicking on column titles
+### Fix Patch v1.0.6.6
+- **Fixed saved command and macro aliases being lost after restarting the game**
+- Updated command suggestion list
+- Removed the previous limit of 100 commands suggestions
+  - Added mouse wheel scrolling support for long suggestion lists
 """


### PR DESCRIPTION
### Important:
- **Fixed saved command and macro aliases being lost after restarting the game**

### Changes:
- Removed the hard-coded list of native commands.
  - Updated command suggestion and conflict validation logic to load native commands from the game's `TextCommand` Excel sheet through Dalamud/Lumina
- Removed the previous limit of showing only up to 100 commands suggestions
  - Added mouse wheel scrolling support for long suggestion lists.
- Updated the project target framework to `net10.0-windows7.0`
- Fixed all warnings during build

_(this is more a patch than update)_
