### PR TITLE
Update SimpleTriggers v1.0.3 (testing)

### DIFF
--- a/testing/live/SimpleTriggers/manifest.toml
+++ b/testing/live/SimpleTriggers/manifest.toml
@@ -1,5 +1,9 @@
 [plugin]
 repository = "https://github.com/Brolijah/SimpleTriggers.git"
-commit = "6276375678edae7208f4717401d3865be8fdad16"
+commit = "5d6a0020cac4b18ba3e8b336a402b533eaa46661"
 owners = ["Brolijah"]
 project_path = "SimpleTriggers"
+changelog = """
+### SimpleTriggers v1.0.3
+* Replaced DECtalk with DECtalkMini.
+"""


### PR DESCRIPTION
* Replaced DECtalk with DECtalkMini
Mini is a more modern, community maintained version of the original DECtalk and is easier and safer to implement.
Needs some testers before I push up to stable. I tried it on both Linux and Windows and didn't have any crashes (or dangling threads like the original DECtalk), so I believe it should be good. DECtalkMini out of the box just supports English, but is a lower CPU-usage alternative to Kokoro for non-Windows platforms.