### PR TITLE
Update Echoglossian to v4.2601.0809.0046

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "9a39a2be87c3a376448f2967ccc5225c63b1e69c"
+commit = "07edc833c03ec6019f63b02ca07fc4671dfd6f1a"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0807.1730 \n MiniTalk recycled-bubble follow-up:\n - isolate the compact detached height baseline preference to MiniTalk only\n - stop recycled oversized Native and Swap MiniTalk bubbles from stretching later dialogue balloons\n - keep the shared tooltip and toast detached-baseline behavior unchanged"
+changelog = "v4.2601.0809.0046 \n Plugin UI localization fix:\n - apply the selected plugin culture before resource lookup to prevent silent English fallback\n - preserve locale-specific resources and Catalan/Dutch locale mappings\n - add exact resource lookup regression coverage and localization guardrails"


### PR DESCRIPTION
Updates Echoglossian to `v4.2601.0809.0046`.

Release: https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0809.0046

Highlights:
- applies the selected plugin UI culture before resource lookup to prevent silent English fallback
- preserves locale-specific resources and Catalan/Dutch locale mappings
- adds exact resource lookup regression coverage and localization guardrails

Validation:
- GitHub release tag and `origin/v4-series` both resolve to `07edc833c03ec6019f63b02ca07fc4671dfd6f1a`
- Debug build passed
- 1107 unit tests passed
- Release build passed
- manifest TOML parsed successfully and the fork delta contains only `stable/Echoglossian/manifest.toml`

AI Usage Disclosure: Assist

Used AI for bounded implementation, regression-test, incident-documentation, and release-workflow assistance. The maintainer defined the scope, approved the fix and release path, and retained review control. The final release commit was validated with local Debug/Release builds and unit tests.

AI-generated assets: none.