### PR TITLE
[TidyChat] bugfixes and move to stable.

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "0d2012311db8de29358f0117ac50371ac584ab7a"
+commit = "c25d12bec0a87f5262f104f541e801e1866f1a9f"
 owners = ["Kagekazu"]
 project_path = "TidyChat"

--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "76014301cdc049ae720dff6ed226f40efe374d10"
+commit = "c25d12bec0a87f5262f104f541e801e1866f1a9f"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
### Housing
- **Ward entry** matching is stricter — lottery lines with “ward ” no longer match the ward-entry rule
- New **Housing lottery** toggle on the Housing tab (lottery submission + estate tab reminder)

### Filtering fixes
- Friend requests no longer tagged as materia retrieval
- Materia “you receive …” matching is more specific
- Venture **coffers** no longer treated as venture currency for hide rules
- Combat log (damage, heals, casts, buffs, etc.) is never filtered
- Error lines only hidden when a hide toggle is explicitly on

### Other
- Localization resource cleanup
- Editor/resx tooling tweaks