### PR TITLE
[TidyChat] 3.1.1.0

### DIFF
--- a/stable/TidyChat/manifest.toml
+++ b/stable/TidyChat/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/NadyaNayme/TidyChat.git"
-commit = "c02fcc0cf7ee3a1b8df0ed1296f678972eab719c"
+commit = "da7fabc34b460fab6ec54eccb63369581b3180fd"
 owners = ["Kagekazu"]
 project_path = "TidyChat"


### PR DESCRIPTION
- Load the plugin asynchronously so startup no longer hitches the game while catalogs load.
- Quest `/say` reminders show again when **Show reminders of what to /say in chat during quests** is on (e.g. “With the chat mode set to Say, use the keyboard or the software keyboard to enter …” / older “With the chat mode in Say, enter a phrase containing …”). Those lines were only appearing if **Show miscellaneous system messages** was checked.
- **Improved /say messages for quests** (and copy-to-clipboard) works with that newer wording, including straight `"quotes"` as well as the old curly ones.
