### PR TITLE
[TidyChat] 3.1.0.21

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "b8f5d055c81b580ff9f3cd16698a183318fe69f4"
+commit = "29b555c82dde0f574d2001c04264f8ba3a5ee759"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
- Always show `/playtime`.
- Fix party leave not showing.
- Preserve party join/leave SFX when toggles are off .
- Show learned actions and emotes.
- Filter Frontline objective announcements — `ShowPvpZoneAnnouncements` now also covers Seal Rock / Fields of Glory / Onsal Hakair objective lines.