### PR TITLE
Discord Rich Presence 2.0.9.5

### DIFF
--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "708d6256a36b30c07e5b51e154bef807028f55bc"
+commit = "038afe26797ec6b3f015fa9e7b76f0d04aca6698"
 owners = [
     "Bronya-Rand"
 ]


### PR DESCRIPTION
# What's New?
- **New Discord Socket.** The plugin can now communicate with all Discord clients on Linux whether it be Flatpak, Snap or a Native Client + 3rd-Party Clients (Vesktop).
   > This feature requires at least Wine 10.8 or GE-Proton 11-1 to work. GE-Proton 10-34 or any Wine version without `AF_UNIX` support will cause the plugin to disable itself in code.

- Removed WineRPCBridge as part of the plugin itself.
- Removed the Wine toggle in the configuration window.