### PR TITLE
Update plugin Clock 1.0.7.2

### DIFF
--- a/stable/Clock/manifest.toml
+++ b/stable/Clock/manifest.toml
@@ -1,27 +1,19 @@
 [plugin]
 repository = "https://github.com/seventity7/Clock.git"
-commit = "6c7da0981d18cb9f7cb89f83ea4e99c5280c8531"
+commit = "471d3707f5531c6e49f79a515feb59dd8201f9c5"
 owners = ["seventity7"]
 maintainers = ["seventity7"]
 project_path = "."
 changelog = """
-## What's New
-Added an experimental **Chat Time Conversion** feature for the in-game chat messages
-When enabled, the plugin can detect date/times in chat, including single times and time ranges, ex: `8PM EST``7PM-10PM EST`, then show the converted time when hovering over it
+### Small Patch Update
+- Added a quick **Feedback/Report** button in the main window.
+**Improved:**
+- Time/date detection including formats like `Jun. 24, 2026 7:59 a.m. (PDT)` and other timezone tags
+- Improved the Alarms tab. It only uses Chat Conversion timezone when an alarm is created from chat
+- Support for more date/time patterns such as weekday-based dates, `tomorrow` and ISO-style
+- Overall chat detection/hover system
 
-### Options/Settings
-- **Enable chat time hover** — turns on/off chat time detection/hover conversion
-- **Primary timezone** — chooses the timezone used for conversions
-- **Create Alarm** — Create a alarm based on the detected date/time from the chat
-- **Show alarm setup option** — turn on/off to show **Create Alarm** option in the conversion tooltip
-- **Tooltip duration** — controls how long the conversion tooltip stays visible
-- **Test** — sends example chat messages to test and see how the feature works
-
-### Notes
-- The feature is disabled by default and marked as **experimental** with multiple warnings
-- Dates/Times found in the same message will be used when creating alarms from it
-  - For time ranges, **Create Alarm** uses the first Time. _(08PM-12PM BRT, would use 08PM only)_
-  - Date context is used when creating alarms, messages having like `June 12th` pre-fill the alarm with the date
-    - If no date is detected, the alarm uses the current date
-- **The feature only changes how detected chat text is displayed/interacted with; it does not resend/consume the original chat message**
+## Notes
+- Removed noisy warning logs from `Xllog`
+- `ChatTimeConversion` option stay as `Experimental`
 """


### PR DESCRIPTION
### Small 'Patch' Update

- Added a `Feedback/Report` shortcut that opens Dalamud's Installed Plugins page directly for `Clock` so users dont need to manually hunt through `/xlplugins`

**Improved:**
- Expanded Chat Time Conversion parsing for more formats, including dotted AM/PM tokens, wrapped timezone tags like `(PDT)`, `[EDT]`, `{GMT}` and dates such as `Jun. 24, 2026`.
- Added stricter contextual date handling for weekday-based dates, relative dates such as `tomorrow` and ISO-style date/time text
- Updated chat alarm creation so the Alarms tab only uses the `Chat Time Conversion` timezone when opened from the `Create Alarm` action
- Refined the chat hover matching flow to keep ranges/single-time matches separated
> Should reduce any overlap/fallback issues and preserve the existing tooltip/alarm behavior for detected chat times

### Notes
- Removed the warning diagnostics from `/xllog` _(The user doesn't need it)_
- `Chat Time Conversion` remains **explicitly** marked as **`Experimental`**