### PR TITLE
Update Echoglossian to v4.2601.0802.2355

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "f0b4dec9265b5cf350464974329d4dae4fbc1dd8"
+commit = "0aa0b9658f63acfece1e41b7b544fe38cd93c12b"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0718.2006 \n OpenRouter live-model refresh and preview-infrastructure follow-up:\n - fix Fetch Live Models when the configured base URL already includes /v1\n - refresh hosted preview validation infrastructure without shipping vendor-only assets"
+changelog = "v4.2601.0802.2355 \n Native UI translation runtime expansion:\n - restore selection dialogs and add DB-first Tooltip, ContextMenu, and ToDo runtimes\n - expand Journal, ToDoList, ScenarioTree, RecommendList, and AreaMap coverage with safer overlay-only behavior\n - add native nameplates, distance-aware overlays, placement-aware toasts, and focused runtime diagnostics"


### PR DESCRIPTION
## Release

- version: `v4.2601.0802.2355`
- Echoglossian release commit: `0aa0b9658f63acfece1e41b7b544fe38cd93c12b`
- GitHub release: https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0802.2355
- integrated runtime corpus: https://github.com/lokinmodar/Echoglossian/pull/240
- release preparation: https://github.com/lokinmodar/Echoglossian/pull/241

## Summary

This release ships the full native UI translation runtime expansion developed and hardened since `v4.2601.0718.2006`. It consolidates a large body of work across selection dialogs, tooltip presentation, quest and journal flows, nameplates, dedicated persistence-backed windows, toast behavior, localization, diagnostics, tests, and documentation.

The source release spans 364 changed files relative to the previous tag and was developed through iterative human/AI collaboration, repeated local validation, and in-game verification by the plugin author.

### Selection dialogs, tooltips, and structured swap/original presentation

- re-enabled and completed the `SelectYesNo`, `SelectOk`, `SelectString`, and `SelectIconString` runtime and configuration paths
- moved selection-dialog translation onto shared persistence and structured plugin tooltip presentation instead of the older overlay-window path
- added the dedicated DB-first `Tooltip` addon runtime with canonical payload recovery and persistence-backed reuse
- preserved semantic lines and explicit line breaks while hardening native tooltip wrapping, measured width, background sizing, and detached-container synchronization
- added rich `SeString`-aware original-text presentation for swap-style tooltip flows
- added an anchored `Tooltip` addon overlay backend for tooltip-only and swap modes, including dedicated configuration and guarded native visibility handling
- repaired tooltip cache preload, hydration, canonical identity, and overlay-publication behavior
- enabled and stabilized `ActionDetail` and `ItemDetail` translation controls, cache-gap prefetch, source-id binding, and atomic detail updates

### Quest and journal-family coverage and correctness

- restored remaining quest addon wiring and re-enabled `ScenarioTree`, `RecommendList`, and `AreaMap` consumers
- stabilized `Journal` and `JournalDetail` lookup, accepted-quest identity, visible-signature handling, list refresh, tooltip anchoring, and native summary/detail restoration
- added asynchronous accepted-quest prefetch for missing journal detail and objective text
- matched visible quest objectives back to canonical rows and improved persisted-row reuse
- added dedicated popup persistence and fallback handling for `JournalAccept` and `JournalResult`
- preserved readable formatted popup payloads and improved body hover geometry and hit areas
- enforced overlay-only language policy across quest-family handlers so overlay-only modes do not mutate native quest UI
- restored addon-owned native state before language or translation-signature resets so retranslation starts from original text
- added `_ToDoList` fallback reuse of persisted quest titles while live progress is still resolving
- moved accepted-quest prefetch away from the hot tick path into serialized background work and reduced runtime log noise
- hardened quest state refresh across acceptance, progression, language changes, recycled addons, and partial translation availability

### Nameplates and distance-aware overlay presentation

- added native nameplate translation for supported target languages
- added distance-aware overlay fallback for overlay-only languages
- added configurable nameplate overlay scale, fade, cutoff, and distance presentation behavior
- refreshed per-frame nameplate overlay synchronization and config-change redraw behavior
- hardened nameplate cache invalidation, lifecycle handling, re-entrant update protection, and player/login readiness gates

### Dedicated DB-first windows, toasts, and native presentation

- added dedicated `ContextMenu` runtime, configuration, persistence, and DB-first translation reuse
- added dedicated `ToDo` runtime, configuration, persistence, and timer-safe state reuse
- added placement-aware toast controls for independent behavior by toast type and screen placement
- added native diacritics-fallback eligibility through language metadata without affecting overlay presentation
- expanded surface-aware translation logging so runtime requests, cache reuse, skips, failures, and applies can be attributed to their UI surface
- strengthened shared native text-node traversal, layout, restore, and UI-transition guards

### Translator and provider follow-ups

