### PR TITLE
Discord Rich Presence (Stable 2.0.9.2/Testing 2.0.9.3)

### DIFF
--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -5,7 +5,7 @@ owners = [
     "Bronya-Rand"
 ]
 maintainers = [
-    "Bronya-Rand"
+    "Bronya-Rand",
     "reiichi001",
     "goaaats"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "432b11e5ae9f9aaaf5bc5254b63df6a4c25bbba0"
+commit = "708d6256a36b30c07e5b51e154bef807028f55bc"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,13 +1,11 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "9d4d55ab5e2240e5b04ebbdca0065aff71ee4489"
+commit = "432b11e5ae9f9aaaf5bc5254b63df6a4c25bbba0"
 owners = [
-    "Bronya-Rand",
-    "vmfunc"
+    "Bronya-Rand"
 ]
 maintainers = [
-    "Bronya-Rand",
-    "vmfunc",
+    "Bronya-Rand"
     "reiichi001",
     "goaaats"
 ]

--- a/testing/live/Dalamud.RichPresence/manifest.toml
+++ b/testing/live/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "f336a74e18c52e8a8cd225f1b7417db719862a78"
+commit = "024b79ea0bda36e32397418398016d82472cf55a"
 owners = [
     "Bronya-Rand"
 ]

--- a/testing/live/Dalamud.RichPresence/manifest.toml
+++ b/testing/live/Dalamud.RichPresence/manifest.toml
@@ -1,13 +1,11 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "70427370a61be4434e7e0727549532dfd64f2487"
+commit = "f336a74e18c52e8a8cd225f1b7417db719862a78"
 owners = [
-    "Bronya-Rand",
-    "vmfunc"
+    "Bronya-Rand"
 ]
 maintainers = [
     "Bronya-Rand",
-    "vmfunc",
     "reiichi001",
     "goaaats"
 ]


### PR DESCRIPTION
## What's New?
> Some features are only available on the testing branch and will be labeled as such.

- **Template System!** Instead of toggling certain things or whatnot, now you can create your own RPC details within XIV.

  | Tag | Description |
  | :--: | :------------: |
  | {playername} | Your character's name (e.g. Y'shtola Rhul) | 
  | {fc} | Your free company's tag (e.g. «FFXIV») |
  | {world} | The current world you are in (e.g. Balmung) |
  | {homeworld} | Your home world (e.g. Goblin) |
  | {dc} | The data center you are in (e.g. Aether) |
  | {ward} | The ward of your current residential area (e.g. Ward 20) |
  | {job} | Your job name or abbreviation [if enabled] (e.g. Summoner or SMN) |
  | {level} | Your current level (e.g. 100) |
  | {location} | The current location name/content you are in/doing (e.g. New Gridania/Windurst) |

> Depending on what you toggled, this update will 'attempt' to reconstruct what you had as valid tags. For all available tags, past this version, see the *Available Tags* drop down. Clicking on a tag in this dropdown will copy the tag to your clipboard to paste in the field textbox. A preview of what will be shown is available to you below every field.

- (Testing Only) **New Discord Socket**. The plugin can now communicate with all Discord clients on Linux whether it be Flatpak, Snap or a Native Client + 3rd-Party Clients (Vesktop).
- (Testing Only) Removed WineRPCBridge as part of the plugin itself.
- (Testing Only) Removed the Wine toggle in the configuration window.