### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "50a00d9ce42b2b38baed9bfc1140ec9aa68bb302"
+commit = "c130dce67e356d39bbac0ae96c76d2c25c751d8e"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## Duty tab
- Duty finder notifications + unrestricted clear time (both default off)
- Instance/duty status master + nested instanced area / duty end / guildhest end / level desync toggles

## Bug fixes
- LogMessage→chat sync is allowlist-only; player chat channels excluded
- Custom Filters help text moved below table; Allow column 96→128px

## New
- **General → Condense enemy cast log** (`BetterEnemyCastLog`, default off) — LogMessages 501/533; enemies only; instant uses still show