### PR TITLE
ChatTwo

### DIFF
--- a/stable/ChatTwo/manifest.toml
+++ b/stable/ChatTwo/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/ChatTwo.git"
-commit = "25ffb320ba6b0ecd2e71d65f496b67e3a1ac3403"
+commit = "ee7768ac0893f14580d89bff5644526d2d271ca0"
 owners = [
     "Infiziert90"
 ]


### PR DESCRIPTION
- Replace chat input if a command is inserted by vanilla functions
- Add a new option that prevents gathering and crafting related messages from being stored in the database
  - If you want gathering/crafting messages to be saved, Config -> Database -> "Save crafting and gathering messages in database"