### PR TITLE
[XivGearExport] 1.5.0.0

### DIFF
--- a/stable/XivGearExport/manifest.toml
+++ b/stable/XivGearExport/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/VioletStardustXIV/XivGearExport.git"
-commit = "b06c3dff523ef886b6bb0b346332d72574ce7197"
+commit = "b11566440534e423f0bdaf9f63f8db0112cd5dfd"
 owners = ["VioletStardustXIV"]
 project_path = "XivGearExport"
 changelog = """
-- Compatibility with 7.5 and Dalamud 15.
+- Added support for Phantom Occultum relic weapons (the ones with selectable stats).
 """


### PR DESCRIPTION
Adds support for Phantom Occultum relics having their stats properly exported to xivgear.

<img width="446" height="70" alt="image" src="https://github.com/user-attachments/assets/d7a201ca-d363-4526-aed3-900a00f0deb6" />

Tested and works great.

Closes https://github.com/VioletStardustXIV/XivGearExport/issues/1