### PR TITLE
[Testing] HUD Manager 2.5.26.0

### DIFF
--- a/testing/live/HUDManager/manifest.toml
+++ b/testing/live/HUDManager/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/zacharied/FFXIV-Plugin-HudManager.git"
-commit = "1cf34a6bf6d6cc14f298c07ab5b1412c847f57cb"
+commit = "3d6aa03953232ca336c678a4abc9573cd58409da"
 owners = ["zacharied", "nebel"]
 project_path = "HUDManager"


### PR DESCRIPTION
- Adds a toggleable tree view to the layout editor:
  - The tree view allows you reorder and reposition layouts (and entire layout subtrees) freely via drag and drop.
  - Rather than setting a layout's parent via dropdown, simply place a layout under another to set it as the child. (Hold shift to attach a layout as the child of another if it currently has no children.)
  - You can also drag and drop an element from the currently selected layout to another layout on the tree. This lets you copy or move element configurations between layouts.
  - Return to the (slightly improved) compact view at any time.
- Numerous other small improvements to the UI.