### PR TITLE
GatherBuddy 3.8.11.0

### DIFF
--- a/stable/GatherBuddy/manifest.toml
+++ b/stable/GatherBuddy/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/Ottermandias/GatherBuddy.git"
-commit = "99986c0f678094ecec31cfd2faf57e11fe0da3ac"
+commit = "c9b4a99dd32686fe5a9ba64297fe3143b162b5e9"
 owners = [
     "Ottermandias",
 ]


### PR DESCRIPTION
- Added several (untested) IPC methods for other plugins to (ab)use.
- Fixed an exception when previewing the No Sound alarm sound.