### PR TITLE
TidyChat 3.1.0.20

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "c25d12bec0a87f5262f104f541e801e1866f1a9f"
+commit = "b8f5d055c81b580ff9f3cd16698a183318fe69f4"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
- Fixed gathering crystals/shards/clusters not being hidden when the message starts with the character name instead of `You`.
- Fixed crystal/shard/clusters obtains on the Obtained channel being allowed by the collectable gathering obtain rule.
- Fixed the title bar version label drawing over other windows.
- Made Jumbo Cactpot ticket purchases always show, independent of the "Hide obtained MGP" setting.
- Tightened MGP obtain matching to reduce false positives.