### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "a688db8db04a658aa4c8f7cb11e46b82d3fdf5d3"
+commit = "fcfb587025a6ff1ee3e02004a6b8e51a1dd2d25f"
 owners = ["Kagekazu"]
 project_path = "TidyChat"

--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "fcfb587025a6ff1ee3e02004a6b8e51a1dd2d25f"
+commit = "b2f793d942edae6a2642b07fa82e17385867b27e"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
## Fixed
- Loot and system message filters no longer hide things other players type in say, shout, party, tell, linkshell, or Free Company chat.
- "Show all players" works again, so other people's loot rolls and lot casts show up like they should.
- Hiding quest item pickups no longer removes the floating pickup text above your character.
- Hiding gil or MGP pickups no longer hides your normal gear and item pickups along with them.
- The kicked-out message in treasure map dungeons now shows the floor you were actually on.
- Cosmic Exploration mission completions and high scores are recognised on their own now, so they follow your Cosmic settings instead of getting caught by a generic filter.

## Added
- Tool mastery point gains are now covered by the "show cosmic class points, tool mastery, and dataset submission" setting.
- Cosmic Exploration sizable contribution messages can now be filtered.
- Stellar mission complete messages now have their own filter.

## Changed
- Setting labels and help text for cosmic class points and exploration now mention tool mastery and sizable contributions.
- Blocked messages always show in the plugin log, while the in-chat debug labels only appear when debug mode is turned on.