### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "cbc8e0b9e4bf243772a1b60ad2bce26745029b80"
+commit = "6c1f472ebbf34ee04f305a3a4dc6dd4644433195"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## New
- **Economy → Trade:** Show trade request sent, incoming trade requests, awaiting confirmation, trade canceled, trade complete, and trade item preview lines (most off by default; trade complete on)

## Bugfixes
- **Duty commence:** "Duty has begun" no longer blocks unrelated lines containing "has begun" (e.g. aramitama Lifestream FATE text)
- **LogMessage path:** More reliable handling — fewer edge-case mis-filters during login, job changes, and combat

## Changed
- **/xllog:** Blocked messages always written to the debug log — visible with `/xllog` → Debug filter, without enabling TidyChat's debug checkbox (dry-run `[TidyChat]` tags in chat still require **Tools → Enable debug mode**)
- Help markers clarified on Combat and General tabs

## Translations (Crowdin)
- Merged Crowdin updates for DE, ES, FR, IT, JA, NN, PT, RU