### PR TITLE
VanillaPlus v1.4.1.20

### DIFF
--- a/stable/VanillaPlus/manifest.toml
+++ b/stable/VanillaPlus/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/MidoriKami/VanillaPlus.git"
-commit = "9a8add0ed7cbf011456a067a98243a48a02b8e90"
+commit = "25d6e41c3307b63dd73a89a4b61d0229c70084f6"
 owners = [ "MidoriKami",]
-maintainers = [ "Haselnussbomber", "Zeffuro",]
+maintainers = [ "Haselnussbomber", "Zeffuro" ]
 project_path = "VanillaPlus"


### PR DESCRIPTION
nofranz

Added a workaround for a deadlock issue.
This is currently from the https://github.com/MidoriKami/VanillaPlus/tree/deadlock-workaround branch, because I don't have the permissions to push to main.

Please also merge the ban for the last version: https://github.com/goatcorp/DalamudAssets/pull/347