### PR TITLE
[TidyChat] 3.1.0.28

### DIFF
--- a/testing/live/TidyChat/manifest.toml
+++ b/testing/live/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "c25d12bec0a87f5262f104f541e801e1866f1a9f"
+commit = "9692b12a64abfcf4cb568afc512d9678f372ea25"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
- **Hide FATE level sync** works again for the “too many levels above this FATE” warning (including older content that says 5 levels instead of 6).
- **Other plugins’ chat** on System (and similar filtered channels) shows again instead of being hidden as spam.
- **Emote filtering** correctly keeps emotes that involve you when filtering is on.