### PR TITLE
Update Echoglossian to v4.2601.0712.1140

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "a6479a8d3354101639ca3b7cc1bedb34b87393d1"
+commit = "2b3c2518b300812c6014c26bcfe25e8c228c3270"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0710.x \n production release:\n - structured dialogue translation, glossary/context routing, and better LLM provider coverage\n - custom OpenAI-compatible providers, live model refresh, and stronger debugger diagnostics/retranslation tools\n - prompt/history/quota hardening plus expanded target-language and downloadable script-font support"
+changelog = "v4.2601.0712.1140 \n production release:\n - explicit retranslate-and-persist support for TalkSubtitle, CutSceneSelectString, and TextGimmickHint story surfaces\n - visible story-surface provenance and direct View In DB Manager handoff in /eglotranslatordebugger\n - shared read-only DB inspection components reused between the debugger and DB manager, plus follow-up diagnostics hardening"


### PR DESCRIPTION
## Summary
- update `stable/Echoglossian/manifest.toml` to release commit `2b3c2518b300812c6014c26bcfe25e8c228c3270`
- refresh the official feed changelog for `v4.2601.0712.1140`
- publish the release already tagged at https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0712.1140

## New Plugin Functionality
- extends explicit retranslate-and-persist support to additional player-visible story surfaces: `TalkSubtitle`, `CutSceneSelectString`, and `TextGimmickHint`, alongside the existing `Talk` and `BattleTalk` flows
- adds visible story-surface provenance inspection in `/eglotranslatordebugger`, including runtime provenance, effective DB table, last update status, and a direct `View In DB Manager` handoff for the current row
- reuses the DB manager's read-only inspection UI primitives inside the debugger so both surfaces render the same table/detail structures while keeping CRUD and EF-specific providers isolated to the DB manager
- includes follow-up hardening for the new diagnostics and persistence path, covering enum mapping safety, latest-snapshot consistency, retranslation outcome promotion, and operator-facing fallback behavior

## Validation
- verified `refs/heads/v4-series` and `refs/tags/v4.2601.0712.1140` both resolve to `2b3c2518b300812c6014c26bcfe25e8c228c3270`
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build Echoglossian.csproj -c Release --no-restore`

AI Usage Disclosure: Pair

Used AI for:
- implementation and release workflow assistance across the underlying Echoglossian changeset
- review follow-up handling and release-prep drafting
- repo and manifest update automation

Human verification:
- reviewed the final diffs manually
- validated the plugin branch before release
- confirmed local build and test results before submission
