### PR TITLE
MouseLock 1.0.0.3

### DIFF
--- a/testing/live/MouseLock/manifest.toml
+++ b/testing/live/MouseLock/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Zeffuro/MouseLock.git"
-commit = "281806c7ac6d4440b0bb78665ae29d80060fff50"
+commit = "fbabddc5752852a44e8196bbecfdb8af8557ca10"
 owners = ["Zeffuro"]
 project_path = "MouseLock"


### PR DESCRIPTION
# 1.0.0.3
- Added a true toggle option for tap release, so the cursor can stay free until you tap the modifier again.
- The existing “release until world click or next tap” behavior is still available and remains the default.
- Made tap release safer around Alt+Tab and other modifier combinations.
- Clarified several settings descriptions, especially tap release, resume behavior, and LMB + RMB movement.