### PR TITLE
[Testing] HUD Manager 2.5.25.0

### DIFF
--- a/testing/live/HUDManager/manifest.toml
+++ b/testing/live/HUDManager/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/zacharied/FFXIV-Plugin-HudManager.git"
-commit = "81fde149dc604e8a3f1ef503bebbbbaf0dbec8f6"
+commit = "1cf34a6bf6d6cc14f298c07ab5b1412c847f57cb"
 owners = ["zacharied", "nebel"]
 project_path = "HUDManager"


### PR DESCRIPTION
- Add missing settings to split Status Info elements
- Fix an issue where changing an element's layout caused the position to change incorrectly when the position preview window was active
- Fix an issue where the export layout popup didn't render correctly
- Small improvements to UI text alignment