### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "fbd127f9fa5eec0f83e1309bad2d39e8f931e2bf"
+commit = "e5d0c33cd616337899253dd0f69760369570929e"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
### Fixed
- Obtain filters (tomestones, nuts, clusters) and custom block rules work again
- Loot/Obtain "Show" toggles behave correctly when unchecked

### Added
- Retainer venture assign/payment toggle (separate from completed venture)
- Separate toggles for job change, portrait, and gearset equipped messages

### Changed
- Glamour/try-on messages default off for new installs
- Gearset toggle no longer controls job change, portrait, or glamour