### PR TITLE
Update LootView to version 1.3.3

### DIFF
--- a/stable/LootView/manifest.toml
+++ b/stable/LootView/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/GitHixy/LootView.git"
-commit = "7948f38adfa1cdb051a9740548be0ff356d2c4a5"
+commit = "db8ef119fe9fe164bdfd60cf14b71ab9bb406d06"
 owners = ["GitHixy"]
 project_path = "."
 changelog = """
-# Version 1.3.2
-- Blacklist Bug Fix
+# Version 1.3.3
+- Updated to Dalamud API Level 15
+- Added option to disable the Need/Greed roll tracking window
 """

--- a/stable/LootView/manifest.toml
+++ b/stable/LootView/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/GitHixy/LootView.git"
-commit = "db8ef119fe9fe164bdfd60cf14b71ab9bb406d06"
+commit = "83346fe4469e606518c032fe392b5b462894c679"
 owners = ["GitHixy"]
 project_path = "."
 changelog = """

--- a/testing/live/LootView/manifest.toml
+++ b/testing/live/LootView/manifest.toml
@@ -1,9 +1,10 @@
 [plugin]
 repository = "https://github.com/GitHixy/LootView.git"
-commit = "7948f38adfa1cdb051a9740548be0ff356d2c4a5"
+commit = "db8ef119fe9fe164bdfd60cf14b71ab9bb406d06"
 owners = ["GitHixy"]
 project_path = "."
 changelog = """
-# Version 1.3.2
-- Blacklist Bug Fix
+# Version 1.3.3
+- Updated to Dalamud API Level 15
+- Added option to disable the Need/Greed roll tracking window
 """

--- a/testing/live/LootView/manifest.toml
+++ b/testing/live/LootView/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/GitHixy/LootView.git"
-commit = "db8ef119fe9fe164bdfd60cf14b71ab9bb406d06"
+commit = "83346fe4469e606518c032fe392b5b462894c679"
 owners = ["GitHixy"]
 project_path = "."
 changelog = """


### PR DESCRIPTION
## Plugin Details
- **Author**: GitHixy
- **Version**: 1.3.3
- **Repository**: https://github.com/GitHixy/LootView
- **Commit**: `db8ef119fe9fe164bdfd60cf14b71ab9bb406d06`

## Changes
- Updated to Dalamud API Level 15 (fixed breaking changes: `IClientState.LocalPlayer`/`LocalContentId` moved to `IObjectTable`/`IPlayerState`, `IChatGui.ChatMessage` delegate signature, `TerritoryType` now `uint`)
- Added a setting to disable the Need/Greed roll tracking window for players who don't want it

## Checklist
- [x] Plugin builds successfully against Dalamud API Level 15
- [x] Tested in-game
- [x] `stable` and `testing/live` manifests both updated