### PR TITLE
Altoholic v1.12.1

### DIFF
--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,12 +1,14 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "bb10567177ddb0922a01439875a5b24673a1c913"
+commit = "6a9ed1fde2a1ffc858a6d16d39dd507c2549dde9"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\
 - **General**: Add some tracking that were only when opening the window to every minutes
 - **Currencies**: Occult crescent currencies
-- **Collection**: Add 7.55 facewears.
+- **Collection**: 
+   - Add 7.55 facewears. 
+   - Add three main tabs to unclutter
 - **Jobs**: Add phantom jobs tracking and displaying
 - **Progress**: Add Yo-Kai event and rewards (minions) 
   - 

--- a/stable/Altoholic/manifest.toml
+++ b/stable/Altoholic/manifest.toml
@@ -1,9 +1,13 @@
 [plugin]
 repository = "https://github.com/Sohtoren/Altoholic.git"
-commit = "c8e9b2ae6c77b874213b6487e7b7a6cf702e7457"
+commit = "bb10567177ddb0922a01439875a5b24673a1c913"
 owners = ["Sohtoren"]
 project_path = "Altoholic"
 changelog = """\
-- **General**: Fix reset window command
-- **Progress**: Fix Dwarven emote reward Lali-ho to Lali-hop
+- **General**: Add some tracking that were only when opening the window to every minutes
+- **Currencies**: Occult crescent currencies
+- **Collection**: Add 7.55 facewears.
+- **Jobs**: Add phantom jobs tracking and displaying
+- **Progress**: Add Yo-Kai event and rewards (minions) 
+  - 
 """


### PR DESCRIPTION
Version 1.121:

- **General**: Add some tracking that were only when opening the plugin window to every minutes
- **Currencies**: Occult crescent currencies
- **Collection**: 
    - Add 7.55 facewears.
    - Add three main tabs to unclutter
- **Jobs**: Add phantom jobs tracking and displaying
- **Progress**: Add Yo-Kai event and rewards (minions)