### PR TITLE
Update plugin QuickSymbols

### DIFF
--- a/stable/QuickSymbols/manifest.toml
+++ b/stable/QuickSymbols/manifest.toml
@@ -1,18 +1,9 @@
 [plugin]
 repository = "https://github.com/LatencyBryer/QuickSymbols.git"
-commit = "d5f35580462cd7cc0979c72d5d478f88da53014a"
+commit = "c53f089146f9e42b189bfe6df81702e40400e814"
 owners = ["LatencyBryer"]
 maintainers = ["LatencyBryer"]
 project_path = "."
 changelog = """
-### What's New?
-- Fixed "♥" button alignment/centering
-- The "♥" button now appears in more native windows:
-  - User Macros
-  - Strategy Board
-- New **optional** feature: Automatic Text-To-Symbol
-  - Automaticaly convert known texts to symbols, like <3 -> ♥
-  - Create your own Text-To-Symbol in the config
-Note:
-"Text-To-Symbol" feature is intended for vanilla chat only and will work ONLY with it.
+- Added a "Compatibility Disclaimer" on config window
 """


### PR DESCRIPTION
I’ve been receiving various requests for the `QuickSymbols` plugin to work with other plugins, specifically the `Chat2` plugin.
This feedback is coming in not only through the feedback channel on the Dalamud server but also via my DM's in Discord.

I don't mind receiving those feedbacks but since the request is something that they shouldn't be asking to me and instead to `Chat2` developers, I decided to put a disclaimer explaining it so people don't think I'm ignoring them.

I’ve added an icon with a tooltip to the `QuickSymbols` settings to provide information about plugin compatibility.
<img width="988" height="340" alt="image" src="https://github.com/user-attachments/assets/bf931641-11a2-4955-b1aa-f3f6bb475aa1" />
> Just note that even tho these type of request shouldn't been sent to me and instead Chat2 devs, I still never said to the user's to go bother them. I just wanted to point out a explaination for they feedback.