### PR TITLE
Discord Rich Presence 2.1.0.0

### DIFF
--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "08db5a31a96390abe3b59b6fe66e9be7b9cfb5aa"
+commit = "734b29685917f30663a0b787a6d6b7dc4df36234"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "734b29685917f30663a0b787a6d6b7dc4df36234"
+commit = "173370383f7d066a4276050ee8ffabe2ff38dd9c"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "ba4e3371d42496fc235548b21c33ef80f004ca7d"
+commit = "05bee47b5e4cacb04e83781c5b1d53e8a591bc4d"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "05bee47b5e4cacb04e83781c5b1d53e8a591bc4d"
+commit = "0bfe25d7af1f4212fb11c65c30514e34bdefd4cb"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "173370383f7d066a4276050ee8ffabe2ff38dd9c"
+commit = "b2f31fc7e00480ec54bdb557c8a1efadbfb8320e"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "b2f31fc7e00480ec54bdb557c8a1efadbfb8320e"
+commit = "ba4e3371d42496fc235548b21c33ef80f004ca7d"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "93684c79b1d760a2f3d02975f1abe379f44cf375"
+commit = "bf70912fab64c5b1f4fb225d18b5cdb8b0df8188"
 owners = [
     "Bronya-Rand"
 ]

--- a/stable/Dalamud.RichPresence/manifest.toml
+++ b/stable/Dalamud.RichPresence/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Bronya-Rand/Dalamud.RichPresence.git"
-commit = "0bfe25d7af1f4212fb11c65c30514e34bdefd4cb"
+commit = "93684c79b1d760a2f3d02975f1abe379f44cf375"
 owners = [
     "Bronya-Rand"
 ]


### PR DESCRIPTION
# What's New?
- Rebuilt from the ground up the Wine bridge for non-`AF_UNIX` Wine/Proton builds on Linux and macOS using A TCP RPC bridge.

## Note
This is **not** the same bridge that once existed and currently can be pushed despite the pending PR in XIVLauncher.Core as a hostable binary is avail on the NuGet repo I made that XOM and XIVLauncher-RB uses.