### PR TITLE
[Testing] Tidychat V3.0.0.0

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,8 +1,6 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "7cfe018c603651417394b7657e1ee30bc3c081c6"
-owners = [
-    "NadyaNayme",
-]
+commit = "b1375d71cf366cfd8bff351fdeb0665f90651cb3"
+owners = ["Kagekazu"]
+maintainers = ["NadyaNayme"]
 project_path = "TidyChat"
-changelog = "Fix GC+10%, Fix LootNotice filters (again), Add toggle for displaying Party Information when joining a party"


### PR DESCRIPTION
Rewrote the whole plugin to use messageID instead of regex where possible.

Bug fixes:
Chat history evicted newest instead of oldest (Stack → Queue/FIFO).
Crash fixes: invalid whitelist regex, single-word player names, null UIState derefs.
Thread safety: locking on log-message sets + chat history.
Dispose() now unsubscribes UI events, removes windows, releases the DTR entry.
UI: ChatHistoryTab saved every frame; Inverse Mode couldn't be enabled; bad EndTabBar.
Whitelist: Allow overrides emote hiding & beats Block; works in disabled channels; empty-name no longer matches all; added match modes.
Perf: cached AllRules + whitelist/name regexes (were rebuilt per message).
Cleanup: deleted dead GetDutyName.cs, merged 3 DTR settings, L10N format/fallback fixes, SmolMode off-by-one, rule typo/copy-paste fixes.
API: SetPlayerName uses ObjectTable.LocalPlayer (deprecated IClientState.LocalPlayer).
New option : server announcement filter