### PR TITLE
[Testing] TidyChat

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "b2f793d942edae6a2642b07fa82e17385867b27e"
+commit = "76014301cdc049ae720dff6ed226f40efe374d10"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
### Bugfix
- Other-player item obtains, loot rolls, and cast lots now respect their party-tab toggles (`HideOthersObtain`, `ShowOthersLootRoll`, `ShowOthersCastLot`)
- Generic obtain/roll show rules no longer match other-player lines when those toggles should defer them
- Added LootNotice hide coverage for shared obtain templates (657/1259) with other-player markers

### New
- **Progress tab:** “Show mettle gain messages” toggle (LogMessage 9635)