### PR TITLE
Update Echoglossian to v4.2601.0816.1235

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "edc589fbe92a4aa52f4e6fa2a23536287d93b9f0"
+commit = "2901ef0d8b1d68956c6ac86afe97ff3bc098e7f3"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0815.1339 \n Dialogue context and LLM follow-up:\n - recover first-line speaker context via quest metadata and live actor fallbacks\n - precompute quest dialogue interlocutor metadata asynchronously off Dalamud callbacks\n - enforce dialogue glossary terms and gate unsupported LLM parameters with shared diagnostics"
+changelog = "v4.2601.0816.1235 \n Dialogue LLM follow-up release:\n - finish #252 prompt save and async structured glossary refresh\n - fix #270 so dialogue-only LLM override still respects per-surface toggles\n - cancel live model discovery requests during shutdown and reload"


### PR DESCRIPTION
## Summary
- update Echoglossian to `v4.2601.0816.1235`
- point the manifest at release commit `2901ef0d8b1d68956c6ac86afe97ff3bc098e7f3`
- ship the remaining dialogue LLM follow-up release work now merged in `v4-series`

## What Is In This Release
- finish [Echoglossian#252](https://github.com/lokinmodar/Echoglossian/issues/252) by making LLM prompt edits save through the shared persistence flow
- finish [Echoglossian#252](https://github.com/lokinmodar/Echoglossian/issues/252) by refreshing the structured dialogue glossary asynchronously instead of blocking the caller path
- fix [Echoglossian#270](https://github.com/lokinmodar/Echoglossian/issues/270) so the dialogue-only LLM override still respects per-surface toggles for windows such as Journal, RecommendList, and AreaMap
- cancel in-flight live model discovery during shutdown and reload so provider model lists and capability overlays stop updating after teardown

## Validation
- verified GitHub release `v4.2601.0816.1235` targets `2901ef0d8b1d68956c6ac86afe97ff3bc098e7f3`
- `dotnet build .\Echoglossian.sln -c Debug --no-restore`
- `dotnet test .\Echoglossian.Tests\Echoglossian.Tests.csproj -c Debug --no-build`
- `dotnet build .\Echoglossian.csproj -c Release --no-restore`

AI Usage Disclosure: Assist
- Used AI for bounded release orchestration help, manifest/changelog drafting, and PR drafting.
- Human verification: reviewed the final diff manually, verified the exact release commit on `origin/v4-series`, created the GitHub release on that hash, and ran the local Debug/Release build plus unit-test validation.

AI-generated assets: none