### PR TITLE
Update LootView to version 1.3.4

### DIFF
--- a/stable/LootView/manifest.toml
+++ b/stable/LootView/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/GitHixy/LootView.git"
-commit = "83346fe4469e606518c032fe392b5b462894c679"
+commit = "8f658020d4bf93551cd4e729ac6e577fb84f0d1a"
 owners = ["GitHixy"]
 project_path = "."
 changelog = """
-# Version 1.3.3
-- Updated to Dalamud API Level 15
-- Added option to disable the Need/Greed roll tracking window
+# Version 1.3.4
+- Recognized more measure words in loot messages (roll of, bunch of, basket of, sheet of, glass of, pouch of, sack of, crate of)
+- Preserved genuine item names that look like measure words, fixing "Set of Liquor Bottles", "Pot of Cream Stew" and "Basket of Flowers"
+- Fixed fishing catches of more than one fish being recorded as a single item
 """

--- a/testing/live/LootView/manifest.toml
+++ b/testing/live/LootView/manifest.toml
@@ -1,10 +1,11 @@
 [plugin]
 repository = "https://github.com/GitHixy/LootView.git"
-commit = "83346fe4469e606518c032fe392b5b462894c679"
+commit = "8f658020d4bf93551cd4e729ac6e577fb84f0d1a"
 owners = ["GitHixy"]
 project_path = "."
 changelog = """
-# Version 1.3.3
-- Updated to Dalamud API Level 15
-- Added option to disable the Need/Greed roll tracking window
+# Version 1.3.4
+- Recognized more measure words in loot messages (roll of, bunch of, basket of, sheet of, glass of, pouch of, sack of, crate of)
+- Preserved genuine item names that look like measure words, fixing "Set of Liquor Bottles", "Pot of Cream Stew" and "Basket of Flowers"
+- Fixed fishing catches of more than one fish being recorded as a single item
 """


### PR DESCRIPTION
## Plugin Details
- **Author**: GitHixy
- **Version**: 1.3.4
- **Repository**: https://github.com/GitHixy/LootView
- **Commit**: `8f658020d4bf93551cd4e729ac6e577fb84f0d1a`

Follow-up to #9243 (which shipped 1.3.3).

## Changes
- Loot messages now recognize more measure words: `roll of`, `bunch of`, `basket of`, `sheet of`, `glass of`, `pouch of`, `sack of`, `crate of`.
- Measure words are checked against the game's item sheet before being stripped, so real item names that merely *look* like measure words survive. This fixes existing mis-parsing of `Set of Liquor Bottles`, `Pot of Cream Stew`, `Piece of Mind Orchestrion Roll` and `Basket of Flowers`.
- Fishing catches yielding more than one fish ("You land 2 mossy globules measuring 7.1 ilms!") no longer record a quantity of 1.

## Checklist
- [x] Builds against Dalamud API Level 15 with the Dalamud.NET.Sdk
- [x] Parsing changes covered by a standalone test pass, including regression cases for genuine item names
- [x] `stable` and `testing/live` manifests both updated