### PR TITLE
Update Echoglossian to v4.2601.0715.1114

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "2b3c2518b300812c6014c26bcfe25e8c228c3270"
+commit = "b584115640c5b9b9bda53001652007a710d892b3"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0712.1140 \n production release:\n - explicit retranslate-and-persist support for TalkSubtitle, CutSceneSelectString, and TextGimmickHint story surfaces\n - visible story-surface provenance and direct View In DB Manager handoff in /eglotranslatordebugger\n - shared read-only DB inspection components reused between the debugger and DB manager, plus follow-up diagnostics hardening"
+changelog = "v4.2601.0715.1114 \n production release:\n - texture-backed RTL presentation with bidi shaping, right alignment, adaptive layout, and bounded memory caches\n - source, target, and engine-scoped canonical translation reuse with normalized language aliases and extended client identities\n - stabilized ActionMenu, Character, MainCommand, context-menu, reference-text, and hover flows while eliminating severe frame-rate drops"


### PR DESCRIPTION
## Summary
- update `stable/Echoglossian/manifest.toml` to release commit `b584115640c5b9b9bda53001652007a710d892b3`
- refresh the official feed changelog for `v4.2601.0715.1114`
- publish the release already tagged at https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0715.1114

## New Plugin Functionality
- adds a texture-backed RTL presentation path with bidirectional shaping, right alignment, adaptive hover sizing, configurable line height, and bounded CPU/GPU memory caches
- scopes canonical translation reuse by client source language, target language, and translation engine, including normalized provider aliases and extended Chinese, Korean, and Traditional Chinese client identities
- stabilizes `MainCommand`, `AddonContextMenuTitle`, `ActionMenu`, and Character-family windows with canonical sheet-backed data and incremental translation application
- removes database and translation work from hot repaint paths that caused severe frame-rate drops in ActionMenu and Character
- improves dense action, item, quest, and game-window hover rendering while preserving native JournalDetail formatting in tooltip-only mode
- includes regression/performance coverage and design specifications for later native RTL support in Echoglossian and potentially Dalamud

## Validation
- verified `refs/tags/v4.2601.0715.1114` resolves to `b584115640c5b9b9bda53001652007a710d892b3`
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`: 588 passed
- `dotnet build Echoglossian.csproj -c Release --no-restore`
- broad in-game validation across RTL rendering, ActionMenu, Character-family windows, game-window menus, and JournalDetail

AI Usage Disclosure: Pair

Used AI for:
- implementation, debugging, test coverage, documentation, and release workflow assistance across the underlying Echoglossian changeset
- log/probe analysis, review follow-up, and manifest submission drafting

Human verification:
- directed the architecture and behavior decisions
- supplied runtime probes and repeated in-game validation
- reviewed the final diffs and confirmed local build/test results
- confirmed that no AI-generated repository assets are included