### PR TITLE
[TidyChat] 3.1.0.31

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "1034cc56858812e0dea25739da9d945fb3c1260c"
+commit = "c02fcc0cf7ee3a1b8df0ed1296f678972eab719c"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
**Fixed**
• Weekly/daily hunt bill mark sensing shows again when “Show mark bill messages” is on (e.g. “You sense your mark to the southwest” / FR “Vous ressentez la présence d’un monstre d’élite au sud-ouest !”). Those lines were being blocked by mistake.

**Added**
• Macro-friendly debug toggle:
  – `/tidy debug` — toggle debug mode
  – `/tidy debug on` / `/tidy debug off` — set it explicitly
  (`/tidychat` accepts the same arguments. With no arguments, `/tidy` still opens settings.)