### PR TITLE
Update Echoglossian to v4.2601.0815.1339

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "d1ac912d0f065e7d0294ab0fa9d80bd40296d06b"
+commit = "edc589fbe92a4aa52f4e6fa2a23536287d93b9f0"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0809.2000 \n BattleTalk and MiniTalk native layout fix:\n - restore clean BattleTalk and MiniTalk baselines after translated reuse\n - keep BattleTalk horizontal geometry game-owned while translated text only grows vertically when needed\n - unify dialogue labels and Translation Display Mode text across locales"
+changelog = "v4.2601.0815.1339 \n Dialogue context and LLM follow-up:\n - recover first-line speaker context via quest metadata and live actor fallbacks\n - precompute quest dialogue interlocutor metadata asynchronously off Dalamud callbacks\n - enforce dialogue glossary terms and gate unsupported LLM parameters with shared diagnostics"


### PR DESCRIPTION
## Summary

- update Echoglossian to `v4.2601.0815.1339`
- point the official manifest at release commit `edc589fbe92a4aa52f4e6fa2a23536287d93b9f0`

## Plugin Changes

- recover first-line dialogue speaker context by carrying speaker identity through the shared dialogue translation flow and reusing quest-derived or live-actor fallback hints when a visible NPC or target can disambiguate the interlocutor
- precompute and persist quest dialogue interlocutor metadata asynchronously after quest acceptance so quest-sheet traversal, EF work, and stale-result suppression stay off Dalamud callbacks while later dialogue resolution remains DB-first
- enforce glossary term protection in the shared dialogue LLM flow so structured provider requests stop silently dropping configured glossary replacements
- add conservative LLM capability learning, capability-gated engine settings UI, and shared structured diagnostics so unsupported parameters such as reasoning or temperature controls can be sanitized or disabled without provider-specific guesswork

## Validation

- verified the release commit from `lokinmodar/Echoglossian` with `git rev-parse v4.2601.0815.1339^{}` and `git ls-remote origin refs/tags/v4.2601.0815.1339 refs/tags/v4.2601.0815.1339^{}`
- local Echoglossian validation on the exact merged release commit:
  - `dotnet build .\Echoglossian.sln -c Debug --no-restore`
  - `dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
  - `dotnet build .\Echoglossian.csproj -c Release --no-restore`
- no AI-generated repository assets are included

## AI Usage Disclosure

Assist

Used AI for:
- bounded release-preparation help
- validation orchestration and release-note drafting assistance

Human verification:
- reviewed the final manifest diff manually
- verified the exact Echoglossian tag and peeled commit before updating the manifest
- ran local Echoglossian build and test validation on the exact merged release commit before opening this PR
