### PR TITLE
ChatTranslated v3.6

### DIFF
--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "ee1df78e0aa169239fc49dafb021ce959eca5b3d"
+commit = "187f4cfa833c623143df3b53188b6fec8f7e5ec5"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """

--- a/stable/ChatTranslated/manifest.toml
+++ b/stable/ChatTranslated/manifest.toml
@@ -1,10 +1,14 @@
 [plugin]
 repository = "https://github.com/kelvin124124/ChatTranslated.git"
-commit = "6c7ad810f305d815310a58655d271fc5df1c6453"
+commit = "ee1df78e0aa169239fc49dafb021ce959eca5b3d"
 owners = ["kelvin124124"]
 project_path = "ChatTranslated"
 changelog = """
-fix self message being translated
+- added setup wizard for fresh installs / whenever needed
+- allow user to choose from local / online language detection
+- allow user to choose from language include / exclude mode
+- update default prompt for llm translation
+- update openai model list
 """
 [plugin.secrets]
 cfv5 = "-----BEGIN PGP MESSAGE-----\n\nwV4D5E6vRX2hj04SAQdAwWjD3/KyJImP8dQmxaYopsnRrAzxTTyBXpjy8wD+\nukMwftTv2MvAmtpo4gs6XnvaiOwFbWGronS9JHxu6KX7VkYfqyoLBZNMdo+P\nqkCaSBuI0lgBYA7NBgG1qsc01OP7aWuQCwEsBTgBxUKHu3NXpJUA39789ZdG\nlijhq24gEee+H7e6TALiGvYh++jDhm7W07WnfBbuN8u/LmRlzXr9t+0ASIVv\niamGCfnX\n=iNor\n-----END PGP MESSAGE-----\n"


### PR DESCRIPTION
- added setup wizard for fresh installs / whenever needed
- allow user to choose from local / online language detection
- allow user to choose from language include / exclude mode
- update default prompt for llm translation
- update openai model list
- feat(cache): persist LRU translation cache to disk [#96](https://github.com/kelvin124124/ChatTranslated/pull/96)

AI usage: copilot