### PR TITLE
ChillFrames

### DIFF
--- a/stable/ChillFrames/manifest.toml
+++ b/stable/ChillFrames/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/MidoriKami/ChillFrames.git"
-commit = "cdc0b8d4a85a461448ab6463e50ce186c080a42b"
+commit = "d678c6d07a71027620c7ae53aea41b1227f801f2"
 owners = [ "MidoriKami",]
 project_path = "ChillFrames"


### PR DESCRIPTION
Adds Idle FPS Limiter Delay (seconds) option, to delay the activation of the idle fps limiter.

This is useful when using high idle fps wait times, as alt-tabbing to and from the game was very jarring. Now with this delay, it won't apply the idle fps limiter until the window has been idle by the specific number of seconds.