### PR TITLE
BilingualTooltips 1.7.1.0

### DIFF
--- a/stable/BilingualTooltips/manifest.toml
+++ b/stable/BilingualTooltips/manifest.toml
@@ -1,12 +1,15 @@
 [plugin]
 repository = "https://github.com/Elypha/BilingualTooltips.git"
-commit = "893ffc56713dbdfa74ef9a7b07dad9edf7d4748c"
+commit = "8f0a689492691cb96ab6c4130dbe076555cd6d14"
 owners = ["Elypha"]
 project_path = "BilingualTooltips"
 changelog = """
-v1.6.0.0
-- Fix display of lo......ng names in tooltips.
+v1.7.1.0
 
-v1.6.0.1
-- Update to API 15.
+This is a major update and please check against your current settings after updating, as some settings have been renamed or removed.
+
+- Add support for NPC dialogues.
+- Add support for a few more actions/items (DeepDungeon, minions/mounts, Bozjan, etc.).
+- Add lookup history window to show some statistics about your bilingual exploration.
+- Add support for all FFXIV official languages (JEDF plus Chinese and Korean, WIP).
 """


### PR DESCRIPTION
hi!

this is an accumulated large update, a few new features and some refactor for WIP feature compatibility.

**legacy Tooltips/ContentsFinder/CosmicMissions etc have been heavily refactored:**
- they are migrated to a new pipeline/data factory to avoid caching a lot of lumina tables and is easier to maintain
- the addon lifecycle is also updated to a managed mutation
- plus the translation injection being redesigned. now the description is added as a separate node without modifying the native description node text payload, and is compatible with other tooltip plugins, same as the name/title node
<img width="401" height="460" alt="image" src="https://github.com/user-attachments/assets/418d4a37-15ce-488c-ad7c-01faf153e6f0" />

**support for NPC dialogue has been added:**
- most chat-box should now be bilingual, plus options for customise rendering (name, gender)

https://github.com/user-attachments/assets/0ccdb1de-94f0-4ac0-b9d0-96cf40723da5

this is related to the majority of the code changes so please let me explain for the sake of code review.

this feature was brought from one of my local QoL plugin and was migrated to BilingualTooltips. it used to require a local API server hosting a large in-memory dataframe to work and the performance was rough.

I thought about it for a long time but didn't find a light/performant/native way to do it at runtime with lumina. I once asked another dev and parsing the dialogue script id (like item ids) requires to patch some lua scripts and is beyond my knowledge.

the current implementation uses an additional binary data pack that holds pre-processed dialogue data (https://github.com/Elypha/btt-source-exporter) for matching and retrieval. this enables the whole pipeline to be highly customisable and is mostly instant. it also makes it possible to extend the plugin's bilingual ability to cover all 7 official localisations (plus Simplified/Traditional Chinese and Korean that are not in SE's client).

**a lookup history window was created:**
- most BilingualTooltips lookups can be configured to count into statistics and can be viewed
- it displays the entry in as many localisations as available on the client & data pack

<img width="925" height="444" alt="image" src="https://github.com/user-attachments/assets/58cf967c-f9f6-4a59-a435-881b75279949" />

