### PR TITLE
Update plugin QuickSymbols 1.0.1.0

### DIFF
--- a/stable/QuickSymbols/manifest.toml
+++ b/stable/QuickSymbols/manifest.toml
@@ -1,9 +1,16 @@
 [plugin]
 repository = "https://github.com/LatencyBryer/QuickSymbols.git"
-commit = "d5968b3eac5bbfc9dc51c16f6715291bf6a6429d"
+commit = "a7163bfe93a7be3ff11d28b329d9c316c97d68bc"
 owners = ["LatencyBryer"]
 maintainers = ["LatencyBryer"]
 project_path = "."
 changelog = """
-- Added IPC support/documentation
+### What's New?
+- Added **Button position** options:
+  - **Left of Chat**
+  - **Right of Chat**
+  - **Keybind Only**
+- Option to **Use Dalamud theme** instead of the FFXIV theme
+- Added a popup **Background opacity** option
+  - Can be adjusted from **0%** to **100%** _(Transparent to Opaque)_
 """


### PR DESCRIPTION
- New `ButtonPlacement` config option for the main plugin button
- Changed the default placement to **Right of Chat** to avoid the button being pushed off-screen when the chat window is close to the left edge
- Added a `UseDalamudTheme` config option that swaps only the symbol popup/list styling to Dalamud theme colors
- Added a `BackgroundOpacity` config option for the popup background
  - Range: `0%` to `100%`