### PR TITLE
Wikilinx Rightclicks v0.0.0.10

### DIFF
--- a/stable/Wikilinx/manifest.toml
+++ b/stable/Wikilinx/manifest.toml
@@ -1,8 +1,8 @@
 [plugin]
 repository = "https://github.com/in1tiate/Wikilinx-Dalamud.git"
-commit = "7d3c12bf240503feb4bd413d53eabbe7935daca0"
+commit = "d1a357f0c3bfbaad070b72de4f366a8b5b11e80f"
 owners = ["in1tiate"]
 project_path = "WikilinxPlugin"
-changelog = "Updated for Patch 7.5 and Dalamud API v15."
+changelog = "Added option to always open wiki with English item name (by pixelify32, thank you!) and bumped Eorzea DB IDs to 7.55"
 
 


### PR DESCRIPTION
- Bumped Lodestone IDs to 7.55
- Added option to always use English item name for wiki links (by @pixelify32)

**Full Changelog**: https://github.com/in1tiate/Wikilinx-Dalamud/compare/v0.9...v0.10