### PR TITLE
Update manifest for CurrencySpender

### DIFF
--- a/stable/CurrencySpender/manifest.toml
+++ b/stable/CurrencySpender/manifest.toml
@@ -2,18 +2,14 @@
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
 owners = ["Blackcatz1911"]
 project_path = "CurrencySpender"
-commit = "69612732fa9cbb139d5fa67de3aff39f6dfa9ed3"
+commit = "2b9fb128fa85c814e7d69844569314fc3c98bfaa"
 changelog = """
-## 1.2.6
+## 1.2.7
 ### Added
-- Fashion accessories can now be considered a collectable.
-- Settings to hide the UI in various scenarios.
+- New Currencies: Oizys Credits & Auxesia Credits.
+- Highlighting for NPCs and items/menus thanks to electr0sheep.
+- Option to automatically add/remove upgrade items to \\\"Items of Interest\\\".
 ### Fixed
-- Spelling errors.
-### Changed
-- Updated for Dalamud API v15.
-- Updated ECommons.
-### Removed
-- Kofi Banner.
+- Select Bait Ball was missing.
 """
-version = "1.2.6"
+version = "1.2.7"

--- a/stable/CurrencySpender/manifest.toml
+++ b/stable/CurrencySpender/manifest.toml
@@ -2,7 +2,7 @@
 repository = "https://github.com/Blackcatz1911/CurrencySpender.git"
 owners = ["Blackcatz1911"]
 project_path = "CurrencySpender"
-commit = "2b9fb128fa85c814e7d69844569314fc3c98bfaa"
+commit = "18e52baecc5b7aabd0ae991cdc1dbccc9c7ec378"
 changelog = """
 ## 1.2.7
 ### Added


### PR DESCRIPTION
# Changelog
## 1.2.7
### Added
- New Currencies: Oizys Credits & Auxesia Credits.
- Highlighting for NPCs and items/menus thanks to electr0sheep.
- Option to automatically add/remove upgrade items to "Items of Interest".
### Fixed
- Select Bait Ball was missing.