### PR TITLE
[TidyChat] 3.1.0.29

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "77e3c22d768d01c419b1078f010233ba1caac4da"
+commit = "b0e42a8fa97b25c00a5b0ce7c1f94a4bd5b1c0ae"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
- **Hide FATE level sync** works again for the “too many levels above this FATE” warning (including older content that says 5 levels instead of 6).
- **Other plugins’ chat** on System (and similar filtered channels) shows again instead of being hidden as spam.
- **Emote filtering** correctly keeps emotes that involve you when filtering is on.