### PR TITLE
Update plugin Clock 1.0.6.8

### DIFF
--- a/stable/Clock/manifest.toml
+++ b/stable/Clock/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/seventity7/Clock.git"
-commit = "4969541ea139f6b453171bfdae9aa2169c206693"
+commit = "aeb223c7ec5bb2a27c3cc56517346585ebb0164e"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."

--- a/stable/Clock/manifest.toml
+++ b/stable/Clock/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/seventity7/Clock.git"
-commit = "96db6b84eeffc07bb1dd94485208cdcbcdbca19d"
+commit = "4969541ea139f6b453171bfdae9aa2169c206693"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
@@ -15,6 +15,12 @@ It still does the same things as before:
 - can show or hide `AM/PM`;
 - uses the configured time zone offset;
 - can apply a custom timestamp color;
+
+### Technicall stuff
+
+- Improved how custom chat timestamps are handled internally
+- Reduced unnecessary processing when the custom timestamp option is disabled
+- Improved further compatibility's
 
 ### Notes
 - `Match Channel Color` option temporarily removed

--- a/stable/Clock/manifest.toml
+++ b/stable/Clock/manifest.toml
@@ -1,18 +1,22 @@
 [plugin]
 repository = "https://github.com/seventity7/Clock.git"
-commit = "faa73350f6ccff89797db55ea674ad954e8c7a2b"
+commit = "96db6b84eeffc07bb1dd94485208cdcbcdbca19d"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
 changelog = """
-## New Chat Timestamp options
+### Changed Chat Timestamp System
 
-New **Chat Timestamp** section in the Clock settings
-- You can now show a custom timestamp directly in chat messages
-- Added options to match the chat channel color or choose a custom color
-- Added a timezone selector for chat timestamps, including a default **Local Time** option
-- Added a **Show AM/PM** option for timestamps
-- Chat timestamps wont show seconds even if the main clock is using a seconds format
-- Moved **Favorite Timezones** into the **Time Display** section
-- Added translations for the new Chat Timestamp settings
+The plugin now uses the native timestamp system.
+It still does the same things as before:
+
+- shows custom timestamps in chat;
+- supports 12-hour and 24-hour time;
+- can show or hide `AM/PM`;
+- uses the configured time zone offset;
+- can apply a custom timestamp color;
+
+### Notes
+- `Match Channel Color` option temporarily removed
+Please note that if you want to use this feature from this plugin, you might need to disable similar features from other plugins to avoid having any incompatibility in case if there is still any.
 """


### PR DESCRIPTION
### Update 1.0.6.8 - Focus: Timestamp feature

The native text-format hook is registered through Dalamud signature scanning and enabled during service construction.

The detour still:
- checks whether the requested addon text ID is the chat timestamp ID
- falls back to the original formatter when custom timestamps are disabled
- falls back to the original formatter for unrelated text formatting calls
- returns the custom timestamp string only when the plugin settings allow it

The custom timestamp output still respects the previous existing configuration options:

- 12-hour/24-hour display
- optional `AM/PM`
- configured timezone offset
- optional custom timestamp color;

> `Match Channel Color` option was temporarily removed since I couldnt get it to work properly/consistently.

The cached `Utf8String` pointer is still reused between calls but the code now reads more clearly around allocation, deletion and replacement.
Disposal behavior remains the same: the hook is disabled/disposed and the cached native string is deleted when the service is disposed.

**This update should solve any previous plugin incompatibility issues.**

> Tried to be more informative to avoid any possible confusion.