### PR TITLE
Update plugin Clock 1.0.7.1

### DIFF
--- a/stable/Clock/manifest.toml
+++ b/stable/Clock/manifest.toml
@@ -1,25 +1,27 @@
 [plugin]
 repository = "https://github.com/seventity7/Clock.git"
-commit = "6e2838f384a6a007e27566bc875be292ea60dcb4"
+commit = "6c7da0981d18cb9f7cb89f83ea4e99c5280c8531"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
 changelog = """
-## What's new
-- Alarms can now repeat instead of being one-time only
-- Added overlay reminders
-  - Clock can now show the next alarm on the main overlay
-  - Clock can now show today's detected maintenance on the main overlay
-- When typing `/clock`, a small suggestion list can now appear with available Clock commands
-  - This can be enabled or disabled from the `General` tab
-- You can now compare two timezones using commands like:
-    - `/clock EST to BRT`
-- Appearance shortcuts were added to make related settings easier to find
+## What's New
+Added an experimental **Chat Time Conversion** feature for the in-game chat messages
+When enabled, the plugin can detect date/times in chat, including single times and time ranges, ex: `8PM EST``7PM-10PM EST`, then show the converted time when hovering over it
 
-### Improvements
-- Alarm creation now prevents setting alarms for dates or times that already passed
-- Presets now focus on visual style without changing the user's current layout, size or position
+### Options/Settings
+- **Enable chat time hover** — turns on/off chat time detection/hover conversion
+- **Primary timezone** — chooses the timezone used for conversions
+- **Create Alarm** — Create a alarm based on the detected date/time from the chat
+- **Show alarm setup option** — turn on/off to show **Create Alarm** option in the conversion tooltip
+- **Tooltip duration** — controls how long the conversion tooltip stays visible
+- **Test** — sends example chat messages to test and see how the feature works
 
 ### Notes
-New overlay and command suggestion options are disabled by default until enabled by the user.
+- The feature is disabled by default and marked as **experimental** with multiple warnings
+- Dates/Times found in the same message will be used when creating alarms from it
+  - For time ranges, **Create Alarm** uses the first Time. _(08PM-12PM BRT, would use 08PM only)_
+  - Date context is used when creating alarms, messages having like `June 12th` pre-fill the alarm with the date
+    - If no date is detected, the alarm uses the current date
+- **The feature only changes how detected chat text is displayed/interacted with; it does not resend/consume the original chat message**
 """


### PR DESCRIPTION
Added an opt-in **Chat Time Conversion** feature that detects timezone-based mentions in chat and shows the converted result on hover.
The feature is marked as experimental because it modifies the displayed chat `SeString` and may interact with other chat-related plugins
<img width="633" height="239" alt="image" src="https://github.com/user-attachments/assets/fa0228f4-3cbb-4015-acf4-87b9c57ad8a6" />


### Main Changes
- Detects common time formats with explicit timezones, including single times and ranges such as `8PM BRT`, `7PM-10PM EST`, `7PM @ 10PM EST`, and `07 PM - 10 PM GMT`
<img width="424" height="150" alt="image" src="https://github.com/user-attachments/assets/bb51e812-c589-47e5-a483-2b1adbaf01ad" /> 
<img width="415" height="151" alt="image" src="https://github.com/user-attachments/assets/7a5122b9-7440-4777-b5b7-f12c8af798a5" />

- Supports AM/PM text and FFXIV AM/PM symbols
- Shows a compact hover tooltip with the converted time
- Adds a `Create Alarm` action when available
<img width="411" height="141" alt="image" src="https://github.com/user-attachments/assets/d7b4eb65-bcb2-4faa-8273-503ef06bb120" />

- Uses the first time in a range as the alarm target, while keeping the full range visible in the tooltip
- Reads date context from the same chat message for alarm creation, such as `June 12th`, `12th June`, or localized month names where supported

### Settings
- `Enable chat time hover`: enables chat time detection and hover conversion
- `Show alarm setup option`: controls whether the `Create Alarm` action can appear for valid times
- `Target timezone selector`: chooses the timezone used for displayed conversions
- `Tooltip duration`: controls how long the tooltip remains visible
- `Test button`: sends local test messages that exercise single-time parsing, range parsing, date context, hover display and alarm creation. _(Testing pourposes)_

### Safety/Compatibility Notes
- The feature is disabled by default and requires a explicit opt-in confirmation
- A one-time experimental warning is also shown before first activation and is only accepted when the user clicks `Yes`
<img width="464" height="212" alt="image" src="https://github.com/user-attachments/assets/fdee75d5-f984-47a0-aa40-57609f8429b6" />

- Existing chat messages **are not** consumed, resent or modified at the source; only the displayed `SeString` is adjusted to add the hover link
- The hover popup is drawn as a normal Dalamud window and is kept separated from the game chat input

This is a feature that fits the plugin main idea pretty well. This is was a quite tricky feature to create and it's not perfect. It is maked as  Experimental with multiple warnings on pourpose to avoid any "unaware" issues.

I'm more than open for feedbacks and suggestions, I'm sure there must be some things that could be done better and I'm more than open to listen.
