### PR TITLE
Update manifest for CurrencySpender

### DIFF
--- a/stable/CurrencySpender/manifest.toml
+++ b/stable/CurrencySpender/manifest.toml
@@ -2,13 +2,12 @@
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
 owners = ["Blackcatz1911"]
 project_path = "CurrencySpender"
-commit = "f08fd02320adce9ca1b1749f34823935976a1c71"
+commit = "69612732fa9cbb139d5fa67de3aff39f6dfa9ed3"
 changelog = """
 ## 1.2.6
 ### Added
 - Fashion accessories can now be considered a collectable.
 - Settings to hide the UI in various scenarios.
-- Lifestream support for various locations.
 ### Fixed
 - Spelling errors.
 ### Changed

--- a/stable/CurrencySpender/manifest.toml
+++ b/stable/CurrencySpender/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
 owners = ["Blackcatz1911"]
 project_path = "CurrencySpender"
-commit = "f66fcb8cb609ee2c13f62edb63d41e2a9c7e20ce"
+commit = "f08fd02320adce9ca1b1749f34823935976a1c71"
 changelog = """
 ## 1.2.6
 ### Added

--- a/stable/CurrencySpender/manifest.toml
+++ b/stable/CurrencySpender/manifest.toml
@@ -2,12 +2,19 @@
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
 owners = ["Blackcatz1911"]
 project_path = "CurrencySpender"
-commit = "c12e7f8f9ec80a2aede01573adfd984f69e66f22"
+commit = "f66fcb8cb609ee2c13f62edb63d41e2a9c7e20ce"
 changelog = """
-## 1.2.5
+## 1.2.6
+### Added
+- Fashion accessories can now be considered a collectable.
+- Settings to hide the UI in various scenarios.
+- Lifestream support for various locations.
+### Fixed
+- Spelling errors.
 ### Changed
-- Updated for 7.4.
+- Updated for Dalamud API v15.
 - Updated ECommons.
-- Mathemathics, Heliometry & Mnemonics changes.
+### Removed
+- Kofi Banner.
 """
-version = "1.2.5"
+version = "1.2.6"


### PR DESCRIPTION
# Changelog

## 1.2.6
### Added
- Fashion accessories can now be considered a collectable.
- Settings to hide the UI in various scenarios.
- Custom repository plugin support for various locations.
### Fixed
- Spelling errors.
### Changed
- Updated for Dalamud API v15.
- Updated ECommons.
### Removed
- Kofi Banner.