### PR TITLE
Update Echoglossian to v4.2601.0829.2219

### DIFF
--- a/stable/Echoglossian/manifest.toml
+++ b/stable/Echoglossian/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/lokinmodar/Echoglossian.git"
-commit = "2901ef0d8b1d68956c6ac86afe97ff3bc098e7f3"
+commit = "fcda77e8c294a9a821c18b23db12cc9828138d38"
 owners = ["lokinmodar"]
-changelog = "v4.2601.0816.1235 \n Dialogue LLM follow-up release:\n - finish #252 prompt save and async structured glossary refresh\n - fix #270 so dialogue-only LLM override still respects per-surface toggles\n - cancel live model discovery requests during shutdown and reload"
+changelog = "v4.2601.0829.2219 \n Arabic RTL overlay fix release:\n - fix #274 so overlay target language stays synchronized with Config.Lang during startup and config refresh\n - make Google Translate honor the per-call target language to avoid stale global RTL routing\n - add deterministic Arabic Previewer and Mock validation coverage for the overlay fix"


### PR DESCRIPTION
## Summary

- update `stable/Echoglossian` to `v4.2601.0829.2219`
- this pulls in the merged Arabic RTL overlay fix that is already live on `v4-series`
- fix details: target language runtime state now stays synchronized with `Config.Lang`, the overlay derives RTL rendering from the configured target, and Google Translate now honors the per-call target language instead of stale global state

## Source Links

- merged Echoglossian PR: https://github.com/lokinmodar/Echoglossian/pull/275
- release tag: https://github.com/lokinmodar/Echoglossian/releases/tag/v4.2601.0829.2219
- issue: https://github.com/lokinmodar/Echoglossian/issues/274

## AI Usage Disclosure

`Pair`

```text
AI scope:
- tooling used: Codex for implementation, validation, release prep, and submission drafting
- human direction/review: scope, approval, and in-game QA stayed human-directed
- verification: local build/test runs, Mock coverage, Previewer validation during the fix flow, and manual in-game verification
```

## AI-Generated Assets Disclosure

```text
AI-generated assets:
- none
```
