### PR TITLE
Update plugin QuickSymbols

### DIFF
--- a/stable/QuickSymbols/manifest.toml
+++ b/stable/QuickSymbols/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/LatencyBryer/QuickSymbols.git"
-commit = "c53f089146f9e42b189bfe6df81702e40400e814"
+commit = "4a2a2d93106da2ea49ba729ac52a5078f22acb4b"
 owners = ["LatencyBryer"]
 maintainers = ["LatencyBryer"]
 project_path = "."
 changelog = """
-- Added a "Compatibility Disclaimer" on config window
+Fix:
+- Text-to-symbol feature can now be used while sending tells or any messages through any channel instead of been blocked like commands.
 """


### PR DESCRIPTION
Text-to-symbol feature can now be used in any chat channels:
  - `/tell` `/party` `/shout` `/yell` `/say` `/alliance` `/fc` `/n`

For safety, other commands are still ignored.