### PR TITLE
[Testing] ChatAnywhere v1.2.0.0

### DIFF
--- a/testing/live/ChatAnywhere/manifest.toml
+++ b/testing/live/ChatAnywhere/manifest.toml
@@ -1,9 +1,14 @@
 [plugin]
 repository = "https://github.com/twelvehouse/ChatAnywhere.git"
-commit = "994b27d7f54705e46ac35ea46b0bab08400c06fe"
+commit = "57e120dc73e12a910e8987ac572986db6b95f6f0"
 owners = ["twelvehouse"]
 project_path = "."
 changelog = """
-Bug Fixes:
-- Fixed a crash when saving a passcode on Linux/Proton (Wine < 11). The OS-level PBKDF2 API missing in older Wine versions is now replaced with a pure managed implementation.
+New Features:
+- Long messages now wrap onto multiple lines in the input area instead of scrolling horizontally, so the full message stays visible while you type.
+
+Changes:
+- Pressing Enter (or Ctrl+Enter, depending on your setting) always sends the message. Line breaks can no longer be inserted by Enter or by pasting multi-line text, since FFXIV chat itself cannot send line breaks.
+- The send button and emote/symbol picker icons have been refreshed for a cleaner look.
+- The composer layout has been tightened so the channel selector, text field, and side buttons stay neatly aligned together at any font size.
 """


### PR DESCRIPTION
# 1.2.0.0

## User-facing changes
- Long messages now wrap onto multiple lines in the input area instead of scrolling horizontally.
- Pressing Enter (or Ctrl+Enter, depending on the user's setting) always sends the message. Line breaks can no longer be inserted by Enter or by pasting multi-line text, since FFXIV chat itself cannot send line breaks.
- Send button and emote/symbol picker icons refreshed for a cleaner look.
- Composer layout tightened so the channel selector, text field, and side buttons stay aligned at any font size.

## Internal changes
- Migrated data fetching to TanStack Query (settings, filter mode, emotes, avatars, OGP previews, character list). Global 401 handler is centralized at the QueryClient level.
- Added Zustand stores for persisted settings (\`settingsStore\`) and live session state (\`sessionStore\`, player identity + connection). Eliminated extensive prop drilling through ChatArea / MessageItem / Settings.
- Replaced the custom class-based ErrorBoundary with \`react-error-boundary\`.
- Replaced inline SVGs with \`lucide-react\` icons.
- Replaced ad-hoc template literal classNames with \`clsx\`.
- Dropped \`useCallback\` wrappers where React Compiler (already enabled) handles memoization.
- Added vitest + @testing-library/react + MSW test infrastructure (11 baseline tests). The MSW handlers are reused by the \`?demo\` page so demo mode no longer requires the plugin server.
- Added Husky + lint-staged pre-commit hook running ESLint on staged files + the full test suite.
- Updated the release workflow to run lint and tests before building.
- Cleaned up the auto-resize textarea: explicit \`min-height\` scaling with the user-selected font size so the placeholder doesn't clip at larger sizes.