### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "a688db8db04a658aa4c8f7cb11e46b82d3fdf5d3"
+commit = "fcfb587025a6ff1ee3e02004a6b8e51a1dd2d25f"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
### Bugfix
- LogMessage sync no longer leaks into player channels (say/shout/party/tell/LS/FC/etc.) via deny-list + channel-matched pending blocks
- Quest obtain filter no longer kills loot flytext (`ShowObtainedQuestItems` soft-hide)
- Treasure dungeon kick-out reports correct floor (stale floor + trap/gate off-by-one; resets on zone change)
- Gil/MGP hide rules no longer false-match generic gear obtains
- Stellar mission complete / high score lines no longer fall through as generic `(Filter)`
- Enemy cast log no longer spams `/xllog` with one line per suppressed ability

### New
- Cosmic tool mastery obtains covered by **Show cosmic class points, tool mastery, and dataset submission** (657/1259)
- Cosmic **sizable contribution** rule (LogMessage 10790)
- Stellar mission **complete** rule (LogMessage 10781)

### Change
- Debug block logging gated behind **Tools → Enable debug mode** only
- Cosmic class points toggle label/help updated for tool mastery
- Cosmic exploration help updated for sizable contribution (10787–10790)