### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "6c1f472ebbf34ee04f305a3a4dc6dd4644433195"
+commit = "50a00d9ce42b2b38baed9bfc1140ec9aa68bb302"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## Removed (always pass through)
- **Combat tab** — entire combat filtering removed (damage, buffs, debuffs, casts, etc.)
- **Error message filters** — bulk of error-message rules removed; only FATE level-sync and active-help entry remain under System
- **Duty / progression noise:** unlocks, quest progress, mount messages, party tools, duty mechanic/sealed/objective bonus, personal effect acquired, “changes discarded/lost”, eligible-for-coffers, and related catch-alls

## New
- **Duty tab** (between Party and Deep Dungeons):
  - **Duty Finder** — registration language, registration complete, briefing, withdrawn, recruitment, unrestricted party lines, etc. (off by default)
  - **Show Unrestricted clear time** (off by default)
  - **Instance & duty status** — `/instance` master + nested toggles moved from System:
    - Instanced area messages
    - Duty will end soon
    - Guildhest will end soon
    - Level no longer synced
- **Allied Societies:** **Omicron Omnitoken** (`37854`) and **Loporrit Carat** (`38952`) per-currency hide toggles

## Changed
- **System tab:** reorganized into Travel, Social, Mail & utility, and Orchestrion; **World & instances** section removed (duty/instance options moved to Duty); commendations moved to **Party**
- **Economy tab:** gear repair moved from Gil → new **Repairs** section
- **Settings search:** paths and label keys updated for tab-prefixed layout (`*Tab_*` for Exploration, Glamour, Housing, Materia, Progress, Party, System, Economy, Duty)
- **Rule metadata:** corrected `SettingsTab` assignments (e.g. spiritbound gear → Materia, gear repair → Economy, duty/instance rules → Duty)