### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "e5d0c33cd616337899253dd0f69760369570929e"
+commit = "e8190228b4fd93eaf0fded2c64bc03d0df3bb141"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## New

- **Clearer General tab help** — Filter descriptions now say which chat channels they affect and when you also need a tab-specific “show” toggle (System, Progress, Obtained, Crafting, etc.).
- **Separate aetherial reduction toggles** — Sands, success, and minigame messages can be shown or hidden independently instead of one bundled option.
- **Offered teleport** — Its own show/hide setting (no longer lumped in with other system lines).
- **MGP spending** — Jumbo Cactpot ticket purchases and similar MGP spend lines follow the MGP filter (including the system-channel purchase message).
- **Crafting errors always visible** — “Unable to craft” and similar error lines are no longer tied to the optional “all other crafting” filter.
- **FATE discovery & friend list** — Always allowed through; removed from the optional Error Messages clutter.
- **Settings layout** — Combat, Crafting & Gathering, Economy, Emotes, and related tabs reorganized with clearer section headers and help text (including cosmic / stellar notes).

## Bugfixes

- **Cosmic exploration** — Dataset submissions, cosmocredits, class points, daily progress, containers, and related lines are no longer overridden by broad “you obtain” or other generic rules when the matching cosmic toggles are on.
- **LogMessage vs chat** — Fixed cases where one inactive rule blocked a message even though another active “show” rule applied (crafting buffs, synthesis, combat effects, shared log IDs).
- **Channel alignment** — Many rules now use the channel the game actually delivers (System, Progress, Loot notice, Gain buff, Retainer sale, etc.), so toggles behave consistently with what you see in chat.
- **Custom deliveries & gil** — Gil from custom deliveries and related obtain lines filter more reliably.
- **FC login/logout** — Login and logout lines are distinguished correctly.
- **Cosmic credit extras** — The extra “you will receive additional cosmocredits” line is handled with the other cosmic reward messages.
- **Combat / crafting debug confusion** — Debug logs are less misleading when several rules share one name (e.g. combat effects).