### PR TITLE
MogMogCheck v3.5.0

### DIFF
--- a/stable/MogMogCheck/manifest.toml
+++ b/stable/MogMogCheck/manifest.toml
@@ -1,5 +1,5 @@
 [plugin]
 repository = "https://github.com/Haselnussbomber/MogMogCheck.git"
-commit = "637b6afd81dd5c2f55ced852a649a4097b6094e8"
+commit = "b5b852b684c9a134318d6dc794139fae6dbb3072"
 owners = [ "Haselnussbomber" ]
 project_path = "MogMogCheck"


### PR DESCRIPTION
- **Added:** The required Uolon Horn Tokens are now also displayed on the Uolon Horn item.
- **Fixed:** The shop of the second part was already displayed in the first part of the event.
- **Fixed:** Items that were present multiple times in the shop (like the Uolon Horn in the second part of the event), will now only be processed once for the calculation of Tomestones needed.
