### PR TITLE
Wotsit 1.1.3.0

### DIFF
--- a/stable/Dalamud.FindAnything/manifest.toml
+++ b/stable/Dalamud.FindAnything/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/goaaats/Dalamud.FindAnything.git"
-commit = "4ea96194c29ca785baf62e4a63c42e4a6af18f11"
+commit = "82fc59ac7eba411ac476eb41fbd05af1214274f2"
 owners = ["goaaats"]
 maintainers = ["nebel"]
 project_path = "Dalamud.FindAnything"


### PR DESCRIPTION
- Now shows the icon set for macro links in the settings window.
- Added the ability to re-arrange "what to search" entries via drag and drop.
- Added new "Other plugins" tab in this settings window. This tab only appears when another plugin is adding search entries to Wotsit. Selecting a plugin in this tab allows you to optionally:
  - Disable that plugin's ability to add search entries.
  - Override that plugin's "weight" for fuzzy matching.
  - Browse the search entries provided by that plugin.
- Changed the internal "other plugins" result limit from a global limit to a per-plugin limit.
- Other small fixes and improvements.