### PR TITLE
Craftimizer 2.11.0.0

### DIFF
--- a/stable/Craftimizer/manifest.toml
+++ b/stable/Craftimizer/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/WorkingRobot/Craftimizer.git"
-commit = "dac6bba611d5909b1a13f5cd8aa0b98598791058"
+commit = "29098e806555b3cac9d95134451e5dc32c4419a0"
 owners = [ "WorkingRobot" ]
 project_path = "Craftimizer"


### PR DESCRIPTION
A Smarter Synthesis Helper!

New Features/Changes:
- Added a new "Next Action" solver that the Synthesis Helper now uses by default. Instead of solving the whole macro every time, it puts all of its effort into figuring out just the single best next step.
- The "Next Action" solver has a new "Time Limit" setting, so giving you a suggestion within a set amount of time no matter how fast or slow your PC is.
- New "Quality Target (%)" setting: aim for a set percentage of a recipe's max quality and stop there instead of always pushing for 100%
- New "Cap Quality to Max Collectable Threshold" setting: on collectables, the solver stops once it reaches the highest collectability tier instead of burning extra steps on quality you don't need.
- The solver is faster across the board, and on lower-core PCs the Next Action solver takes a quick first look at the options and then spends its time on the most promising ones (tweakable in the advanced settings).
- Removed the old Score Weights settings, since the scoring rework left them doing nothing.

Bug Fixes:
- Fixed a threading issue where the forked/genetic solvers would share one random number generator, which caused lots of annoying rare crashes.
- The solver no longer pads the end of a craft with pointless extra actions just to spend leftover durability or CP. It now finishes first, then maximizes quality, then uses as few steps as possible.
