### PR TITLE
HUDUnlimited

### DIFF
--- a/stable/HUDUnlimited/manifest.toml
+++ b/stable/HUDUnlimited/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/HUDUnlimited.git"
-commit = "e1de2cde53ef55d925221aab56fdacee2f2c2c26"
+commit = "8244a1af4e897c7abffd2203c298160a60c9f6bc"
 owners = [ "MidoriKami",]
 project_path = "HUDUnlimited"


### PR DESCRIPTION
When HUDU Can't find a node, it will now only log the warning once per session.

Some nodes don't exist at all times, and so seeing a warning for some nodes might be normal.

