### PR TITLE
[Testing] Tidychat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "e8190228b4fd93eaf0fded2c64bc03d0df3bb141"
+commit = "8f8b9a9cc8575e1f179bcadd54650557b724eb05"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## New

- **Obtain tab intro** — Short note on when you need **Filter Loot Roll** vs **Filter Obtained**, and that **Hide …** options hide when checked.
- **Smarter help tooltips** — Obtain, System, Economy, and search results append which **General** master filter must be on (System / Obtained / Loot Roll).
- **Allied Society** — UI wording updated from “beast tribe”; tribal currency list includes current tokens (e.g. Mamool Ja Nanook, Yok Huy Ward, Pelu Pelplume).
- **Tomestone hiding** — Shared check so hidden tomestones stay hidden in both chat and LogMessage paths.

## Bugfix

- **Allied Society currency IDs** — Corrected outdated item IDs so hide rules actually match in-game obtains.
- **“Show/ Hide …” labels** — Readded and cleanup up the Show / Hide labels.
- **Aetheryte ticket** — Split “ready” vs “used” messages; default off; fixed a rule that could never match both phrases at once.
- **LogMessage state** — Pending allows clear when you change settings so old toggles do not stick around in debug/filtering.
- **Search / help copy** — General Obtain filter help and several obsolete strings cleaned up.