### PR TITLE
SubmarineTracker

### DIFF
--- a/stable/SubmarineTracker/manifest.toml
+++ b/stable/SubmarineTracker/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Infiziert90/SubmarineTracker.git"
-commit = "1f38cda233b1edc5a1530f13334373308a235199"
+commit = "382a4957af5b6bbf9e366d8ebc8fa11e9d79d722"
 owners = [
     "Infiziert90",
 ]


### PR DESCRIPTION
- Add better multi account sorting support
  - Create categories and sort each character into these
- Add inventory count support even without Allagan Tools installed
  - Only counts inventory, no saddlebag, retainer or fc chest!
  - No Data means the character hasn't been logged in yet
  - All Overview displays tanks + kits now, can be disabled in the config
- Add future predict to builder
- Prevent ESC from closing tracker window [default true]