### PR TITLE
[Testing] HUD Manager 2.7.1.0

### DIFF
--- a/testing/live/HUDManager/manifest.toml
+++ b/testing/live/HUDManager/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/zacharied/FFXIV-Plugin-HudManager.git"
-commit = "4ddecb9e8313174848c8c80785378d2ed23afa70"
+commit = "51aee2f6e3cf07927edb6b14eb170ddec2f1d5ae"
 owners = ["zacharied", "nebel"]
 project_path = "HUDManager"


### PR DESCRIPTION
- Re-apply HUD state if swap happened during UI fade. This should fix any lingering opacity issues caused by the fadeout after it ends.