### PR TITLE
[Stable] AcrylicXIV 0.1.0.0

### DIFF
--- a/stable/AcrylicXIV/manifest.toml
+++ b/stable/AcrylicXIV/manifest.toml
@@ -3,4 +3,4 @@ repository = "https://github.com/MapleRecall/AcrylicXIV.git"
 commit = "62d38ff8df810d52b8ee441c376a149172914238"
 owners = ["MapleRecall"]
 project_path = ""
-changelog = "### Added\n- Add an option to exclude the current target's nameplate, HP bar, and cursor from the effect.\n- Add an option to disable the effect during native UI fades, with an adjustable smooth recovery."
+changelog = "- Add an option to exclude the current target's nameplate, HP bar, and cursor from the effect.\n- Add an option to disable the effect during native UI fades, with an adjustable smooth recovery."

--- a/stable/AcrylicXIV/manifest.toml
+++ b/stable/AcrylicXIV/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/MapleRecall/AcrylicXIV.git"
-commit = "df34c9704e3c13507dbfc45fa9b2afc421743c9b"
+commit = "62d38ff8df810d52b8ee441c376a149172914238"
 owners = ["MapleRecall"]
 project_path = ""
-changelog = "Fix a crash when exiting the game."
+changelog = "### Added\n- Add an option to exclude the current target's nameplate, HP bar, and cursor from the effect.\n- Add an option to disable the effect during native UI fades, with an adjustable smooth recovery."


### PR DESCRIPTION
Updates AcrylicXIV stable to 0.1.0.0.

- Adds an option to exclude the current target nameplate, HP bar, and cursor from the effect.
- Adds an option to disable the effect during native UI fades, with an adjustable smooth recovery.
