### PR TITLE
[Testing] Update PartySortPlus for Dalamud API 15

### DIFF
--- a/testing/live/PartySortPlus/manifest.toml
+++ b/testing/live/PartySortPlus/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
-repository = "https://github.com/Rietty/PartySortPlus.git"
-commit = "cfd260c7974597627a5602d1b147b6b1630de98f"
-owners = ["Rietty"]
+repository = "https://github.com/tenyu27/PartySortPlus.git"
+commit = "283c958e9e4e16a6f9f415340fb5ac8e4ebb7404"
+owners = ["Rietty", "tenyu27"]
 project_path = "PartySortPlus"
-changelog = "Initial testing release!"
+changelog = "Updated for Dalamud API 15. Fixed rule evaluation, negative-only conditions, preset persistence, duplicate-job sorting, and rule reordering."

--- a/testing/live/PartySortPlus/manifest.toml
+++ b/testing/live/PartySortPlus/manifest.toml
@@ -1,6 +1,6 @@
 [plugin]
 repository = "https://github.com/tenyu27/PartySortPlus.git"
-commit = "283c958e9e4e16a6f9f415340fb5ac8e4ebb7404"
+commit = "83e8b002bc37f15361341601dba66efc6046aa9b"
 owners = ["Rietty", "tenyu27"]
 project_path = "PartySortPlus"
-changelog = "Updated for Dalamud API 15. Fixed rule evaluation, negative-only conditions, preset persistence, duplicate-job sorting, and rule reordering."
+changelog = "Updated for Dalamud API 15. Fixed rule evaluation, negative-only conditions, preset persistence, duplicate-job sorting, rule reordering, and Linux CI restore compatibility."


### PR DESCRIPTION
Updates the existing PartySortPlus testing entry for Dalamud API 15.

- Transfers the repository URL to https://github.com/tenyu27/PartySortPlus
- Adds tenyu27 as an owner alongside Rietty
- Updates to Dalamud API 15 / .NET 10
- Fixes rule evaluation and negative-only conditions
- Fixes preset persistence
- Fixes duplicate-job sorting
- Restores rule reordering

Notice of adoption: https://discord.com/channels/581875019861328007/653504487352303619/1473109458224812062
