### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "54f39bb93857649c91f9b861ec6aa64ee15f6efa"
+commit = "31beff6f81c5933514975a7a14f0521b10eed7fc"
 owners = ["Kagekazu"]
 project_path = "TidyChat"

--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "31beff6f81c5933514975a7a14f0521b10eed7fc"
+commit = "c897dd49a74e1166725fe524628d334857e2f88c"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## New
- **Exploration → Hunt Messages:** Show mark bill messages (pick up, complete, abandon)
- **Glamour:** Dresser master toggle with nested outfit / projection / armoire options; try-on preview toggle; show personal effect acquired
- **Fishing:** Separate toggles for lure attempts, bite feelings, reel in line, and lose bait
- **Gathering:** Show stellar GP recovery; hide elemental shards now includes desynth
- **Settings:** Version in config title bar; clear (×) button on settings search

## Bugfixes
- Hunt currency hides (Allied Seals, Centurio Seals, sacks of Nuts) now block reliably on the LogMessage path
- **Custom filters:** Text/regex filters now apply on the LogMessage path (not just `#ID` filters); global whitelisted-player overrides no longer treat custom filters as player entries
- Broader LogMessage catalog matching — fewer missed or inconsistent filters
- Clearer `[LogMessage]` debug output when debug mode is on (`ID match` for dedicated LogMessage IDs)
- **Crafting:** Failure lines (`You use … → Failure!`, LogMessages 1155 / 5913) are now covered by **Show All other crafting** alongside success lines
- **LogMessage crashes:** Hardened text extraction before calling the game’s `FormatString` — validates message address and parameter readability, uses Lumina sheet text when possible, and skips unsafe format calls (fixes native crashes during login, job changes, and combat reported on 3.1.0.7)
- **Debug vs normal blocking (LogMessage path):**
  - **Debug on:** blocked lines still appear in chat with `[TidyChat] … [Blocked] [LogMessage]` tags; full detail also goes to `/xllog`
  - **Debug off:** blocked lines are actually hidden via `PreventOriginal()` (normal play)

## Changed
- Eligible for coffers moved from Glamour to System → Duty/instance section
- Old "glamour altered" and "lure messages" settings auto-migrate to the new split toggles
- New custom filters default to the **System** channel (was a different default before)
- **Settings search:** Commendations and personal message book now route to **System → Social and misc**; obsolete migrated settings (`ShowGlamourAltered`, `ShowLureMessages`) and duplicate `ShowPartyDissolved` entry removed from search
- **Custom filters UI:** Channel label lookup uses `ChatFlags` consistently
- **Localization:** Resx / Designer files resynced and normalized
- **Code cleanup:** Global usings adoption and minor formatting pass across plugin, rules, and settings tabs