### PR TITLE
Update Echoglossian to v4.2601.0718.2006

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "578bce65cc09deeb23571e0e58ed6306f871d859"
+commit = "f0b4dec9265b5cf350464974329d4dae4fbc1dd8"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0717.0008 \n MiniTalk regression hotfix:\n - restore bubble layout safely after game-owned repaints\n - normalize wrapped source overlay line breaks and control bytes\n - stabilize MiniTalk overlay and native sizing against the visible balloon"
+changelog = "v4.2601.0718.2006 \n OpenRouter live-model refresh and preview-infrastructure follow-up:\n - fix Fetch Live Models when the configured base URL already includes /v1\n - refresh hosted preview validation infrastructure without shipping vendor-only assets"


### PR DESCRIPTION
## Summary
- update `stable/Echoglossian/manifest.toml` to `v4.2601.0718.2006`
- point the official manifest at Echoglossian commit `f0b4dec9265b5cf350464974329d4dae4fbc1dd8`
- publish the submitted changelog for the OpenRouter live-model refresh fix and the hosted preview infrastructure follow-up

## Validation
- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build Echoglossian.csproj -c Release --no-restore`

## Release
- GitHub release: https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0718.2006

## AI Usage Disclosure
AI Usage Disclosure: Auto

Used AI for:
- release-preparation bookkeeping, changelog drafting, manifest update, and PR drafting
- validation assistance and exact-commit release coordination

Human verification:
- reviewed the final diff manually
- resolved and verified the exact release commit and remote branch hash
- ran local build and tests from the exact release commit

## AI-Generated Assets Disclosure
```text
AI-generated assets:
- none
```