### PR TITLE
[Testing] ChatAnywhere v1.1.1.0

### DIFF
--- a/testing/live/ChatAnywhere/manifest.toml
+++ b/testing/live/ChatAnywhere/manifest.toml
@@ -1,12 +1,9 @@
 [plugin]
 repository = "https://github.com/twelvehouse/ChatAnywhere.git"
-commit = "1d5cd9996fd2b21bd75fcdbaceb04151d14c8e3d"
+commit = "994b27d7f54705e46ac35ea46b0bab08400c06fe"
 owners = ["twelvehouse"]
 project_path = "."
 changelog = """
-New Features:
-- Each character can now have their own personal filter settings, separate from the shared filters. Toggle per-character mode by clicking the character name in the sidebar header.
-- The sidebar header now shows your current character's name and home world. Clicking it opens a dialog to switch between shared and personal filter modes.
-- Import filters and folders from another character's saved settings (Filters tab in Settings).
-- When the plugin server is unreachable, the interface shows a pulsing "Connecting..." animation and automatically retries with exponential backoff, instead of silently failing.
+Bug Fixes:
+- Fixed a crash when saving a passcode on Linux/Proton (Wine < 11). The OS-level PBKDF2 API missing in older Wine versions is now replaced with a pure managed implementation.
 """


### PR DESCRIPTION
# 1.1.1.0

- Fixed a crash when saving a passcode on Linux/Proton (Wine < 11). The OS-level PBKDF2 API (`BCryptDeriveKeyPBKDF2`) missing in older Wine versions is now replaced with a pure managed C# implementation.