### PR TITLE
Altoholic v1.10.15

### DIFF
--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "ed6369fd0fae5d93aab027fdaea218a240bd48d2"
+commit = "2529d1ba4c95865666c296ef747d6b07a2a1174d"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\

--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,8 +1,12 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "7e24304159e79b337a55fa67943584fec3ddee07"
+commit = "ed6369fd0fae5d93aab027fdaea218a240bd48d2"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\
-- **General**: Put debug logs behind setting checkbox"
+- **Collection**: 7.51 facewear"
+- **Progress**:
+  - Cosmic exploration rewards update
+  - Events reward for 2026 updated when optional reward not given by questline available (ie: those buyable via event currency) 
+- **Timers**: Tribe unlocking check was using custom deliveries check instead of correct one.
 """


### PR DESCRIPTION
Version 1.10.15: 

- **Collection**: 7.51 facewear
- **Progress**:
  - Cosmic exploration rewards update
  - Events reward for 2026 updated when optional reward not given by questline available (ie: those buyable via event currency)
- **Timers**: Tribe unlocking check was using custom deliveries check instead of correct one.