### PR TITLE
Allagan Tools 1.15.0.12

### DIFF
--- a/stable/InventoryTools/manifest.toml
+++ b/stable/InventoryTools/manifest.toml
@@ -1,7 +1,7 @@
 [plugin]
 repository = "https://github.com/Critical-Impact/InventoryTools.git"
-commit = "d17337a6ee2531421697c2d83748f57d5ffda520"
+commit = "84af1851fb3a7fd976ec440ddf1ac7cb02c2b5cc"
 owners = [ "Critical-Impact",]
 project_path = "InventoryTools"
-version = "1.15.0.11"
-changelog = "### Changed\n- Added configuration window setting search\n- Reworked configuration/wizard settings pages\n- Wizard now has an introduction explaining key plugin concepts\n- Changed the defaults for certain settings"
+version = "1.15.0.12"
+changelog = "### Added\n- Added a tooltip that lists which of your curated lists contain the hovered item\n- Added IPC `AllaganTools.ItemCountOwnedByCategory` which counts an item across a character and its retainers in a single call, scoped by inventory category with the option to include/exclude shared storage(free companies/housing)\n- Added IPC `AllaganTools.GetItemCountsByCharacter` which returns the same count broken down per character, retainer, free company and house\n### Fixed\n- Certain items that can be collectable were not showing up in the retrieval list in craft lists\n- IPC `AllaganTools.GetCharacterItems` and `AllaganTools.GetCharacterItemsByType` were throwing an exception when given a character with no loaded inventory, now return an empty array"


### PR DESCRIPTION
### Added
- Added a tooltip that lists which of your curated lists contain the hovered item
- Added IPC `AllaganTools.ItemCountOwnedByCategory` which counts an item across a character and its retainers in a single call, scoped by inventory category with the option to include/exclude shared storage(free companies/housing)
- Added IPC `AllaganTools.GetItemCountsByCharacter` which returns the same count broken down per character, retainer, free company and house

### Fixed
- Certain items that can be collectable were not showing up in the retrieval list in craft lists
- IPC `AllaganTools.GetCharacterItems` and `AllaganTools.GetCharacterItemsByType` were throwing an exception when given a character with no loaded inventory, now return an empty array