### PR TITLE
[Testing] Tidychat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "8f8b9a9cc8575e1f179bcadd54650557b724eb05"
+commit = "16f9714d2bb74271559281920f2861da0e352919"
 owners = ["Kagekazu"]
 project_path = "TidyChat"

--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "16f9714d2bb74271559281920f2861da0e352919"
+commit = "0c06179a19992379a678b862c12be4d3262a3b4d"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## New

- **Per-line filters** — Instance/duty, submarine voyage, glamour, `/isearch`, misc system, crafting/gathering catch-alls, and stellar missions expose nested toggles; existing configs migrate on upgrade (v10/v11).
- **Cosmic split** — Class points/dataset vs daily progress are separate (v11 migration copies prior daily-progress users to both).
- **Master toggle behavior** — `FilterMasterAccessors` gates nested rules (master **and** child must be on); improved market board lines respect the market board sales master.
- **Settings layout** — Shared `SettingsTabLayout` (nested groups + separators): market board (sales → nested lines → gil entrusted), exploration (spidey vs location/hostile), stellar vs cosmic, airship vs submarine, loot rolls vs hide other obtains.
- **Help text / audit** — Tooltips list LogMessage IDs where rules use them; master help explains that turning a master off disables nested filtering until re-enabled.

## Bugfix

- **Market board UX** — Gil entrusted no longer sits between master and nested sale lines; gil entrusted stays independent of “show market board sales.”
- **Aetheryte** — Ticket ready vs attune are sibling toggles, not nested.
- **System tab** — Relic and mail use separate section headers.
- **Hunt currency obtains** — Wolf marks, allied seals, centurio seals, sacks of nuts, and GC seals were blocked while **Hide …** was unchecked (especially with **Show general item obtains** off). Shared obtain LogMessage template **657** was matching too broadly for marker-based hide rules.
  - **`ObtainCurrencyHelper`** — Explicit allow when the matching **Hide …** toggle is off (chat + LogMessage paths; debug tag `ObtainCurrency (hide off)`).
  - **Marker-based hide rules** — No longer match from template ID alone; must match the actual currency text/marker.
  - **Inactive show rules** — No longer block obtain lines on template match alone; currency lines exempt when hide is off.
- **ChatStrings / rules** — Assorted ID and matcher alignment from the LogMessage audit (e.g. gil spent, mount speed, crafting buff/execute IDs).