### PR TITLE
[Testing] TidyChat v 3.1.0.0

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "3bfec1496f05c404b67adc47399107cd2dc8e44c"
+commit = "478647552c3e65935d1b8e9d55e03b85e3f4ea81"
 owners = ["Kagekazu"]
 project_path = "TidyChat"

--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "695045e6ba1b79e64733ec90c3c5ff8484a45da7"
+commit = "3bfec1496f05c404b67adc47399107cd2dc8e44c"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
### New
- Filter profiles (Balanced, Minimal, Vanilla+) in Settings → General
- Combat tab under Advanced with combat log toggles
- Autosave when you close settings (Save / Save and Close removed)
- UI toggles for general item obtains, mount unlocks, and Active Help entries

### Bugfix
- Open-world XP and level-up lines now respect Progress filters (not just deep dungeons)
- LogMessage filtering wired/fixed for many system, obtain, combat, and gathering messages
- Party join filter bypass no longer depends on removed settings
- Gearset equipped help tooltip leading newline fixed in localization

### Update
- Balanced defaults for new installs; existing configs preserved (apply Balanced manually to switch)
- Always visible messages (instances, hunts, invites, quest progress, ready checks, combat adds, BGM, etc.); related toggles removed
- Merged settings (trade, relic book, loot rolls, hide others' obtain)
- Editing any setting switches profile to Custom
- Settings UI cleanup (Improved Messages grouped, blocked-message counter moved)
- Plugin punchline and description refreshed