### PR TITLE
InventorySearchBar 1.9.5.0

### DIFF
--- a/stable/InventorySearchBar/manifest.toml
+++ b/stable/InventorySearchBar/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/caitlyn-gg/InventorySearchBar.git"
-commit = "512d035d2bd702f1dbb4886607c914c02e7f9a5b"
+commit = "55ea35005257afb4ffeea27dca45a8b5b4def13f"
 owners = ["caitlyn-gg"]
 project_path = "InventorySearchBar"
 changelog = "- Added tradable filter"


### PR DESCRIPTION
Fixed the missing dependency service for CriticalCommons.

Apologies for the bad push, didn't get a build or load error after bumping CC so it looked fine at a glance after I had tested the actual feature changes. I will make sure to test properly before pushing dependency changes in the future.

P.S. I miss dependencies being a compile-time contract, can the world collectively decide that service locators are bad yet? :(