### PR TITLE
ChillFrames

### DIFF
--- a/stable/ChillFrames/manifest.toml
+++ b/stable/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "97f7d364819ffd401ed61b444c1a0dd919e544c4"
+commit = "ac7cf4750e457acab46a3b294a3e88efbd712aee"
 owners = [ "MidoriKami",]
 project_path = "ChillFrames"


### PR DESCRIPTION
Now disables the games idle frame limiter entirely while between loading areas.

Turns out the game has been making your loading screens take longer for years if you're tabbed out while loading with the idle frame limiter options enabled.

No more I say! I tab out because I am tired of waiting! I don't want that to make me have to wait even longer!