- fixed the prompt preview target-language initialization tracked by [lokinmodar/Echoglossian#206](https://github.com/lokinmodar/Echoglossian/issues/206)
- clarified Gemini / Google AI Studio labels and aligned the current model defaults tracked by [lokinmodar/Echoglossian#234](https://github.com/lokinmodar/Echoglossian/issues/234)
- improved handling for recoverable Google translation failures
- kept translation reuse and runtime refresh behavior scoped to the correct surface and payload identity

### Persistence, localization, diagnostics, and documentation

- added or expanded persistence models and migrations for nameplates, quest popups, selection dialogs, context menus, ToDo text, and tooltip text
- switched plugin resources to locale-specific `.resx` usage and normalized persisted plugin culture handling, including `pt` to `pt-PT` while preserving `pt-BR`
- expanded localized UI coverage for the new tooltip, overlay, logging, nameplate, and toast controls
- completed the dedicated rotating `<PluginConfigDirectory>\logs\Echoglossian.log` workflow
- moved runtime and structured diagnostic file writes onto safer asynchronous/rotating paths
- refreshed internal runtime documentation, public support matrices, translation-mode guidance, diagnostics guidance, and the hosted docs site
- expanded DalaMock scenarios and regression/contract coverage across quest, tooltip, nameplate, selection-dialog, overlay, persistence, configuration, and translator behavior

### Related Echoglossian issue fronts

This corpus implements or materially advances the following source-repository issues. States shown here were verified directly against `lokinmodar/Echoglossian` while preparing this submission:

- [#15 — Activate and validate ActionDetail / ItemDetail tooltip translation](https://github.com/lokinmodar/Echoglossian/issues/15) — closed; implementation included in this release
- [#68 — Finish remaining addon coverage for selection dialogs and other specific surfaces](https://github.com/lokinmodar/Echoglossian/issues/68) — open; this release restores the selection-dialog family while the broader tracker remains open
- [#103 — Translate Interactible WorldObjects](https://github.com/lokinmodar/Echoglossian/issues/103) — closed; eligible nameplate/world-object presentation included in this release
- [#206 — `{targetLanguage}` variable does not use the selected target language](https://github.com/lokinmodar/Echoglossian/issues/206) — open; the prompt-preview initialization fix is included for publication/retest
- [#217 — Refactor native replacement diacritics fallback eligibility into explicit language metadata](https://github.com/lokinmodar/Echoglossian/issues/217) — closed; implementation included in this release
- [#230 — Add position-aware toast translation controls by toast type and placement](https://github.com/lokinmodar/Echoglossian/issues/230) — closed; implementation included in this release
- [#231 — Fix quest-family translation retriggering, cache invalidation, and UI reapplication](https://github.com/lokinmodar/Echoglossian/issues/231) — closed; implementation included in this release
- [#232 — Restore translation application in remaining Journal* and recommendation-family quest surfaces](https://github.com/lokinmodar/Echoglossian/issues/232) — closed; implementation included in this release
- [#233 — Add surface-aware logging for translation requests, skips, and failures](https://github.com/lokinmodar/Echoglossian/issues/233) — closed; implementation included in this release
- [#234 — Audit Google AI Studio compatibility and add a dedicated engine if needed](https://github.com/lokinmodar/Echoglossian/issues/234) — closed; audit, labels, and compatible model defaults included in this release

## Official manifest change

- update `stable/Echoglossian/manifest.toml` to `v4.2601.0802.2355`
- point the official manifest at exact release commit `0aa0b9658f63acfece1e41b7b544fe38cd93c12b`
- publish a compact user-facing changelog covering the major runtime additions
- no other plugin manifest or asset is changed by this PR

## Validation

Release validation from the exact submitted commit:

- `dotnet build Echoglossian.sln -c Debug --no-restore`
- `dotnet test Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build` — 647 passed, 0 failed
- `dotnet build Echoglossian.csproj -c Release --no-restore`
- resolved project version: `4.2601.0802.2355`
- verified `origin/v4-series` and tag `v4.2601.0802.2355` both resolve to `0aa0b9658f63acfece1e41b7b544fe38cd93c12b`
- CodeQL and GitGuardian checks passed on the integrated release-preparation PR
- docs-site locale, coverage, check, and build validation passed during [Echoglossian PR #240](https://github.com/lokinmodar/Echoglossian/pull/240)
- in-game verification was performed throughout the behavior-sensitive runtime work in [Echoglossian PR #240](https://github.com/lokinmodar/Echoglossian/pull/240)

Behavior-sensitive surfaces verified during development include `Tooltip`, `Journal*`, `_ToDoList`, `ScenarioTree`, `RecommendList`, `AreaMap`, selection dialogs, toast families, and `NamePlate`.

## AI Usage Disclosure

AI Usage Disclosure: Pair

Used AI for:

- active human/AI collaboration throughout the runtime implementation consolidated in [Echoglossian PR #240](https://github.com/lokinmodar/Echoglossian/pull/240)
- implementation and review assistance across quest-family handlers, tooltip runtimes, nameplate behavior, shared overlay/runtime helpers, persistence, tests, resources, and documentation
- automated release-preparation bookkeeping, changelog drafting, exact-commit coordination, manifest update, and PR drafting

Human verification:

- the plugin author planned, directed, reviewed, and iteratively validated the runtime behavior
- repeated in-game verification was performed for behavior-sensitive native UI and overlay changes
- final source, generated documentation, release metadata, and manifest diffs were inspected
- local Debug, test, and Release validation passed from the exact submitted commit

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```



