### PR TITLE
Altoholic v1.10.8

### DIFF
--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,8 +1,10 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "bf7c9e307e7ab6b919c708b94a35284e18503f13"
+commit = "0a3785da57135bece447f647408e77bf2d81b98f"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\
-- **Gear set list**: Fix gear set list not displaying some gear sets when missing ids in between
+- **Timers**:
+  - Add 'ban' icon on fashion reports timer column when unlocked but judging period is not active. 
+  - Fix roulette unlocked state for timers reminders
 """


### PR DESCRIPTION
Version 1.10.8:

- **Timers**:
  - Add 'ban' icon on fashion reports timer column when unlocked but judging period is not active.
  - Fix roulette unlocked state for timers reminders