### PR TITLE
Job roulette 1.4.1.0

### DIFF
--- a/stable/JobRoulettePlugin/manifest.toml
+++ b/stable/JobRoulettePlugin/manifest.toml
@@ -1,11 +1,11 @@
 [plugin]
 repository = "https://github.com/sleeds2/jobroulette.git"
-commit = "8b6eb6addfe17ecbb71c2c38174e0d2174eb57a0"
+commit = "5ea28329c69530d940804584ee0cd927bbe43762"
 owners = ["sleeds2"]
 maintainers = ["mchudoba"]
 project_path = "JobRoulettePlugin"
 changelog = """\
-**New Feature**: Added an option to choose a random glamour plate when randomly choosing a job.
-- Option added to the settings panel to toggle random glamour plate switching
-- /jobroulette `glam`|`glamour` will toggle the random glamour option
+**New Feature**: Added an option to allow/disallow rolling your current job.
+- Toggle added to the settings panel
+- /jobroulette `current` will toggle the current job option
 """

--- a/stable/JobRoulettePlugin/manifest.toml
+++ b/stable/JobRoulettePlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/sleeds2/jobroulette.git"
-commit = "5ea28329c69530d940804584ee0cd927bbe43762"
+commit = "88d74aee534bd1023db06e6c90d22c14fd67c3cc"
 owners = ["sleeds2"]
 maintainers = ["mchudoba"]
 project_path = "JobRoulettePlugin"

--- a/testing/live/JobRoulettePlugin/manifest.toml
+++ b/testing/live/JobRoulettePlugin/manifest.toml
@@ -1,11 +1,11 @@
 [plugin]
 repository = "https://github.com/sleeds2/jobroulette.git"
-commit = "8b6eb6addfe17ecbb71c2c38174e0d2174eb57a0"
+commit = "5ea28329c69530d940804584ee0cd927bbe43762"
 owners = ["sleeds2"]
 maintainers = ["mchudoba"]
 project_path = "JobRoulettePlugin"
 changelog = """\
-**New Feature**: Added an option to choose a random glamour plate when randomly choosing a job.
-- Option added to the settings panel to toggle random glamour plate switching
-- /jobroulette `glam`|`glamour` will toggle the random glamour option
+**New Feature**: Added an option to allow/disallow rolling your current job.
+- Toggle added to the settings panel
+- /jobroulette `current` will toggle the current job option
 """

--- a/testing/live/JobRoulettePlugin/manifest.toml
+++ b/testing/live/JobRoulettePlugin/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/sleeds2/jobroulette.git"
-commit = "5ea28329c69530d940804584ee0cd927bbe43762"
+commit = "88d74aee534bd1023db06e6c90d22c14fd67c3cc"
 owners = ["sleeds2"]
 maintainers = ["mchudoba"]
 project_path = "JobRoulettePlugin"


### PR DESCRIPTION
### Changelog
1.4.1.0

**New Feature**
- Added a feature to enable/disable rolling current job
-- Added a toggle in the settings menu for new option
-- Added a new command `/jobroulette current` to toggle new option

**AI Usage**: Assist