### PR TITLE
[Testing] Discord Rich Presence 2.0.9.5

### DIFF
--- a/testing/live/Dalamud.RichPresence/manifest.toml
+++ b/testing/live/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "041a27ff90179dc6f0f8fd79cfb3ec36fdc86749"
+commit = "705c88bacb35b0ca1a7481a03f2b23517d2e85b3"
 owners = [
     "Bronya-Rand"
 ]


### PR DESCRIPTION
# What's New?
- Blocks plugin from running on GE-Proton 10-34 due to WinSock limitiations.
    > User's should bump their Proton to at min GE Proton 11-1 or swap to official Wine.