### PR TITLE
Battery Buddy v2.0.1

### DIFF
--- a/stable/RazerReader/manifest.toml
+++ b/stable/RazerReader/manifest.toml
@@ -3,4 +3,4 @@ repository = "https://github.com/mashirochan/FFXIV-BatteryBuddy.git"
 commit = "fcfc99fbf87d8d72d3c38f0dabc3fcc2f2f8344c"
 owners = ["mashirochan"]
 project_path = "RazerReader"
-changelog = "Massive v2.0 overhaul into Battery Buddy! Logitech device support!"
+changelog = "Hide main window when no devices are enabled/connected"

--- a/stable/RazerReader/manifest.toml
+++ b/stable/RazerReader/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/mashirochan/FFXIV-BatteryBuddy.git"
-commit = "240e32309a0a4833d5366155b6e91e66e9794972"
+commit = "fcfc99fbf87d8d72d3c38f0dabc3fcc2f2f8344c"
 owners = ["mashirochan"]
 project_path = "RazerReader"
 changelog = "Massive v2.0 overhaul into Battery Buddy! Logitech device support!"


### PR DESCRIPTION
- Hide main window when no devices enabled/connected
- Only set lowest device to one that is enabled and connected
- Show Last Updated timestamp in main config tab