### PR TITLE
Update Echoglossian to v4.2601.0516.x

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "3ff33f753910d06043ebb389a57c044d73385a49"
+commit = "7be033b7c2c0809d664823690e029959a76caf4c"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0512.x \n fixes:\n - fixed repeated translation requests after changing translation engine or model settings\n - completed the handler unregister follow-up so stale listeners stop surviving runtime refreshes"
+changelog = "v4.2601.0516.x \n fixes:\n - fixed the OpenRouter prompt-expansion bug so fully materialized prompts reach the provider\n - hardened prompt substitution so literal placeholder text inside dialogue content is preserved"


### PR DESCRIPTION
## Summary
- update Echoglossian to `v4.2601.0516.x`
- ship the OpenRouter prompt-expansion hotfix

## Validation
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build Echoglossian.csproj -c Release --no-restore`

AI Usage Disclosure: Pair

Used AI for:
- bounded implementation help
- code review follow-up
- release workflow assistance

Human verification:
- reviewed the final diff manually
- ran local build and tests
