### PR TITLE
[Testing] Discord Rich Presence 2.0.9.4

### DIFF
--- a/testing/live/Dalamud.RichPresence/manifest.toml
+++ b/testing/live/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "024b79ea0bda36e32397418398016d82472cf55a"
+commit = "041a27ff90179dc6f0f8fd79cfb3ec36fdc86749"
 owners = [
     "Bronya-Rand"
 ]


### PR DESCRIPTION
# What's New?
- Added a alternate envar check `WINE_HOST_XDG_RUNTIME_DIR` to fix issues finding Discord's socket on Wine/Proton 11 installs.