### PR TITLE
Update plugin Clock

### DIFF
--- a/stable/Clock/manifest.toml
+++ b/stable/Clock/manifest.toml
@@ -1,24 +1,18 @@
 [plugin]
 repository = "https://github.com/LatencyBryer/Clock.git"
-commit = "2c9b68db6ef7b6617a07e037d7df52027f193caf"
+commit = "956eb6aa496810f738197c064d8fd3cd2b26f2e5"
 owners = ["LatencyBryer"]
 maintainers = ["LatencyBryer"]
 project_path = "."
 changelog = """
 ### **Added:**
-- New themes: **Digital**, **Tech**, **Cartoon** **Countdown**
-- New option for changing the clock font style
-- New **Alarm overlay** with keybind support and better visual/functionality
-- New **Seasonal Events** reminder option
-  - Optional notifications + Alarm
+- Maintenance reminders now auto-create alarms
+- Chat time conversion now detect time formats using symbols
 
-**Improved:**
-- UI cleanup, translation improvements and general stability
-- Chat time conversion/alarm creation
+### **Improved:**
+- Maintenance reminders now uses the start time
+- Maintenance checks run automatically every 2 hours
 
 ### **Notes:**
-- The `alarm` section was removed from the main window
-  - **Alarm management is now focused on `/alarms`**
-  - Existing alarm features were reorganized, not removed
-- Reminders are now under **Reminders** tab
+- Old **24 hours** maintenance reminder option was replaced for **5 hours before**
 """


### PR DESCRIPTION
- Maintenance reminder options now create alarm entries
- Added support for special number glyphs in Chat Time Conversion
  - `U+E08F` for `0`
         <img width="18" height="20" alt="image" src="https://github.com/user-attachments/assets/b7a923d0-eba5-4bac-a524-27b92a2769b1" />
  - `U+E090` till `U+E098` = `1` till `9`
         <img width="149" height="25" alt="image" src="https://github.com/user-attachments/assets/a922fed7-dcf7-4008-99ca-71c961d88da8" />
  - `U+E099` till `U+E0AE` = `10` till `31`
         <img width="354" height="21" alt="image" src="https://github.com/user-attachments/assets/e0d0d195-6eab-4406-8ea2-74dae1784ce6" />
  - Combinations of both mixed are also supported
 _source: https://ffxiv.consolegameswiki.com/wiki/Special_chat_characters_
 <div align="center">
<img width="388" height="140" alt="image" src="https://github.com/user-attachments/assets/c480a37f-cfd2-44b6-a210-c7c377f44b55" />
</div>

- Maintenance reminder  **24 hours** option changed  to **5 hours**
- Maintenance auto-check interval changed to every **2 hours**
- Maintenance check no longer depends on the config window being open to run

### **Fixed:**
- Maintenance parser now prioritizes the Lodestone text `From ... to ...` range and stores the actual start time
_(Example: **`From`** `Jun. 22, 2026 11:00 p.m.` **`to`** `Jun. 23, 2026 3:00 a.m. (PDT)`)_