### PR TITLE
Update Echoglossian to v4.2601.0531.0115

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "059d8e7795dd7d48322b8a80c4f9186a4e6f2f72"
+commit = "059d8e7687b4692fa5666e6f8d0a6030015afb32"
 owners = ["lokinmodar"]
 changelog = "v4.2601.0531.x \n production release:\n - toast family moved to ToastGui runtime path with corrected per-type gating\n - native reflow and alignment fixes for MiniTalk, BattleTalk, and toasts\n - unified native replacement diacritics toggle and cross-surface isolation fixes"

--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "7be033b7c2c0809d664823690e029959a76caf4c"
+commit = "059d8e7795dd7d48322b8a80c4f9186a4e6f2f72"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0516.x \n fixes:\n - fixed the OpenRouter prompt-expansion bug so fully materialized prompts reach the provider\n - hardened prompt substitution so literal placeholder text inside dialogue content is preserved"
+changelog = "v4.2601.0531.x \n production release:\n - toast family moved to ToastGui runtime path with corrected per-type gating\n - native reflow and alignment fixes for MiniTalk, BattleTalk, and toasts\n - unified native replacement diacritics toggle and cross-surface isolation fixes"


### PR DESCRIPTION
## Summary
- Production submission for Echoglossian `v4.2601.0531.0115`
- Updates `stable/Echoglossian/manifest.toml` to commit `059d8e7795dd7d48322b8a80c4f9186a4e6f2f72`
- Changelog highlights include ToastGui routing, native dialogue/toast reflow stabilization, and native replacement diacritics unification

## Validation
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build Echoglossian.csproj -c Release --no-restore`

AI Usage Disclosure: Pair

Used AI for:
- implementation and release workflow assistance
- review/checklist support

Human verification:
- reviewed diffs
- ran local build/tests
- performed in-game runtime verification during the stabilization cycle