### PR TITLE
Update NoTypeSay to 1.0.3.0

### DIFF
--- a/stable/NoTypeSay/manifest.toml
+++ b/stable/NoTypeSay/manifest.toml
@@ -1,9 +1,11 @@
 [plugin]
 repository = "https://github.com/salanth357/NoTypeSay.git"
-commit = "9e8653eec2ab8026ab16225cf7fe4a91e1ac54e1"
+commit = "42c3f9c31afb843ab4a30e61ff62a15f73c4cfbf"
 owners = ["salanth357"]
 project_path = "NoTypeSay"
 changelog = """
+1.0.3.0:
+- Update to avoid doing an /eatchicken in some circumstances
 1.0.2.2:
 - Update for 7.5
 """


### PR DESCRIPTION
More detail in the repo commit message and code comments, but tl;dr-

My existing hook on ReceiveEvent would sometimes fail to hook properly. As a result, if the player clicked the button, /eatchicken would get sent to the native handler as if that was the emote for the quest button and the player would /eatchicken (only if they had it unlocked, otherwise nothing happens).

Two main changes to fix this:
1. Switch to AddonLifecycle now that it has PreventOriginal
2. Don't pretend to be an emote button- the native handlers ignore params where the button's "type" isn't understood, so use type `9` for our buttons. This also lets us use the rest of the param's value to indicate which quest the button is for, rather than using node ids to work it out.

Also fixes an unrelated UTF8String leak in SendChat