### PR TITLE
Update Echoglossian to v4.2601.0717.0008

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "b584115640c5b9b9bda53001652007a710d892b3"
+commit = "578bce65cc09deeb23571e0e58ed6306f871d859"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0715.1114 \n production release:\n - texture-backed RTL presentation with bidi shaping, right alignment, adaptive layout, and bounded memory caches\n - source, target, and engine-scoped canonical translation reuse with normalized language aliases and extended client identities\n - stabilized ActionMenu, Character, MainCommand, context-menu, reference-text, and hover flows while eliminating severe frame-rate drops"
+changelog = "v4.2601.0717.0008 \n MiniTalk regression hotfix:\n - restore bubble layout safely after game-owned repaints\n - normalize wrapped source overlay line breaks and control bytes\n - stabilize MiniTalk overlay and native sizing against the visible balloon"


### PR DESCRIPTION
## Summary

- update Echoglossian stable manifest to `v4.2601.0717.0008`
- point the official feed at release commit `578bce65cc09deeb23571e0e58ed6306f871d859`
- publish the MiniTalk regression hotfix summary for users in the stable manifest

## Validation

- [x] `dotnet build Echoglossian.sln -c Debug --no-restore`
- [x] `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- [x] `dotnet build Echoglossian.csproj -c Release --no-restore`
- [x] in-game verification was performed for the MiniTalk regression fix

## AI Usage Disclosure

- [ ] `Assist`
- [ ] `Pair`
- [x] `Copilot`
- [ ] `Auto`

AI scope:
- tooling used: Codex
- files or areas most affected: MiniTalk native reflow and overlay normalization in Echoglossian, plus release metadata and manifest submission
- how the result was reviewed/tested: manual diff review, local Debug/Test/Release validation, GitHub checks on the integration PR, and in-game verification

## AI-Generated Assets Disclosure

AI-generated assets:
- none
