### PR TITLE
Update Echoglossian to v4.2601.0512.x

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "6ee927a0a0ccb14a25f3fb98cf00542372757b94"
+commit = "b3662579d2b1ee78d50bf5584590f770a15f8462"
 owners = ["lokinmodar"]
-changelog = "v4.2600.1205.x \n fixes:\n - fixed repeated translation requests after changing translation engine or model settings\n - completed the handler unregister follow-up so stale listeners stop surviving runtime refreshes"
+changelog = "v4.2601.0512.x \n fixes:\n - fixed repeated translation requests after changing translation engine or model settings\n - completed the handler unregister follow-up so stale listeners stop surviving runtime refreshes"

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "720e655e213d0bb105154272a04c36098d75bb07"
+commit = "6ee927a0a0ccb14a25f3fb98cf00542372757b94"
 owners = ["lokinmodar"]
-changelog = "v4.2600.1105.x \n fixes:\n - stabilized setup, engine selection, and first-use activation\n - improved action and main menu translation reuse between game versions\n - fixed translator cache concurrency and several native UI read-only rewrite regressions"
+changelog = "v4.2600.1205.x \n fixes:\n - fixed repeated translation requests after changing translation engine or model settings\n - completed the handler unregister follow-up so stale listeners stop surviving runtime refreshes"

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "b3662579d2b1ee78d50bf5584590f770a15f8462"
+commit = "3ff33f753910d06043ebb389a57c044d73385a49"
 owners = ["lokinmodar"]
 changelog = "v4.2601.0512.x \n fixes:\n - fixed repeated translation requests after changing translation engine or model settings\n - completed the handler unregister follow-up so stale listeners stop surviving runtime refreshes"


### PR DESCRIPTION
## Summary
- update Echoglossian to v4.2601.0512.x
- point the manifest at commit 3ff33f753910d06043ebb389a57c044d73385a49
- correct the submitted version scheme to the new 4.yy01.mmdd.HHmm format
