### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "76b922dde7e2341dcb12beb4b4d9e4f35d495e60"
+commit = "411a77ff118371e6d641f5be3f9dd34453f8335b"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## What's new

### Chat highlights
You can now pick **any colour** for chat highlight rules in **Tools → Chat Highlights**, instead of being stuck with preset swatches. Matching lines show up in chat in the colour you chose.

### Mark bill messages
Dawn Hunt and Clan mark bills are less noisy. With **General → Message rewrites → Improved mark bill obtain lines** on (default), you get one short obtain line and the “Mark details can viewed at any time…” reminder is hidden.

---

## Fixes

### Chat lines disappearing when they shouldn't
Some normal chat — especially in **FC or party** — could vanish from your log after unrelated system messages (e.g. talking about a **mount** after a mount unlock). That should happen much less often now.

### Old duty messages popping up again
Lines like **“Syrcus Tower has begun”** could show up later during unrelated things (e.g. FC crafting), even when you had instance messages filtered off. Improved duty commence messages now follow your System filter settings again.

### Gear “added to your inventory” still showing
If you use **bypass armoury chest**, gear could still appear when **Hide added to your inventory** was on. That hide path should be more reliable now.

If you still see those lines, check:
- **Currencies → Hide added to your inventory**
- **General → Filter Obtained** (master toggle for obtain filtering)

### NPC lines showing as blocked in debug
Boss/NPC dialogue occasionally showed `[Blocked]` in debug for no obvious reason — same family of fix as the FC/party chat issue above.

---

## If something still looks wrong

1. Turn on **Tools → Enable debug mode** and note whether the missing line shows `[Blocked]` and what label appears.
2. If party/FC lines vanish, try turning off **Tools → Chat history** for a session.
3. Check **Tools → Custom filters** for any Block rules that might match normal chat.