### PR TITLE
PetScale 2.1.0.0

### DIFF
--- a/testing/live/PetScale/manifest.toml
+++ b/testing/live/PetScale/manifest.toml
@@ -1,8 +1,12 @@
 [plugin]
 repository = "https://github.com/Kurochi51/PetScale.git"
-commit = "cc6e9e4ca782059263f3d7e8266d4105de60cb5b"
+commit = "1ba2de3c7be5f4cef35eb7a151546a8ffac0ff9a"
 owners = ["Kurochi51"]
 project_path = "PetScale"
 changelog = """
-- Quarterly API Bump
+- Added provisional Beastmaster support
+Warning: 
+- There's a very real chance that I ommited something, or broke some of the existing scaling, so this is a true testing release.
+  
+  Data should be unaffected by this change, but I can't make any guarantees.
 """


### PR DESCRIPTION
This update is 99% beastmaster, but the untested sync IPC is still included since I was working on it prior to the class release. Since I never actually field tested it, I just return out of the ctor and function calls to it to effectively disable it, but if PAC desires me to remove it I can do so. 
However as far as the state of the IPC itself goes, this is what I intend to roll out for any sync to use as they desire, so any feedback is welcome.