### PR TITLE
ChatTwo

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "87f76cb1f5c6830c2ed5cc3eaa311e85b00bffac"
+commit = "25ffb320ba6b0ecd2e71d65f496b67e3a1ac3403"
 owners = [
     "Infiziert90"
 ]


### PR DESCRIPTION
- Fix context menu not working with input preview visible
- Separator lines now appear correct in world selection