### PR TITLE
[Testing] Glamour Roulette 0.9.9.1

### DIFF
--- a/testing/live/GlamourRoulette/manifest.toml
+++ b/testing/live/GlamourRoulette/manifest.toml
@@ -1,10 +1,12 @@
 [plugin]
 repository = "https://github.com/sleeds2/glamourroulette.git"
-commit = "a6ca31d37030053fc692fce2f5449d7825901c6c"
+commit = "91db46705a414b7ca1d1eae76b192c6bfa1dd5e7"
 owners = ["sleeds2"]
 maintainers = ["mchudoba"]
 changelog = """\
 **New Plugin**: Glamour Roulette is a plugin for Final Fantasy XIV that randomly selects one of your saved Glamour Plates and swaps to it.
 - Allows the user to select eligible gearsets to be randomized.
 - Don't know what to wear tonight? Glamour Roulette has you covered!
+
+0.9.9.1 Testing Update - Modified Glamour Plate window and applications to utilize client actions.
 """

--- a/testing/live/GlamourRoulette/manifest.toml
+++ b/testing/live/GlamourRoulette/manifest.toml
@@ -8,5 +8,5 @@ changelog = """\
 - Allows the user to select eligible gearsets to be randomized.
 - Don't know what to wear tonight? Glamour Roulette has you covered!
 
-0.9.9.1 Testing Update - Modified Glamour Plate window and applications to utilize client actions.
+0.9.9.1 Testing Update - Modified Glamour Plate window and switching to utilize client actions.
 """


### PR DESCRIPTION
### Glamour Roulette

Glamour Roulette is a plugin for **Final Fantasy XIV** that randomly selects one of your saved Glamour Plates and swaps to it.

With the recent lifting of glamour restrictions, more and more gear can be used with any job. Show off your outfits no matter what you are doing. 

Don't know what to wear tonight? `Glamour Roulette` has you covered!

### Testing Pre-Release 0.9.9.1 Patch Notes
- Updated Glamour Plate functionality to utilize native client condition checks and actions
- Removed plugin conditional checks to utilize client native errors

**AI Usage**
Pair - Worked alongside the AI and a software engineer friend to build the plug-in. All testing done by humans. 