### PR TITLE
[Stable] ChatAnywhere v1.4.0.0

### DIFF
--- a/stable/ChatAnywhere/manifest.toml
+++ b/stable/ChatAnywhere/manifest.toml
@@ -1,17 +1,16 @@
 [plugin]
 repository = "https://github.com/twelvehouse/ChatAnywhere.git"
-commit = "d50c110887b149f5dbda41a8b27a6f98d9ea1a12"
+commit = "b75e4d354b5a2b8fc3938bde15e0889b634fdb8b"
 owners = ["twelvehouse"]
 project_path = "."
 changelog = """
 New Features:
-- Added Light, Dark, and System (follows your OS setting) theme options — choose your preferred appearance in the settings panel.
+- Added a send queue: after pressing Send, a brief countdown gives you a moment to cancel an accidental send. (Can be turned on in Settings.)
 
 Changes:
-- The avatar placeholder for anonymous users now adapts to match your selected theme.
-- The channel selector is now disabled in Direct Message view, where switching channels does not apply.
+- Made the light theme a little more kawaii.
 
 Fixes:
-- Text overflow highlighting in the message input now works correctly across all browsers.
-- Tooltip colors are now consistent throughout the UI.
+- The settings panel now opens as a full-screen modal on mobile.
+- The emote and symbol picker now expands inline below the input on mobile.
 """

--- a/stable/ChatAnywhere/manifest.toml
+++ b/stable/ChatAnywhere/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/twelvehouse/ChatAnywhere.git"
-commit = "b75e4d354b5a2b8fc3938bde15e0889b634fdb8b"
+commit = "b82f6b913f7480107f17c642e9432266c1bf7672"
 owners = ["twelvehouse"]
 project_path = "."
 changelog = """


### PR DESCRIPTION
# v1.4.0.0

## User-facing
- Added send queue: after pressing Send, a brief countdown lets you cancel an accidental send before it goes through (opt-in via Settings)
- Made the light theme a little more kawaii
- Settings panel now opens as a full-screen modal on mobile
- Emote and symbol picker now expands inline below the input on mobile instead of overlapping the message list

## Internal
- Added `react-countdown-circle-timer` package for the countdown animation in the send queue
- Added `pendingSendStore.ts` (Zustand) to manage the pending send state
- Added `PendingSendBackdrop` component that renders the countdown ring and intercepts taps to cancel the queued send
- Added `sendQueueDelay` setting (off by default) wired through `settingsStore`, `useSettingsSync`, and `OthersSettings`
- Extracted dark/light theme CSS variables from `index.css` into `src/theme/dark.css` and `src/theme/light.css`; `theme/index.ts` re-exports them
- `InputArea`: reworked mobile layout so the emote/symbol picker expands inline below the input rather than as a floating overlay
- `SettingsModal`: added `@media (max-width)` rule to go full-screen on mobile