### PR TITLE
HUD Manager 2.6.0.0

### DIFF
--- a/stable/HUDManager/manifest.toml
+++ b/stable/HUDManager/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/zacharied/FFXIV-Plugin-HudManager.git"
-commit = "c87a7e0c0e4b443754a45baa1f97d4e3b47c460b"
+commit = "b0af937dab1ecb307650bb9d5124b3f4588e274f"
 owners = ["zacharied", "nebel"]
 project_path = "HUDManager"


### PR DESCRIPTION
- Make movable previews accurately reflect the size and position of the visual element. The shape and size of HUD Manager's preview should now always match those from the built-in HUD Layout.
- Make movable previews correctly switch to the "simple" variant when changing a job gauge to simple mode.
- Make movable preview windows accurately scale when global scaling from the "High Resolution UI" system configuration is used.
- Fix an issue where enabling a movable preview window could cause an element to move slightly even if it was never dragged.
- Add a "fix size" button which can repair certain saved HUD elements when the plugin detects that the saved size and the in-game size of certain HUD elements are out of sync. This button will be shown automatically in the element configuration if and only if the stored size of the element is detected as being incorrect.
- Remove the pet hotbar PvP fix, as this issue seems to have been fixed in the base game. If you notice strangeness in PvP when using mounts with special actions, please let me know.
- Wrap the very long setting name "Display target information independently" into two lines.