### PR TITLE
v1.0.10 updating to use new SDK version

### DIFF
--- a/testing/live/WachuMakeyMaking/manifest.toml
+++ b/testing/live/WachuMakeyMaking/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/ArcaneAj/WachuMakeyMaking.git"
-commit = "88ba81bb14728605dbac34f7064fd1ecbd4255b7"
+commit = "e56373c4e7290d51189af83af52a013dc518c29d"
 owners = ["ArcaneAj"]
 project_path = "WachuMakeyMaking"
 
 changelog = """
-Better handles large numbers of recipes with Universalis, while giving progress updates on requests.
-Fixed bug where switching gearset reset the resource overrides. Changes that don't affect total amounts shouldn't reset them.
+Updated to use SDK v15.
+Fixed bug where opening any extra inventory or changing item quantities in game reset the resource overrides.
+Manually set/overriden quantities do not get thrown away, even if the item you've changed the quantity for has had its underlying quantity change.
 """


### PR DESCRIPTION
AI Usage: Hint (or whatever you call the default suggestions that vs community 2026 has)

Using the new SDK version

Fixed an issue where the manually set resources get wiped when you open a retainer/saddlebag even if you've opened it before.